### PR TITLE
feat!: make Result/AsyncResult natively matchable (discriminated union)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,9 +18,11 @@ was planned).
 ## Thesis (do not drift from these)
 
 1. **`Result<T, E>` where `E` is only the _anticipated_ domain failures.** A
-   defect (an unmodeled failure) is a third runtime state — a `Defect` — that is
-   **invisible to the type**. If a failure mode appears in `E`, it is by
-   definition modeled and is no longer a defect.
+   defect (an unmodeled failure) is the third variant of the `Result` union
+   (`{ tag: "Defect" }`), but it **never appears in `E`**. If a failure mode
+   appears in `E`, it is by definition modeled and is no longer a defect. The
+   defect is matchable like any variant, but you never thread it through your
+   domain error type.
 2. **No `Option` type.** Absence is expressed with the type system we already
    trust: `T | undefined`, `T | null`, or `Result<T, NotFound>`. Interop with
    nullable third-party APIs goes through `fromNullable`. Do not add `Option`.
@@ -61,14 +63,19 @@ was planned).
 
 ## Public surface (implemented in packages/core/src/, split into focused modules)
 
-`Result<T, E>` and `AsyncResult<T, E>` share one method surface. `AsyncResult`
-is an awaitable wrapper (method parity with `Result`) typed as
-`Awaitable<Result<T, E>>` — a **success-only thenable**, not a full
-`PromiseLike` (its internal promise never rejects, so there is no rejection
-channel to model). Its **combinator callbacks are synchronous** (no raw
-`Promise` — see Thesis #3); async work re-enters via `fromPromise` /
-`fromSafePromise` and composes with `flatMap`. `await` collapses an
-`AsyncResult` to a `Result`.
+`Result<T, E>` is a **discriminated union** — `{ tag: "Ok"; value } | { tag:
+"Err"; error } | { tag: "Defect"; cause }`, each intersected with the shared
+method surface — so it matches **natively** (a `switch` on `tag`, or
+`ts-pattern`'s `match(r).with({ tag: "Ok" }, …).exhaustive()`) **and** chains
+fluently. The payload is reachable only after narrowing, so "check before you
+access" still holds.
+
+`AsyncResult<T, E>` shares that method surface as an awaitable wrapper typed
+`Awaitable<Result<T, E>>` — a **success-only thenable**, not a full `PromiseLike`
+(its internal promise never rejects, so there is no rejection channel to model).
+Its **combinator callbacks are synchronous** (no raw `Promise` — see Thesis #3);
+async work re-enters via `fromPromise` / `fromSafePromise` and composes with
+`flatMap`. `await` collapses an `AsyncResult` to a `Result` (then match it).
 
 - success: `map`, `flatMap`, `tap`, `as`
 - error: `mapErr`, `orElse`, `recover`, `tapErr`
@@ -93,16 +100,20 @@ addition; revisit only if sequential code demands it), accumulation/`Validation`
 and aliases (`andThen`, etc. — one name per concept). Keep the surface small
 enough that the library can be "done".
 
-## Internal design (don't break the encapsulation)
+## Internal design (don't break these)
 
-- **`Result` / `AsyncResult` are types; `Res` / `AsyncRes` are the classes that
-  implement them.** The classes live in `core.ts` and are **never re-exported
-  from `index.ts`**. `Res._state` (the `ok | err | defect` discriminated union)
-  is public-at-runtime so module-mates (`AsyncRes`, `all`) can branch on it, but
-  it is **absent from the `Result` type** — which is what keeps the third state
-  invisible and forces users through guards. A single public class can't hide its
-  own field; the type/class split is load-bearing. Do not export `Res`/`AsyncRes`
-  or move `_state` onto the public type.
+- **`Result` / `AsyncResult` are the public types; `Res` / `AsyncRes` are the
+  internal classes that implement them** (in `core.ts`, **never re-exported from
+  `index.ts`**). `Result` is a discriminated union exposing `tag` / `value` /
+  `error` / `cause`; `Res` is the single class behind all three variants, with
+  `Res._state` (lowercase `ok|err|defect`) kept **module-private** and the public
+  `tag` (capitalised) surfaced via a getter. The three cast-builders
+  `okRes`/`errRes`/`defectRes` are the **only** place a `Res` is bridged to the
+  `Result` type (`as unknown as Result`) — don't scatter that cast or export
+  `Res`. "Check before you access" is enforced by the union: `result.value` only
+  type-checks on the `Ok` variant. `AsyncRes` operates purely on the public
+  `Result` union (it wraps a `Promise<Result>` and branches on `r.tag`), never on
+  `Res` internals.
 - **Builders are free functions** (`ok`, `err`, …) because they tree-shake — and
   there is a `bundle-size` CI gate that protects this. The `Result` companion
   object is additive sugar (value + type share the name via a re-alias in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,17 +103,21 @@ enough that the library can be "done".
 ## Internal design (don't break these)
 
 - **`Result` / `AsyncResult` are the public types; `Res` / `AsyncRes` are the
-  internal classes that implement them** (in `core.ts`, **never re-exported from
-  `index.ts`**). `Result` is a discriminated union exposing `tag` / `value` /
-  `error` / `cause`; `Res` is the single class behind all three variants, with
-  `Res._state` (lowercase `ok|err|defect`) kept **module-private** and the public
-  `tag` (capitalised) surfaced via a getter. The three cast-builders
-  `okRes`/`errRes`/`defectRes` are the **only** place a `Res` is bridged to the
-  `Result` type (`as unknown as Result`) — don't scatter that cast or export
-  `Res`. "Check before you access" is enforced by the union: `result.value` only
+  internal classes** (in `core.ts`, **never re-exported from `index.ts`**).
+  `Result` is a discriminated union (`{ tag; value/error/cause } & methods`) where
+  each variant is `Res` (a method holder, like boxed's `__Result`) intersected
+  with its `tag`/payload. `Res` is **never `new`'d**: the builders
+  `okRes`/`errRes`/`defectRes` create instances with `Object.create(Res.prototype)`
+  and return them as the variant type (`OkView`/`ErrView`/`DefectView`) — so a
+  builder yields a value that already _is_ a union member, with **no construction
+  cast**. `Res` methods type `this` as `Result<T, E>` and narrow on `tag`. The
+  only remaining casts are the inherent type-changing pass-throughs (`map` reusing
+  an `Err` as a differently-typed `Result`) — the same `as unknown as` boxed uses,
+  sound because the passed-through variant carries no value of the changed type.
+- "Check before you access" is enforced by the union: `result.value` only
   type-checks on the `Ok` variant. `AsyncRes` operates purely on the public
-  `Result` union (it wraps a `Promise<Result>` and branches on `r.tag`), never on
-  `Res` internals.
+  `Result` union (wraps a `Promise<Result>`, branches on `r.tag`), never on `Res`
+  internals.
 - **Builders are free functions** (`ok`, `err`, …) because they tree-shake — and
   there is a `bundle-size` CI gate that protects this. The `Result` companion
   object is additive sugar (value + type share the name via a re-alias in

--- a/docs/guide/core-concepts.md
+++ b/docs/guide/core-concepts.md
@@ -13,6 +13,12 @@ A `Result<T, E>` has **three** runtime states but only **two** type parameters:
 The defect channel is the heart of the library and has [its own
 page](./the-defect-channel). This page covers the everyday surface.
 
+A `Result` is a real **discriminated union** — each variant carries a `tag` of
+`"Ok"` / `"Err"` / `"Defect"` plus its payload (`value` / `error` / `cause`) —
+so you can `switch` on it or [match it natively](./pattern-matching) with
+`ts-pattern`. It also carries the full method surface below; the payload is only
+reachable once you've narrowed to a variant.
+
 ## The method surface
 
 Every `Result` shares one method surface, grouped by the channel it touches:

--- a/docs/guide/pattern-matching.md
+++ b/docs/guide/pattern-matching.md
@@ -60,10 +60,23 @@ const status = match(result)
 ```
 
 - `P.ok(sub?)` / `P.err(sub?)` / `P.defect(sub?)` — match a channel; pass a
-  sub-pattern (a literal, `P.string`, `P.select()`, …) to constrain or select
-  the payload.
+  sub-pattern to constrain or select the payload: a literal, or any `ts-pattern`
+  pattern.
 - `P.tag(t)` — sugar for `{ _tag: t }`; nested in `P.err(...)` it narrows to the
   matching tagged-error variant, payload and all.
+
+Above, `P` is `@unthrown/pattern`. To also use `ts-pattern`'s own patterns
+(wildcards, `P.select()`, `P.string`, …), import them from `ts-pattern` under a
+different name:
+
+```ts
+import { match, P as t } from "ts-pattern";
+import * as P from "@unthrown/pattern";
+
+match(result)
+  .with(P.ok(t.select()), (value) => value) // t.select() is ts-pattern's
+  .otherwise(() => 0);
+```
 
 `ts-pattern` is a peer dependency.
 

--- a/docs/guide/pattern-matching.md
+++ b/docs/guide/pattern-matching.md
@@ -1,11 +1,36 @@
 # Pattern Matching
 
-For the everyday exhaustive case, [`matchTags`](./tagged-errors) is all you need.
-When you want richer matching — guards, nested patterns, wildcards, `P.union` —
-`@unthrown/pattern` is a thin bridge to
-[ts-pattern](https://github.com/gvergnaud/ts-pattern).
+A `Result` is a **discriminated union** — `{ tag: "Ok"; value } | { tag: "Err";
+error } | { tag: "Defect"; cause }` — so you can pattern-match it **natively**,
+no adapter required.
 
-## Installation
+For the everyday exhaustive fold over a tagged _error_ union,
+[`matchTags`](./tagged-errors) is the simplest tool. When you want
+[ts-pattern](https://github.com/gvergnaud/ts-pattern)'s full power — guards,
+nested patterns, wildcards, selection — match the `Result` directly.
+
+## Matching a Result directly
+
+Because `tag` is a real discriminant, ts-pattern matches a `Result` out of the
+box, and `.exhaustive()` works:
+
+```ts
+import { match } from "ts-pattern";
+
+const status = match(result)
+  .with({ tag: "Ok" }, ({ value }) => 200)
+  .with({ tag: "Err" }, ({ error }) => 400)
+  .with({ tag: "Defect" }, ({ cause }) => 500)
+  .exhaustive(); // ✅ omit a variant and it won't compile
+```
+
+The payload (`value` / `error` / `cause`) is reachable only inside the matching
+arm — exactly like the type guards.
+
+## `@unthrown/pattern` — pattern sugar
+
+`@unthrown/pattern` adds small constructors so you don't write the raw object
+patterns, plus `tag` for matching a [`TaggedError`](./tagged-errors).
 
 ::: code-group
 
@@ -19,50 +44,45 @@ npm install @unthrown/pattern ts-pattern
 
 :::
 
-`ts-pattern` is a peer dependency. The integration is deliberately small — the
-matching power is ts-pattern's.
-
-## `toMatchable` — expose the channels
-
-A `Result` hides its internal state, so you can't pattern-match it directly.
-`toMatchable` adapts a `Result` into a discriminated union that ts-pattern can
-match, exposing the ok / err / defect channels under a `_kind` discriminant:
-
 ```ts
 import { match } from "ts-pattern";
-import { toMatchable, tag } from "@unthrown/pattern";
+import * as P from "@unthrown/pattern";
 
-const status = match(toMatchable(result))
-  .with({ _kind: "Ok" }, ({ value }) => 200)
-  .with({ _kind: "Err" }, ({ error }) => 400)
-  .with({ _kind: "Defect" }, ({ cause }) => 500)
+const status = match(result)
+  .with(P.ok(), ({ value }) => 200)
+  .with(P.err(P.tag("NotFound")), () => 404)
+  .with(P.err(P.tag("Forbidden")), ({ error }) => {
+    audit(error.user); // narrowed to Forbidden — payload available
+    return 403;
+  })
+  .with(P.defect(), ({ cause }) => 500)
   .exhaustive();
 ```
 
-The `_kind` discriminant is distinct from any `_tag` on an error value, so the
-two never collide in nested patterns.
+- `P.ok(sub?)` / `P.err(sub?)` / `P.defect(sub?)` — match a channel; pass a
+  sub-pattern (a literal, `P.string`, `P.select()`, …) to constrain or select
+  the payload.
+- `P.tag(t)` — sugar for `{ _tag: t }`; nested in `P.err(...)` it narrows to the
+  matching tagged-error variant, payload and all.
 
-## `tag` — match a tagged error
+`ts-pattern` is a peer dependency.
 
-`tag(t)` is sugar for the `{ _tag: t }` pattern. Nested inside an `Err` pattern,
-it narrows to the matching [`TaggedError`](./tagged-errors) variant — including
-its payload:
+## Matching an AsyncResult
+
+`ts-pattern`'s `match` is synchronous, so `await` an `AsyncResult` first — the
+result is a plain, matchable `Result`:
 
 ```ts
-match(toMatchable(result))
-  .with({ _kind: "Ok" }, ({ value }) => `ok: ${value}`)
-  .with({ _kind: "Err", error: tag("NotFound") }, () => "404")
-  .with({ _kind: "Err", error: tag("Forbidden") }, ({ error }) => `403 ${error.user}`)
-  .with({ _kind: "Defect" }, () => "500")
+const status = match(await asyncResult)
+  .with(P.ok(), () => 200)
+  .with(P.err(), () => 400)
+  .with(P.defect(), () => 500)
   .exhaustive();
 ```
-
-In the `Forbidden` branch, `error` is narrowed to the full `Forbidden` variant,
-so `error.user` type-checks.
 
 ## Which should I use?
 
-- **`matchTags`** (core) — the everyday exhaustive fold over a tagged error
-  union. Zero dependencies, no `.exhaustive()` to forget.
-- **`@unthrown/pattern` + ts-pattern** — when you need guards, nested matching on
-  payloads, wildcards, or to match on the success value's shape.
+- **`matchTags`** (core, zero-dep) — the everyday exhaustive fold over a tagged
+  error union. No `.exhaustive()` to forget.
+- **`ts-pattern`** (+ `@unthrown/pattern` sugar) — when you need guards, nested
+  matching on payloads, wildcards, or to match on the success value's shape.

--- a/packages/core/src/constructors.ts
+++ b/packages/core/src/constructors.ts
@@ -1,6 +1,6 @@
 // Result constructors and the standalone narrowing guards.
 
-import { Res } from "./core.js";
+import { errRes, okRes } from "./core.js";
 import type { DefectView, ErrView, OkView, Result } from "./types.js";
 
 /**
@@ -16,7 +16,7 @@ import type { DefectView, ErrView, OkView, Result } from "./types.js";
  * ```
  */
 export function ok<T>(value: T): Result<T, never> {
-  return new Res<T, never>({ tag: "ok", value });
+  return okRes(value);
 }
 
 /**
@@ -32,11 +32,11 @@ export function ok<T>(value: T): Result<T, never> {
  * ```
  */
 export function err<E>(error: E): Result<never, E> {
-  return new Res<never, E>({ tag: "err", error });
+  return errRes(error);
 }
 
 /**
- * Type guard: narrow a {@link Result} to an {@link OkView}, exposing `.value`.
+ * Type guard: narrow a {@link Result} to its `Ok` variant, exposing `.value`.
  *
  * @returns `true` when `r` is `Ok`.
  *
@@ -47,22 +47,22 @@ export function err<E>(error: E): Result<never, E> {
  * if (isOk(r)) r.value; // number, narrowed
  * ```
  */
-export function isOk<T, E>(r: Result<T, E>): r is OkView<T> {
-  return r.isOk();
+export function isOk<T, E>(r: Result<T, E>): r is OkView<T, E> {
+  return r.tag === "Ok";
 }
 /**
- * Type guard: narrow a {@link Result} to an {@link ErrView}, exposing `.error`.
+ * Type guard: narrow a {@link Result} to its `Err` variant, exposing `.error`.
  *
  * @returns `true` when `r` is `Err`.
  */
-export function isErr<T, E>(r: Result<T, E>): r is ErrView<E> {
-  return r.isErr();
+export function isErr<T, E>(r: Result<T, E>): r is ErrView<E, T> {
+  return r.tag === "Err";
 }
 /**
- * Type guard: narrow a {@link Result} to a {@link DefectView}, exposing `.cause`.
+ * Type guard: narrow a {@link Result} to its `Defect` variant, exposing `.cause`.
  *
  * @returns `true` when `r` is a `Defect`.
  */
-export function isDefect<T, E>(r: Result<T, E>): r is DefectView {
-  return r.isDefect();
+export function isDefect<T, E>(r: Result<T, E>): r is DefectView<T, E> {
+  return r.tag === "Defect";
 }

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -1,11 +1,11 @@
-// unthrown — the runtime engine. Three states (Ok | Err | Defect) live in a
-// single `Res` class over a `State` discriminated union; `AsyncRes` wraps a
-// `Promise<Res>` constructed never to reject.
+// unthrown — the runtime engine.
 //
-// `Res._state` is public-at-runtime so module-mates (AsyncRes, aggregation) can
-// branch on it, but it is ABSENT from the `Result` type — so user code never
-// sees it. This module must never be re-exported from `index.ts`; that is what
-// keeps the representation (and the third state) hidden. See CLAUDE.md →
+// `Result` is the PUBLIC discriminated union (tag/value/error/cause + methods).
+// `Res` is its sole internal implementation: one class over a `State` union,
+// exposing the public discriminant via getters. `Res` is never exported from
+// `index.ts`; the three cast-builders below (`okRes`/`errRes`/`defectRes`) are
+// the only place a `Res` instance is bridged to the `Result` type. `AsyncRes`
+// wraps a `Promise<Result>` constructed never to reject. See CLAUDE.md →
 // "Internal design".
 
 import type { AsyncResult, Result } from "./types.js";
@@ -40,19 +40,23 @@ type State<T, E> =
   | { readonly tag: "err"; readonly error: E }
   | { readonly tag: "defect"; readonly cause: unknown };
 
+const PUBLIC_TAG = { ok: "Ok", err: "Err", defect: "Defect" } as const;
+
 /**
  * The sole runtime implementation of {@link Result}. Never re-exported from
- * `index.ts`, which is what keeps `_state` (and the third runtime state) hidden
- * from the public type.
+ * `index.ts`. Bridged to the `Result` type only via `okRes`/`errRes`/`defectRes`.
  *
  * @internal
  */
-export class Res<T, E> implements Result<T, E> {
-  // public-at-runtime, but absent from the Result<T,E> interface, so user code
-  // never sees it; AsyncResult (same module) reads it for branching.
+class Res<T, E> {
   readonly _state: State<T, E>;
 
-  // exposed only on the narrowed views via the standalone guards
+  // The public discriminant. `value`/`error`/`cause` are only reachable on the
+  // matching variant of the `Result` union, so reading the wrong one is a type
+  // error, not a runtime surprise.
+  get tag(): "Ok" | "Err" | "Defect" {
+    return PUBLIC_TAG[this._state.tag];
+  }
   get value(): T {
     return (this._state as { value: T }).value;
   }
@@ -70,9 +74,9 @@ export class Res<T, E> implements Result<T, E> {
   map<U>(f: (value: T) => U): Result<U, E> {
     if (this._state.tag !== "ok") return this as unknown as Result<U, E>;
     try {
-      return new Res<U, E>({ tag: "ok", value: f(this._state.value) });
+      return okRes(f(this._state.value));
     } catch (cause) {
-      return defectRes<U, E>(cause);
+      return defectRes(cause);
     }
   }
 
@@ -81,31 +85,31 @@ export class Res<T, E> implements Result<T, E> {
     try {
       return f(this._state.value) as Result<U, E | E2>;
     } catch (cause) {
-      return defectRes<U, E | E2>(cause);
+      return defectRes(cause);
     }
   }
 
   tap(f: (value: T) => void): Result<T, E> {
-    if (this._state.tag !== "ok") return this;
+    if (this._state.tag !== "ok") return this as unknown as Result<T, E>;
     try {
       f(this._state.value);
-      return this;
+      return this as unknown as Result<T, E>;
     } catch (cause) {
-      return defectRes<T, E>(cause);
+      return defectRes(cause);
     }
   }
 
   as<U>(value: U): Result<U, E> {
     if (this._state.tag !== "ok") return this as unknown as Result<U, E>;
-    return new Res<U, E>({ tag: "ok", value });
+    return okRes(value);
   }
 
   mapErr<E2>(f: (error: E) => E2): Result<T, E2> {
     if (this._state.tag !== "err") return this as unknown as Result<T, E2>;
     try {
-      return new Res<T, E2>({ tag: "err", error: f(this._state.error) });
+      return errRes(f(this._state.error));
     } catch (cause) {
-      return defectRes<T, E2>(cause);
+      return defectRes(cause);
     }
   }
 
@@ -114,26 +118,26 @@ export class Res<T, E> implements Result<T, E> {
     try {
       return f(this._state.error) as Result<T | U, E2>;
     } catch (cause) {
-      return defectRes<T | U, E2>(cause);
+      return defectRes(cause);
     }
   }
 
   recover<U>(f: (error: E) => U): Result<T | U, never> {
     if (this._state.tag !== "err") return this as unknown as Result<T | U, never>;
     try {
-      return new Res<T | U, never>({ tag: "ok", value: f(this._state.error) });
+      return okRes(f(this._state.error));
     } catch (cause) {
-      return defectRes<T | U, never>(cause);
+      return defectRes(cause);
     }
   }
 
   tapErr(f: (error: E) => void): Result<T, E> {
-    if (this._state.tag !== "err") return this;
+    if (this._state.tag !== "err") return this as unknown as Result<T, E>;
     try {
       f(this._state.error);
-      return this;
+      return this as unknown as Result<T, E>;
     } catch (cause) {
-      return defectRes<T, E>(cause);
+      return defectRes(cause);
     }
   }
 
@@ -142,17 +146,17 @@ export class Res<T, E> implements Result<T, E> {
     try {
       return f(this._state.cause) as Result<T | U, E | E2>;
     } catch (cause) {
-      return defectRes<T | U, E | E2>(cause);
+      return defectRes(cause);
     }
   }
 
   tapDefect(f: (cause: unknown) => void): Result<T, E> {
-    if (this._state.tag !== "defect") return this;
+    if (this._state.tag !== "defect") return this as unknown as Result<T, E>;
     try {
       f(this._state.cause);
-      return this;
+      return this as unknown as Result<T, E>;
     } catch (cause) {
-      return defectRes<T, E>(cause);
+      return defectRes(cause);
     }
   }
 
@@ -224,27 +228,46 @@ export class Res<T, E> implements Result<T, E> {
   }
 
   toAsync(): AsyncResult<T, E> {
-    return new AsyncRes<T, E>(Promise.resolve(this));
+    return new AsyncRes<T, E>(Promise.resolve(this as unknown as Result<T, E>));
   }
 }
 
 /**
- * Construct a `Result` already in the `defect` state.
+ * Construct an `Ok` result.
+ *
+ * @internal
+ */
+export function okRes<T, E>(value: T): Result<T, E> {
+  return new Res<T, E>({ tag: "ok", value }) as unknown as Result<T, E>;
+}
+
+/**
+ * Construct an `Err` result.
+ *
+ * @internal
+ */
+export function errRes<T, E>(error: E): Result<T, E> {
+  return new Res<T, E>({ tag: "err", error }) as unknown as Result<T, E>;
+}
+
+/**
+ * Construct a `Defect` result.
  *
  * @internal
  */
 export function defectRes<T, E>(cause: unknown): Result<T, E> {
-  return new Res<T, E>({ tag: "defect", cause });
+  return new Res<T, E>({ tag: "defect", cause }) as unknown as Result<T, E>;
 }
 
 /**
  * The sole runtime implementation of {@link AsyncResult}: wraps a
- * `Promise<Res>` constructed never to reject. Never re-exported from `index.ts`.
+ * `Promise<Result>` constructed never to reject. Operates on the public `Result`
+ * union (via `tag`), never on `Res` internals. Never re-exported from `index.ts`.
  *
  * @internal
  */
 export class AsyncRes<T, E> implements AsyncResult<T, E> {
-  constructor(private readonly promise: Promise<Res<T, E>>) {}
+  constructor(private readonly promise: Promise<Result<T, E>>) {}
 
   // oxlint-disable-next-line no-thenable -- AsyncResult is an intentional (success-only) thenable so `await` collapses it to a Result; see the Awaitable type. onrejected is still forwarded so a hypothetical internal rejection settles the await instead of hanging — though the internal promise never rejects.
   then<R1 = Result<T, E>, R2 = never>(
@@ -257,11 +280,11 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
   map<U>(f: (value: T) => U): AsyncResult<U, E> {
     return new AsyncRes<U, E>(
       this.promise.then((r) => {
-        if (r._state.tag !== "ok") return r as unknown as Res<U, E>;
+        if (r.tag !== "Ok") return r as unknown as Result<U, E>;
         try {
-          return new Res<U, E>({ tag: "ok", value: f(r._state.value) });
+          return okRes(f(r.value));
         } catch (cause) {
-          return new Res<U, E>({ tag: "defect", cause });
+          return defectRes(cause);
         }
       }),
     );
@@ -270,11 +293,11 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
   flatMap<U, E2>(f: (value: T) => Result<U, E2> | AsyncResult<U, E2>): AsyncResult<U, E | E2> {
     return new AsyncRes<U, E | E2>(
       this.promise.then(async (r) => {
-        if (r._state.tag !== "ok") return r as unknown as Res<U, E | E2>;
+        if (r.tag !== "Ok") return r as unknown as Result<U, E | E2>;
         try {
-          return (await f(r._state.value)) as Res<U, E | E2>;
+          return (await f(r.value)) as Result<U, E | E2>;
         } catch (cause) {
-          return new Res<U, E | E2>({ tag: "defect", cause });
+          return defectRes(cause);
         }
       }),
     );
@@ -283,12 +306,12 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
   tap(f: (value: T) => void): AsyncResult<T, E> {
     return new AsyncRes<T, E>(
       this.promise.then((r) => {
-        if (r._state.tag !== "ok") return r;
+        if (r.tag !== "Ok") return r;
         try {
-          f(r._state.value);
+          f(r.value);
           return r;
         } catch (cause) {
-          return new Res<T, E>({ tag: "defect", cause });
+          return defectRes<T, E>(cause);
         }
       }),
     );
@@ -297,7 +320,7 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
   as<U>(value: U): AsyncResult<U, E> {
     return new AsyncRes<U, E>(
       this.promise.then((r) =>
-        r._state.tag === "ok" ? new Res<U, E>({ tag: "ok", value }) : (r as unknown as Res<U, E>),
+        r.tag === "Ok" ? okRes<U, E>(value) : (r as unknown as Result<U, E>),
       ),
     );
   }
@@ -305,11 +328,11 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
   mapErr<E2>(f: (error: E) => E2): AsyncResult<T, E2> {
     return new AsyncRes<T, E2>(
       this.promise.then((r) => {
-        if (r._state.tag !== "err") return r as unknown as Res<T, E2>;
+        if (r.tag !== "Err") return r as unknown as Result<T, E2>;
         try {
-          return new Res<T, E2>({ tag: "err", error: f(r._state.error) });
+          return errRes(f(r.error));
         } catch (cause) {
-          return new Res<T, E2>({ tag: "defect", cause });
+          return defectRes(cause);
         }
       }),
     );
@@ -318,11 +341,11 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
   orElse<U, E2>(f: (error: E) => Result<U, E2> | AsyncResult<U, E2>): AsyncResult<T | U, E2> {
     return new AsyncRes<T | U, E2>(
       this.promise.then(async (r) => {
-        if (r._state.tag !== "err") return r as unknown as Res<T | U, E2>;
+        if (r.tag !== "Err") return r as unknown as Result<T | U, E2>;
         try {
-          return (await f(r._state.error)) as Res<T | U, E2>;
+          return (await f(r.error)) as Result<T | U, E2>;
         } catch (cause) {
-          return new Res<T | U, E2>({ tag: "defect", cause });
+          return defectRes(cause);
         }
       }),
     );
@@ -331,11 +354,11 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
   recover<U>(f: (error: E) => U): AsyncResult<T | U, never> {
     return new AsyncRes<T | U, never>(
       this.promise.then((r) => {
-        if (r._state.tag !== "err") return r as unknown as Res<T | U, never>;
+        if (r.tag !== "Err") return r as unknown as Result<T | U, never>;
         try {
-          return new Res<T | U, never>({ tag: "ok", value: f(r._state.error) });
+          return okRes<T | U, never>(f(r.error));
         } catch (cause) {
-          return new Res<T | U, never>({ tag: "defect", cause });
+          return defectRes(cause);
         }
       }),
     );
@@ -344,12 +367,12 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
   tapErr(f: (error: E) => void): AsyncResult<T, E> {
     return new AsyncRes<T, E>(
       this.promise.then((r) => {
-        if (r._state.tag !== "err") return r;
+        if (r.tag !== "Err") return r;
         try {
-          f(r._state.error);
+          f(r.error);
           return r;
         } catch (cause) {
-          return new Res<T, E>({ tag: "defect", cause });
+          return defectRes<T, E>(cause);
         }
       }),
     );
@@ -360,11 +383,11 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
   ): AsyncResult<T | U, E | E2> {
     return new AsyncRes<T | U, E | E2>(
       this.promise.then(async (r) => {
-        if (r._state.tag !== "defect") return r as unknown as Res<T | U, E | E2>;
+        if (r.tag !== "Defect") return r as unknown as Result<T | U, E | E2>;
         try {
-          return (await f(r._state.cause)) as Res<T | U, E | E2>;
+          return (await f(r.cause)) as Result<T | U, E | E2>;
         } catch (cause) {
-          return new Res<T | U, E | E2>({ tag: "defect", cause });
+          return defectRes(cause);
         }
       }),
     );
@@ -373,12 +396,12 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
   tapDefect(f: (cause: unknown) => void): AsyncResult<T, E> {
     return new AsyncRes<T, E>(
       this.promise.then((r) => {
-        if (r._state.tag !== "defect") return r;
+        if (r.tag !== "Defect") return r;
         try {
-          f(r._state.cause);
+          f(r.cause);
           return r;
         } catch (cause) {
-          return new Res<T, E>({ tag: "defect", cause });
+          return defectRes<T, E>(cause);
         }
       }),
     );
@@ -403,10 +426,9 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
   }
   unwrapOrElse(f: (error: E) => T): Promise<T> {
     return this.promise.then((r) => {
-      const s = r._state;
-      if (s.tag === "ok") return s.value;
-      if (s.tag === "defect") throw s.cause;
-      return f(s.error);
+      if (r.tag === "Ok") return r.value;
+      if (r.tag === "Defect") throw r.cause;
+      return f(r.error);
     });
   }
   getOrNull(): Promise<T | null> {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -1,14 +1,19 @@
 // unthrown — the runtime engine.
 //
 // `Result` is the PUBLIC discriminated union (tag/value/error/cause + methods).
-// `Res` is its sole internal implementation: one class over a `State` union,
-// exposing the public discriminant via getters. `Res` is never exported from
-// `index.ts`; the three cast-builders below (`okRes`/`errRes`/`defectRes`) are
-// the only place a `Res` instance is bridged to the `Result` type. `AsyncRes`
-// wraps a `Promise<Result>` constructed never to reject. See CLAUDE.md →
-// "Internal design".
+// `Res` is a method holder only: its prototype carries the implementations, and
+// instances are built by `okRes`/`errRes`/`defectRes` with `Object.create` +
+// the variant type — so a builder returns a value that already *is* a union
+// member (no `as unknown as`). `Res` is never exported from `index.ts`.
+// `AsyncRes` wraps a `Promise<Result>` constructed never to reject and operates
+// purely on the public union (via `r.tag`). See CLAUDE.md → "Internal design".
+//
+// The only casts left are the inherent type-changing pass-throughs (e.g. `map`
+// reusing an `Err` as a differently-typed `Result`) — the same `as unknown as`
+// boxed uses, sound because the passed-through variant carries no value of the
+// changed type.
 
-import type { AsyncResult, Result } from "./types.js";
+import type { AsyncResult, DefectView, ErrView, OkView, Result } from "./types.js";
 
 /**
  * Thrown by a {@link Result}'s `unwrap` / `unwrapErr` when the assertion is
@@ -35,210 +40,190 @@ export class UnwrapError<E = unknown> extends Error {
   }
 }
 
-type State<T, E> =
-  | { readonly tag: "ok"; readonly value: T }
-  | { readonly tag: "err"; readonly error: E }
-  | { readonly tag: "defect"; readonly cause: unknown };
-
-const PUBLIC_TAG = { ok: "Ok", err: "Err", defect: "Defect" } as const;
-
 /**
- * The sole runtime implementation of {@link Result}. Never re-exported from
- * `index.ts`. Bridged to the `Result` type only via `okRes`/`errRes`/`defectRes`.
+ * Method holder for {@link Result}. Never instantiated with `new` and never
+ * exported; the builders below attach its prototype to plain objects. Every
+ * method types `this` as the public `Result` union, so it narrows on `tag`.
  *
  * @internal
  */
 class Res<T, E> {
-  readonly _state: State<T, E>;
-
-  // The public discriminant. `value`/`error`/`cause` are only reachable on the
-  // matching variant of the `Result` union, so reading the wrong one is a type
-  // error, not a runtime surprise.
-  get tag(): "Ok" | "Err" | "Defect" {
-    return PUBLIC_TAG[this._state.tag];
-  }
-  get value(): T {
-    return (this._state as { value: T }).value;
-  }
-  get error(): E {
-    return (this._state as { error: E }).error;
-  }
-  get cause(): unknown {
-    return (this._state as { cause: unknown }).cause;
-  }
-
-  constructor(state: State<T, E>) {
-    this._state = state;
-  }
-
-  map<U>(f: (value: T) => U): Result<U, E> {
-    if (this._state.tag !== "ok") return this as unknown as Result<U, E>;
+  map<U>(this: Result<T, E>, f: (value: T) => U): Result<U, E> {
+    if (this.tag !== "Ok") return this as unknown as Result<U, E>;
     try {
-      return okRes(f(this._state.value));
+      return okRes(f(this.value));
     } catch (cause) {
       return defectRes(cause);
     }
   }
 
-  flatMap<U, E2>(f: (value: T) => Result<U, E2>): Result<U, E | E2> {
-    if (this._state.tag !== "ok") return this as unknown as Result<U, E | E2>;
+  flatMap<U, E2>(this: Result<T, E>, f: (value: T) => Result<U, E2>): Result<U, E | E2> {
+    if (this.tag !== "Ok") return this as unknown as Result<U, E | E2>;
     try {
-      return f(this._state.value) as Result<U, E | E2>;
+      return f(this.value) as Result<U, E | E2>;
     } catch (cause) {
       return defectRes(cause);
     }
   }
 
-  tap(f: (value: T) => void): Result<T, E> {
-    if (this._state.tag !== "ok") return this as unknown as Result<T, E>;
+  tap(this: Result<T, E>, f: (value: T) => void): Result<T, E> {
+    if (this.tag !== "Ok") return this;
     try {
-      f(this._state.value);
-      return this as unknown as Result<T, E>;
+      f(this.value);
+      return this;
     } catch (cause) {
       return defectRes(cause);
     }
   }
 
-  as<U>(value: U): Result<U, E> {
-    if (this._state.tag !== "ok") return this as unknown as Result<U, E>;
+  as<U>(this: Result<T, E>, value: U): Result<U, E> {
+    if (this.tag !== "Ok") return this as unknown as Result<U, E>;
     return okRes(value);
   }
 
-  mapErr<E2>(f: (error: E) => E2): Result<T, E2> {
-    if (this._state.tag !== "err") return this as unknown as Result<T, E2>;
+  mapErr<E2>(this: Result<T, E>, f: (error: E) => E2): Result<T, E2> {
+    if (this.tag !== "Err") return this as unknown as Result<T, E2>;
     try {
-      return errRes(f(this._state.error));
+      return errRes(f(this.error));
     } catch (cause) {
       return defectRes(cause);
     }
   }
 
-  orElse<U, E2>(f: (error: E) => Result<U, E2>): Result<T | U, E2> {
-    if (this._state.tag !== "err") return this as unknown as Result<T | U, E2>;
+  orElse<U, E2>(this: Result<T, E>, f: (error: E) => Result<U, E2>): Result<T | U, E2> {
+    if (this.tag !== "Err") return this as unknown as Result<T | U, E2>;
     try {
-      return f(this._state.error) as Result<T | U, E2>;
+      return f(this.error) as Result<T | U, E2>;
     } catch (cause) {
       return defectRes(cause);
     }
   }
 
-  recover<U>(f: (error: E) => U): Result<T | U, never> {
-    if (this._state.tag !== "err") return this as unknown as Result<T | U, never>;
+  recover<U>(this: Result<T, E>, f: (error: E) => U): Result<T | U, never> {
+    if (this.tag !== "Err") return this as unknown as Result<T | U, never>;
     try {
-      return okRes(f(this._state.error));
+      return okRes(f(this.error));
     } catch (cause) {
       return defectRes(cause);
     }
   }
 
-  tapErr(f: (error: E) => void): Result<T, E> {
-    if (this._state.tag !== "err") return this as unknown as Result<T, E>;
+  tapErr(this: Result<T, E>, f: (error: E) => void): Result<T, E> {
+    if (this.tag !== "Err") return this;
     try {
-      f(this._state.error);
-      return this as unknown as Result<T, E>;
+      f(this.error);
+      return this;
     } catch (cause) {
       return defectRes(cause);
     }
   }
 
-  recoverDefect<U, E2>(f: (cause: unknown) => Result<U, E2>): Result<T | U, E | E2> {
-    if (this._state.tag !== "defect") return this as unknown as Result<T | U, E | E2>;
+  recoverDefect<U, E2>(
+    this: Result<T, E>,
+    f: (cause: unknown) => Result<U, E2>,
+  ): Result<T | U, E | E2> {
+    if (this.tag !== "Defect") return this as unknown as Result<T | U, E | E2>;
     try {
-      return f(this._state.cause) as Result<T | U, E | E2>;
+      return f(this.cause) as Result<T | U, E | E2>;
     } catch (cause) {
       return defectRes(cause);
     }
   }
 
-  tapDefect(f: (cause: unknown) => void): Result<T, E> {
-    if (this._state.tag !== "defect") return this as unknown as Result<T, E>;
+  tapDefect(this: Result<T, E>, f: (cause: unknown) => void): Result<T, E> {
+    if (this.tag !== "Defect") return this;
     try {
-      f(this._state.cause);
-      return this as unknown as Result<T, E>;
+      f(this.cause);
+      return this;
     } catch (cause) {
       return defectRes(cause);
     }
   }
 
-  match<R>(cases: { ok: (value: T) => R; err: (error: E) => R; defect: (cause: unknown) => R }): R {
-    switch (this._state.tag) {
-      case "ok":
-        return cases.ok(this._state.value);
-      case "err":
-        return cases.err(this._state.error);
-      case "defect":
-        return cases.defect(this._state.cause);
+  match<R>(
+    this: Result<T, E>,
+    cases: { ok: (value: T) => R; err: (error: E) => R; defect: (cause: unknown) => R },
+  ): R {
+    switch (this.tag) {
+      case "Ok":
+        return cases.ok(this.value);
+      case "Err":
+        return cases.err(this.error);
+      case "Defect":
+        return cases.defect(this.cause);
     }
   }
 
-  unwrap(): T {
-    switch (this._state.tag) {
-      case "ok":
-        return this._state.value;
-      case "err":
-        throw new UnwrapError(this._state.error);
-      case "defect":
-        throw this._state.cause; // rethrow original cause, original stack
+  unwrap(this: Result<T, E>): T {
+    switch (this.tag) {
+      case "Ok":
+        return this.value;
+      case "Err":
+        throw new UnwrapError(this.error);
+      case "Defect":
+        throw this.cause; // rethrow original cause, original stack
     }
   }
 
-  unwrapErr(): E {
-    switch (this._state.tag) {
-      case "err":
-        return this._state.error;
-      case "ok":
-        throw new UnwrapError(this._state.value);
-      case "defect":
-        throw this._state.cause;
+  unwrapErr(this: Result<T, E>): E {
+    switch (this.tag) {
+      case "Err":
+        return this.error;
+      case "Ok":
+        throw new UnwrapError(this.value);
+      case "Defect":
+        throw this.cause;
     }
   }
 
-  unwrapOr(fallback: T): T {
-    if (this._state.tag === "ok") return this._state.value;
-    if (this._state.tag === "defect") throw this._state.cause;
+  unwrapOr(this: Result<T, E>, fallback: T): T {
+    if (this.tag === "Ok") return this.value;
+    if (this.tag === "Defect") throw this.cause;
     return fallback;
   }
 
-  unwrapOrElse(f: (error: E) => T): T {
-    if (this._state.tag === "ok") return this._state.value;
-    if (this._state.tag === "defect") throw this._state.cause;
-    return f(this._state.error);
+  unwrapOrElse(this: Result<T, E>, f: (error: E) => T): T {
+    if (this.tag === "Ok") return this.value;
+    if (this.tag === "Defect") throw this.cause;
+    return f(this.error);
   }
 
-  getOrNull(): T | null {
-    if (this._state.tag === "ok") return this._state.value;
-    if (this._state.tag === "defect") throw this._state.cause;
+  getOrNull(this: Result<T, E>): T | null {
+    if (this.tag === "Ok") return this.value;
+    if (this.tag === "Defect") throw this.cause;
     return null;
   }
 
-  getOrUndefined(): T | undefined {
-    if (this._state.tag === "ok") return this._state.value;
-    if (this._state.tag === "defect") throw this._state.cause;
+  getOrUndefined(this: Result<T, E>): T | undefined {
+    if (this.tag === "Ok") return this.value;
+    if (this.tag === "Defect") throw this.cause;
     return undefined;
   }
 
-  isOk(): boolean {
-    return this._state.tag === "ok";
+  isOk(this: Result<T, E>): boolean {
+    return this.tag === "Ok";
   }
-  isErr(): boolean {
-    return this._state.tag === "err";
+  isErr(this: Result<T, E>): boolean {
+    return this.tag === "Err";
   }
-  isDefect(): boolean {
-    return this._state.tag === "defect";
+  isDefect(this: Result<T, E>): boolean {
+    return this.tag === "Defect";
   }
 
-  toAsync(): AsyncResult<T, E> {
-    return new AsyncRes<T, E>(Promise.resolve(this as unknown as Result<T, E>));
+  toAsync(this: Result<T, E>): AsyncResult<T, E> {
+    return new AsyncRes<T, E>(Promise.resolve(this));
   }
 }
 
+const RESULT_PROTO = Res.prototype;
+
 /**
- * Construct an `Ok` result.
+ * Construct an `Ok` result — a plain object on the {@link Res} prototype.
  *
  * @internal
  */
 export function okRes<T, E>(value: T): Result<T, E> {
-  return new Res<T, E>({ tag: "ok", value }) as unknown as Result<T, E>;
+  return Object.assign(Object.create(RESULT_PROTO), { tag: "Ok" as const, value }) as OkView<T, E>;
 }
 
 /**
@@ -247,7 +232,10 @@ export function okRes<T, E>(value: T): Result<T, E> {
  * @internal
  */
 export function errRes<T, E>(error: E): Result<T, E> {
-  return new Res<T, E>({ tag: "err", error }) as unknown as Result<T, E>;
+  return Object.assign(Object.create(RESULT_PROTO), { tag: "Err" as const, error }) as ErrView<
+    E,
+    T
+  >;
 }
 
 /**
@@ -256,7 +244,10 @@ export function errRes<T, E>(error: E): Result<T, E> {
  * @internal
  */
 export function defectRes<T, E>(cause: unknown): Result<T, E> {
-  return new Res<T, E>({ tag: "defect", cause }) as unknown as Result<T, E>;
+  return Object.assign(Object.create(RESULT_PROTO), {
+    tag: "Defect" as const,
+    cause,
+  }) as DefectView<T, E>;
 }
 
 /**

--- a/packages/core/src/interop.ts
+++ b/packages/core/src/interop.ts
@@ -2,7 +2,7 @@
 // through `qualify`, which triages each cause into a modeled `E` or a `Defect`;
 // there is no path that yields `unknown` in `E`.
 
-import { AsyncRes, defectRes, Res } from "./core.js";
+import { AsyncRes, defectRes, errRes, okRes } from "./core.js";
 import { type Defect, isDefectMarker } from "./defect.js";
 import { err, ok } from "./constructors.js";
 import type { AsyncResult, ErrOf, OkOf, Result } from "./types.js";
@@ -97,9 +97,9 @@ export function fromPromise<T, E>(
   qualify: (cause: unknown) => E | Defect,
 ): AsyncResult<T, E> {
   const p = typeof promise === "function" ? Promise.resolve().then(promise) : promise;
-  const settled: Promise<Res<T, E>> = p.then(
-    (value) => new Res<T, E>({ tag: "ok", value }),
-    (cause) => qualifyToResult<T, E>(cause, qualify) as Res<T, E>,
+  const settled: Promise<Result<T, E>> = p.then(
+    (value) => okRes<T, E>(value),
+    (cause) => qualifyToResult<T, E>(cause, qualify),
   );
   return new AsyncRes<T, E>(settled);
 }
@@ -120,9 +120,9 @@ export function fromSafePromise<T>(
   promise: Promise<T> | (() => Promise<T>),
 ): AsyncResult<T, never> {
   const p = typeof promise === "function" ? Promise.resolve().then(promise) : promise;
-  const settled: Promise<Res<T, never>> = p.then(
-    (value) => new Res<T, never>({ tag: "ok", value }),
-    (cause) => new Res<T, never>({ tag: "defect", cause }),
+  const settled: Promise<Result<T, never>> = p.then(
+    (value) => okRes<T, never>(value),
+    (cause) => defectRes<T, never>(cause),
   );
   return new AsyncRes<T, never>(settled);
 }
@@ -133,7 +133,7 @@ function qualifyToResult<T, E>(
 ): Result<T, E> {
   try {
     const q = qualify(cause);
-    return isDefectMarker(q) ? defectRes<T, E>(q.cause) : (err(q) as Result<T, E>);
+    return isDefectMarker(q) ? defectRes<T, E>(q.cause) : errRes<T, E>(q);
   } catch (qErr) {
     // a throw inside qualify is itself a defect
     return defectRes<T, E>(qErr);
@@ -167,10 +167,9 @@ export function all<Rs extends readonly Result<unknown, unknown>[]>(
   let firstDefect: Result<unknown, unknown> | undefined;
 
   for (const r of results) {
-    const s = (r as Res<unknown, unknown>)._state;
-    if (s.tag === "defect") firstDefect ??= r;
-    else if (s.tag === "err") firstErr ??= r;
-    else values.push(s.value);
+    if (r.tag === "Defect") firstDefect ??= r;
+    else if (r.tag === "Err") firstErr ??= r;
+    else values.push(r.value);
   }
 
   if (firstDefect)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -122,7 +122,8 @@ export type ResultMethods<T, E> = {
    * Exactly one handler runs. Together with the throw-to-defect guarantee, this
    * is typically the single place a pipeline is handled at the edge — mapping
    * `ok`/`err`/`defect` to (for example) 2xx / 4xx / 5xx with no `try`/`catch`.
-   * (For richer matching, a `Result` is also a discriminated union — see `tag`.)
+   * (For richer matching, a `Result` is also a discriminated union — branch on
+   * its `tag` property, e.g. with `ts-pattern`.)
    *
    * @typeParam R - the folded result type.
    * @param cases - one handler per channel.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,45 +1,15 @@
 // unthrown — public type surface. Pure types, no runtime.
 
 /**
- * The core type of the library: a computation that has either succeeded with a
- * value of type `T` or failed with a *modeled* error of type `E`.
- *
- * @remarks
- * A `Result` has **three** runtime states but only **two** type parameters:
- *
- * - **Ok** — a success carrying a `T`.
- * - **Err** — a modeled, anticipated failure carrying an `E`.
- * - **Defect** — an *unmodeled* failure (a thrown bug, an un-triaged rejection).
- *   A defect is deliberately **invisible to the type**: it never appears in `E`.
- *
- * The success combinators (`map`, `flatMap`, …) run only on `Ok`; the error
- * combinators (`mapErr`, `recover`, …) run only on `Err`. A `Defect` flows
- * through every method untouched **except** `match` and `recoverDefect` — those
- * are the only two that can observe it.
- *
- * Any value thrown by a callback inside a combinator is captured as a `Defect`
- * rather than escaping, so a pipeline can be folded once at the edge with
- * `match` and no surrounding `try`/`catch`.
+ * The method surface every {@link Result} variant carries. Factored out so the
+ * three variants ({@link OkView}, {@link ErrView}, {@link DefectView}) can each
+ * intersect it. Not part of the public API on its own.
  *
  * @typeParam T - the success value type.
- * @typeParam E - the modeled error type (only anticipated domain failures).
- *
- * @example
- * ```ts
- * import { ok, err, type Result } from "unthrown";
- *
- * function half(n: number): Result<number, "odd"> {
- *   return n % 2 === 0 ? ok(n / 2) : err("odd");
- * }
- *
- * const message = half(10).match({
- *   ok: (n) => `got ${n}`,
- *   err: (e) => `failed: ${e}`,
- *   defect: (cause) => `bug: ${String(cause)}`,
- * });
- * ```
+ * @typeParam E - the modeled error type.
+ * @internal
  */
-export type Result<T, E> = {
+export type ResultMethods<T, E> = {
   /**
    * Transform the success value with `f`.
    *
@@ -152,6 +122,7 @@ export type Result<T, E> = {
    * Exactly one handler runs. Together with the throw-to-defect guarantee, this
    * is typically the single place a pipeline is handled at the edge — mapping
    * `ok`/`err`/`defect` to (for example) 2xx / 4xx / 5xx with no `try`/`catch`.
+   * (For richer matching, a `Result` is also a discriminated union — see `tag`.)
    *
    * @typeParam R - the folded result type.
    * @param cases - one handler per channel.
@@ -213,6 +184,61 @@ export type Result<T, E> = {
   toAsync(): AsyncResult<T, E>;
 };
 
+/** The `Ok` variant of a {@link Result}: a success carrying a `value`. */
+export type OkView<T, E = never> = ResultMethods<T, E> & {
+  readonly tag: "Ok";
+  readonly value: T;
+};
+/** The `Err` variant of a {@link Result}: a modeled failure carrying an `error`. */
+export type ErrView<E, T = never> = ResultMethods<T, E> & {
+  readonly tag: "Err";
+  readonly error: E;
+};
+/** The `Defect` variant of a {@link Result}: an unmodeled failure carrying a `cause`. */
+export type DefectView<T = never, E = never> = ResultMethods<T, E> & {
+  readonly tag: "Defect";
+  readonly cause: unknown;
+};
+
+/**
+ * The core type of the library: a computation that has either succeeded with a
+ * value of type `T` or failed with a *modeled* error of type `E`.
+ *
+ * @remarks
+ * A `Result` is a **discriminated union** of three variants, distinguished by a
+ * `tag` of `"Ok"` | `"Err"` | `"Defect"`:
+ *
+ * - **`Ok`** — a success carrying a `value: T`.
+ * - **`Err`** — a modeled, anticipated failure carrying an `error: E`.
+ * - **`Defect`** — an *unmodeled* failure carrying an unknown `cause`. A defect
+ *   never appears in `E`; it is the library's third, out-of-band channel.
+ *
+ * Because it is a real union, you can match it natively (a `switch` on `tag`, or
+ * `ts-pattern`'s `match(...).with({ tag: "Ok" }, …).exhaustive()`), *and* it
+ * carries the full method surface ({@link ResultMethods}) for fluent chaining.
+ * Either way, the payload (`value`/`error`/`cause`) is only reachable after you
+ * narrow — so "check before you access" still holds.
+ *
+ * @typeParam T - the success value type.
+ * @typeParam E - the modeled error type (only anticipated domain failures).
+ *
+ * @example
+ * ```ts
+ * import { ok, err, type Result } from "unthrown";
+ *
+ * function half(n: number): Result<number, "odd"> {
+ *   return n % 2 === 0 ? ok(n / 2) : err("odd");
+ * }
+ *
+ * const message = half(10).match({
+ *   ok: (n) => `got ${n}`,
+ *   err: (e) => `failed: ${e}`,
+ *   defect: (cause) => `bug: ${String(cause)}`,
+ * });
+ * ```
+ */
+export type Result<T, E> = OkView<T, E> | ErrView<E, T> | DefectView<T, E>;
+
 /**
  * A success-only thenable: awaitable, but deliberately **not** a full
  * `PromiseLike`.
@@ -242,6 +268,8 @@ export type Awaitable<T> = {
  * qualified boundary and compose it: `ar.flatMap((v) => fromPromise(work(v),
  * qualify))`. The eliminators (`unwrap`, …) return promises; the binds
  * (`flatMap`, `orElse`, `recoverDefect`) additionally accept an `AsyncResult`.
+ *
+ * To pattern-match an `AsyncResult`, `await` it first: `match(await ar)`.
  *
  * @typeParam T - the success value type.
  * @typeParam E - the modeled error type.
@@ -296,34 +324,14 @@ export type AsyncResult<T, E> = Awaitable<Result<T, E>> & {
 };
 
 /**
- * An `Ok`-narrowed {@link Result} that additionally exposes its `value`. Yielded
- * by the {@link isOk} guard.
- *
- * @typeParam T - the success value type.
- */
-export type OkView<T> = Result<T, never> & { readonly value: T };
-/**
- * An `Err`-narrowed {@link Result} that additionally exposes its `error`.
- * Yielded by the {@link isErr} guard.
- *
- * @typeParam E - the modeled error type.
- */
-export type ErrView<E> = Result<never, E> & { readonly error: E };
-/**
- * A `Defect`-narrowed {@link Result} that additionally exposes its unknown
- * `cause`. Yielded by the {@link isDefect} guard.
- */
-export type DefectView = Result<never, never> & { readonly cause: unknown };
-
-/**
- * Extract the success type `T` from a `Result<T, unknown>`.
+ * Extract the success type `T` from a `Result`.
  *
  * @typeParam R - the `Result` type to inspect.
  */
-export type OkOf<R> = R extends Result<infer T, unknown> ? T : never;
+export type OkOf<R> = R extends { readonly tag: "Ok"; readonly value: infer T } ? T : never;
 /**
- * Extract the error type `E` from a `Result<unknown, E>`.
+ * Extract the error type `E` from a `Result`.
  *
  * @typeParam R - the `Result` type to inspect.
  */
-export type ErrOf<R> = R extends Result<unknown, infer E> ? E : never;
+export type ErrOf<R> = R extends { readonly tag: "Err"; readonly error: infer E } ? E : never;

--- a/packages/core/typedoc.json
+++ b/packages/core/typedoc.json
@@ -2,5 +2,5 @@
   "extends": "@unthrown/typedoc/base.json",
   "entryPoints": ["src/index.ts"],
   "out": "docs",
-  "intentionallyNotExported": ["Result", "Props"]
+  "intentionallyNotExported": ["Result", "Props", "ResultMethods"]
 }

--- a/packages/pattern/README.md
+++ b/packages/pattern/README.md
@@ -27,8 +27,9 @@ match(result)
 ```
 
 - `P.ok(sub?)` / `P.err(sub?)` / `P.defect(sub?)` — match a channel; pass a
-  sub-pattern (a literal, `P.string`, `P.select()`, …) to constrain or select the
-  payload. (Or skip the sugar and match `{ tag: "Ok", … }` directly.)
+  sub-pattern to constrain or select the payload: a literal, or any `ts-pattern`
+  pattern (e.g. `ts-pattern`'s own `P.string` / `P.select()`, imported from
+  `ts-pattern`). (Or skip the sugar and match `{ tag: "Ok", … }` directly.)
 - `P.tag(t)` — sugar for `{ _tag: t }`; nested in `P.err(...)` it narrows to the
   matching `TaggedError` variant, including its payload.
 

--- a/packages/pattern/README.md
+++ b/packages/pattern/README.md
@@ -10,22 +10,27 @@
 pnpm add @unthrown/pattern ts-pattern
 ```
 
+A `Result` is a discriminated union (`{ tag: "Ok" | "Err" | "Defect" }`), so
+ts-pattern matches it **natively** — narrowing, selection, and `.exhaustive()`
+all work. This package is just pattern-constructor sugar.
+
 ```ts
 import { match } from "ts-pattern";
-import { toMatchable, tag } from "@unthrown/pattern";
+import * as P from "@unthrown/pattern";
 
-match(toMatchable(result))
-  .with({ _kind: "Ok" }, ({ value }) => `ok: ${value}`)
-  .with({ _kind: "Err", error: tag("Forbidden") }, ({ error }) => `403 ${error.user}`)
-  .with({ _kind: "Err" }, () => "error")
-  .with({ _kind: "Defect" }, () => "bug")
+match(result)
+  .with(P.ok(), ({ value }) => `ok: ${value}`)
+  .with(P.err(P.tag("Forbidden")), ({ error }) => `403 ${error.user}`)
+  .with(P.err(), () => "error")
+  .with(P.defect(), () => "bug")
   .exhaustive();
 ```
 
-- `toMatchable(result)` — adapt a `Result` into a `_kind`-discriminated union
-  ts-pattern can match, exposing the ok / err / defect channels.
-- `tag(t)` — sugar for the `{ _tag: t }` pattern; narrows to the matching
-  `TaggedError` variant, including its payload.
+- `P.ok(sub?)` / `P.err(sub?)` / `P.defect(sub?)` — match a channel; pass a
+  sub-pattern (a literal, `P.string`, `P.select()`, …) to constrain or select the
+  payload. (Or skip the sugar and match `{ tag: "Ok", … }` directly.)
+- `P.tag(t)` — sugar for `{ _tag: t }`; nested in `P.err(...)` it narrows to the
+  matching `TaggedError` variant, including its payload.
 
 For the everyday exhaustive case, `matchTags` in core is simpler. Reach for this
 when you need ts-pattern's guards, nested patterns, or wildcards.

--- a/packages/pattern/src/index.spec.ts
+++ b/packages/pattern/src/index.spec.ts
@@ -1,8 +1,8 @@
-import { match } from "ts-pattern";
+import { match, P as TP } from "ts-pattern";
 import { err, ok, type Result, TaggedError } from "unthrown";
 import { describe, expect, it } from "vitest";
 
-import { tag, toMatchable } from "./index.js";
+import * as P from "./index.js";
 
 class NotFound extends TaggedError("NotFound") {}
 class Forbidden extends TaggedError("Forbidden")<{ user: string }> {}
@@ -13,44 +13,49 @@ const aDefect: Result<number, never> = ok(0).map<number>(() => {
   throw boom;
 });
 
-describe("toMatchable", () => {
-  it("exposes the ok / err / defect channels as a discriminated union", () => {
-    expect(toMatchable(ok(1))).toEqual({ _kind: "Ok", value: 1 });
-    expect(toMatchable(err("e"))).toEqual({ _kind: "Err", error: "e" });
-    expect(toMatchable(aDefect)).toMatchObject({ _kind: "Defect", cause: boom });
-  });
-
-  it("lets ts-pattern match across all three channels", () => {
+describe("a Result is natively matchable", () => {
+  it("matches directly on its tag, exhaustively", () => {
     const fold = (r: Result<number, string>): string =>
-      match(toMatchable(r))
-        .with({ _kind: "Ok" }, ({ value }) => `ok:${value}`)
-        .with({ _kind: "Err" }, ({ error }) => `err:${error}`)
-        .with({ _kind: "Defect" }, () => "defect")
+      match(r)
+        .with({ tag: "Ok" }, ({ value }) => `ok:${value}`)
+        .with({ tag: "Err" }, ({ error }) => `err:${error}`)
+        .with({ tag: "Defect" }, ({ cause }) => `defect:${String(cause)}`)
         .exhaustive();
 
     expect(fold(ok(2))).toBe("ok:2");
     expect(fold(err("x"))).toBe("err:x");
-    expect(fold(aDefect)).toBe("defect");
+    expect(fold(aDefect)).toBe(`defect:${String(boom)}`);
   });
 });
 
-describe("tag", () => {
-  it("returns the { _tag } object pattern", () => {
-    expect(tag("Foo")).toEqual({ _tag: "Foo" });
+describe("pattern constructors", () => {
+  const fold = (r: Result<number, ApiError>): string =>
+    match(r)
+      .with(P.ok(), ({ value }) => `ok:${value}`)
+      // `error.user` only type-checks because P.tag narrows to Forbidden.
+      .with(P.err(P.tag("Forbidden")), ({ error }) => `forbidden:${error.user}`)
+      .with(P.err(P.tag("NotFound")), () => "not-found")
+      .with(P.defect(), () => "defect")
+      .exhaustive();
+
+  it("P.ok / P.err / P.defect narrow each channel", () => {
+    expect(fold(ok(5))).toBe("ok:5");
+    expect(fold(err(new NotFound()))).toBe("not-found");
+    expect(fold(err(new Forbidden({ user: "bob" })))).toBe("forbidden:bob");
   });
 
-  it("matches a TaggedError by _tag and narrows to the variant's payload", () => {
-    const fold = (r: Result<number, ApiError>): string =>
-      match(toMatchable(r))
-        .with({ _kind: "Ok" }, ({ value }) => `ok:${value}`)
-        // `error.user` below only typechecks because `tag` narrows to Forbidden.
-        .with({ _kind: "Err", error: tag("Forbidden") }, ({ error }) => `forbidden:${error.user}`)
-        .with({ _kind: "Err", error: tag("NotFound") }, () => "not-found")
-        .with({ _kind: "Defect" }, () => "defect")
-        .exhaustive();
+  it("P.ok(pattern) constrains and selects the value", () => {
+    const out = match(ok<number>(42) as Result<number, string>)
+      .with(P.ok(TP.select()), (v) => v + 1)
+      .otherwise(() => 0);
+    expect(out).toBe(43);
+  });
 
-    expect(fold(err(new Forbidden({ user: "bob" })))).toBe("forbidden:bob");
-    expect(fold(err(new NotFound()))).toBe("not-found");
-    expect(fold(ok(5))).toBe("ok:5");
+  it("constructors return plain ts-pattern object patterns", () => {
+    expect(P.ok()).toEqual({ tag: "Ok" });
+    expect(P.err()).toEqual({ tag: "Err" });
+    expect(P.defect()).toEqual({ tag: "Defect" });
+    expect(P.ok(1)).toEqual({ tag: "Ok", value: 1 });
+    expect(P.tag("X")).toEqual({ _tag: "X" });
   });
 });

--- a/packages/pattern/src/index.ts
+++ b/packages/pattern/src/index.ts
@@ -15,11 +15,19 @@
 //     .with(P.err(), ({ error }) => `error: ${error}`)
 //     .with(P.defect(), ({ cause }) => `bug: ${String(cause)}`)
 //     .exhaustive();
+//
+// Here `P` is THIS package. To also use ts-pattern's own patterns (wildcards,
+// `P.select()`, `P.string`, …), import ts-pattern's `P` under another name:
+//
+//   import { match, P as t } from "ts-pattern";
+//   import * as P from "@unthrown/pattern";
+//   match(result).with(P.ok(t.select()), (value) => value).otherwise(() => …);
 
 /**
  * A `ts-pattern` pattern matching the `Ok` variant of a `Result`. With no
- * argument it matches any `Ok`; pass a sub-pattern (e.g. a literal, `P.string`,
- * or `P.select()`) to constrain or select the `value`.
+ * argument it matches any `Ok`; pass a sub-pattern to constrain or select the
+ * `value` — a literal, or any `ts-pattern` pattern (e.g. `ts-pattern`'s own
+ * `P.string` / `P.select()`, imported from `ts-pattern`, not this package).
  *
  * @typeParam V - the sub-pattern matched against the `Ok` value.
  */

--- a/packages/pattern/src/index.ts
+++ b/packages/pattern/src/index.ts
@@ -1,59 +1,64 @@
-// @unthrown/pattern — a thin `ts-pattern` integration for `Result`.
+// @unthrown/pattern — native `ts-pattern` interop for `Result`.
 //
-// `ts-pattern` already matches tagged unions natively, so this package is
-// deliberately small: `toMatchable` exposes a Result's otherwise-hidden
-// ok/err/defect channels as a discriminated union `ts-pattern` can match, and
-// `tag` is sugar for matching a `TaggedError` by its `_tag`. The matching power
-// is `ts-pattern`'s; `matchTags` from `unthrown` covers the everyday exhaustive
-// case.
-
-import type { Result } from "unthrown";
-
-/**
- * A discriminated view of a `Result`'s three channels, suitable for
- * `ts-pattern`'s `match`. The `_kind` discriminant is distinct from any `_tag`
- * an error value may carry, so the two never collide in nested patterns.
- *
- * @typeParam T - the success value type.
- * @typeParam E - the modeled error type.
- */
-export type ResultMatchable<T, E> =
-  | { readonly _kind: "Ok"; readonly value: T }
-  | { readonly _kind: "Err"; readonly error: E }
-  | { readonly _kind: "Defect"; readonly cause: unknown };
+// A `Result` is a discriminated union (`{ tag: "Ok" | "Err" | "Defect" }`), so
+// `ts-pattern` matches it directly — narrowing, selection, and `.exhaustive()`
+// all work out of the box. This package is just sugar: pattern constructors so
+// you can write `P.ok(...)` instead of the raw `{ tag: "Ok", value: ... }`
+// object pattern, plus `tag` for matching a `TaggedError` by its `_tag`.
+//
+//   import { match } from "ts-pattern";
+//   import * as P from "@unthrown/pattern";
+//
+//   match(result)
+//     .with(P.ok(), ({ value }) => `ok: ${value}`)
+//     .with(P.err(P.tag("NotFound")), () => "404")
+//     .with(P.err(), ({ error }) => `error: ${error}`)
+//     .with(P.defect(), ({ cause }) => `bug: ${String(cause)}`)
+//     .exhaustive();
 
 /**
- * Adapt a `Result` into a discriminated union `ts-pattern` can match on,
- * exposing the otherwise-hidden ok / err / defect channels.
+ * A `ts-pattern` pattern matching the `Ok` variant of a `Result`. With no
+ * argument it matches any `Ok`; pass a sub-pattern (e.g. a literal, `P.string`,
+ * or `P.select()`) to constrain or select the `value`.
  *
- * @typeParam T - the success value type.
- * @typeParam E - the modeled error type.
- * @param result - the result to view.
- *
- * @example
- * ```ts
- * import { match } from "ts-pattern";
- * import { toMatchable, tag } from "@unthrown/pattern";
- *
- * match(toMatchable(result))
- *   .with({ _kind: "Ok" }, ({ value }) => `ok ${value}`)
- *   .with({ _kind: "Err", error: tag("NotFound") }, () => 404)
- *   .with({ _kind: "Defect" }, ({ cause }) => `bug ${String(cause)}`)
- *   .exhaustive();
- * ```
+ * @typeParam V - the sub-pattern matched against the `Ok` value.
  */
-export function toMatchable<T, E>(result: Result<T, E>): ResultMatchable<T, E> {
-  return result.match<ResultMatchable<T, E>>({
-    ok: (value) => ({ _kind: "Ok", value }),
-    err: (error) => ({ _kind: "Err", error }),
-    defect: (cause) => ({ _kind: "Defect", cause }),
-  });
+export function ok(): { tag: "Ok" };
+export function ok<const V>(value: V): { tag: "Ok"; value: V };
+export function ok(...args: [] | [unknown]): { tag: "Ok"; value?: unknown } {
+  return args.length === 0 ? { tag: "Ok" } : { tag: "Ok", value: args[0] };
 }
 
 /**
- * `ts-pattern` sugar: a pattern matching any value whose `_tag` equals `value`
- * (e.g. a `TaggedError`). Equivalent to the object pattern `{ _tag: value }`,
- * but reads better nested inside an `Err` pattern and narrows to the matching
+ * A `ts-pattern` pattern matching the `Err` variant of a `Result`. With no
+ * argument it matches any `Err`; pass a sub-pattern (e.g. {@link tag}) to
+ * constrain or select the `error`.
+ *
+ * @typeParam V - the sub-pattern matched against the `Err` error.
+ */
+export function err(): { tag: "Err" };
+export function err<const V>(error: V): { tag: "Err"; error: V };
+export function err(...args: [] | [unknown]): { tag: "Err"; error?: unknown } {
+  return args.length === 0 ? { tag: "Err" } : { tag: "Err", error: args[0] };
+}
+
+/**
+ * A `ts-pattern` pattern matching the `Defect` variant of a `Result`. With no
+ * argument it matches any `Defect`; pass a sub-pattern to constrain or select
+ * the unknown `cause`.
+ *
+ * @typeParam V - the sub-pattern matched against the `Defect` cause.
+ */
+export function defect(): { tag: "Defect" };
+export function defect<const V>(cause: V): { tag: "Defect"; cause: V };
+export function defect(...args: [] | [unknown]): { tag: "Defect"; cause?: unknown } {
+  return args.length === 0 ? { tag: "Defect" } : { tag: "Defect", cause: args[0] };
+}
+
+/**
+ * A `ts-pattern` pattern matching any value whose `_tag` equals `value` (e.g. a
+ * `TaggedError`). Equivalent to the object pattern `{ _tag: value }`, but reads
+ * better nested inside an {@link err} pattern and narrows to the matching
  * variant — including its payload.
  *
  * @typeParam Tag - the string literal tag to match.
@@ -61,7 +66,7 @@ export function toMatchable<T, E>(result: Result<T, E>): ResultMatchable<T, E> {
  *
  * @example
  * ```ts
- * .with({ _kind: "Err", error: tag("Forbidden") }, ({ error }) => error.user)
+ * .with(P.err(P.tag("Forbidden")), ({ error }) => error.user)
  * ```
  */
 export function tag<const Tag extends string>(value: Tag): { _tag: Tag } {


### PR DESCRIPTION
## What & why

`Result` is now a real **discriminated union** — `{ tag: "Ok"; value } | { tag: "Err"; error } | { tag: "Defect"; cause }`, each intersected with the shared method surface. So a `Result` matches **natively** with `ts-pattern` (and a plain `switch`), with working `.exhaustive()`, narrowing, and `P.select()` — no `toMatchable` adapter.

```ts
import { match } from "ts-pattern";
import * as P from "@unthrown/pattern";

match(result)
  .with(P.ok(), ({ value }) => 200)
  .with(P.err(P.tag("Forbidden")), ({ error }) => error.user) // narrowed payload
  .with(P.defect(), ({ cause }) => 500)
  .exhaustive();
```

This was prompted by wanting [boxed-style](https://boxed.cool/result#ts-pattern-interop) interop. `.exhaustive()` only works when the matched value is a real union (ts-pattern subtracts matched variants from the input), so the change had to happen in the core type, not just the pattern package.

## How it stays clean

- `Res` is now **fully internal** (never exported), bridged to the `Result` type only via three `okRes`/`errRes`/`defectRes` cast-builders; `_state` stays module-private, the public `tag` is a getter. `AsyncRes` operates on the public union (`r.tag`), not `_state`.
- **Check-before-access is preserved** — `result.value` only type-checks on the `Ok` arm.
- The defect is now a *visible* variant (`{ tag: "Defect" }`) but **still never appears in `E`** (Thesis #1 holds).
- `@unthrown/pattern` is now thin sugar (`P.ok`/`P.err`/`P.defect`/`P.tag`).

## Breaking changes

- `@unthrown/pattern`: `toMatchable` / `ResultMatchable` removed; replaced by `P.ok`/`P.err`/`P.defect`/`P.tag`.
- `Result` type shape changed (now exposes `tag`/`value`/`error`/`cause`). Nothing published yet, so no downstream impact.

## Verification

- **120 tests** across packages (incl. native-match + a real `.exhaustive()` `@ts-expect-error` check), core **100% line/function** coverage.
- Full gate green: `format` · `lint` · `typecheck` · `knip` · `test` · `build` (incl. the VitePress site) · typedoc warning-free.
- CLAUDE.md (Thesis #1, Public surface, Internal design), the guide (core-concepts, pattern-matching), and the `@unthrown/pattern` README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)