### PR TITLE
feat(vitest): toBeErrTagged can assert the tagged error's payload

### DIFF
--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -49,10 +49,14 @@ test("matchers", () => {
 ```
 
 `toBeErrTagged` takes an optional second argument to also assert the tagged
-error's payload (its own fields, minus `_tag`). A plain object matches it
-**exactly**; an asymmetric matcher matches it **partially**:
+error's payload — its own fields, minus the `_tag` and `name` that `TaggedError`
+sets. A plain object matches it **exactly**; an asymmetric matcher matches it
+**partially**:
 
 ```ts
+import { err, TaggedError } from "unthrown";
+import { expect } from "vitest";
+
 class NotFound extends TaggedError("NotFound")<{ id: number; msg: string }> {}
 
 // exact — every payload field must match

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -48,13 +48,34 @@ test("matchers", () => {
 });
 ```
 
-| Matcher              | Passes when                                          |
-| -------------------- | ---------------------------------------------------- |
-| `toBeOk()`           | the result is `Ok`                                   |
-| `toBeOkWith(value)`  | the result is `Ok` and the value deep-equals `value` |
-| `toBeErr()`          | the result is `Err`                                  |
-| `toBeErrTagged(tag)` | the result is `Err` whose error has `_tag === tag`   |
-| `toBeDefect()`       | the result is a `Defect`                             |
+`toBeErrTagged` takes an optional second argument to also assert the tagged
+error's payload (its own fields, minus `_tag`). A plain object matches it
+**exactly**; an asymmetric matcher matches it **partially**:
+
+```ts
+class NotFound extends TaggedError("NotFound")<{ id: number; msg: string }> {}
+
+// exact — every payload field must match
+expect(err(new NotFound({ id: 1, msg: "nope" }))).toBeErrTagged("NotFound", {
+  id: 1,
+  msg: "nope",
+});
+
+// partial — only the listed fields are checked
+expect(err(new NotFound({ id: 1, msg: "nope" }))).toBeErrTagged(
+  "NotFound",
+  expect.objectContaining({ id: 1 }),
+);
+```
+
+| Matcher                        | Passes when                                                                                       |
+| ------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `toBeOk()`                     | the result is `Ok`                                                                                |
+| `toBeOkWith(value)`            | the result is `Ok` and the value deep-equals `value`                                              |
+| `toBeErr()`                    | the result is `Err`                                                                               |
+| `toBeErrTagged(tag)`           | the result is `Err` whose error has `_tag === tag`                                                |
+| `toBeErrTagged(tag, expected)` | …and its payload matches `expected` (exact for a plain object, partial for an asymmetric matcher) |
+| `toBeDefect()`                 | the result is a `Defect`                                                                          |
 
 ## Async results — `await` is required
 

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -22,11 +22,19 @@ expect(ok(1)).toBeOkWith(1);
 expect(err(new NotFound())).toBeErrTagged("NotFound");
 expect(aDefect).toBeDefect();
 
+// toBeErrTagged also takes an optional payload: a plain object matches exactly,
+// an asymmetric matcher matches partially.
+expect(err(new NotFound({ id: 1 }))).toBeErrTagged("NotFound", { id: 1 });
+expect(err(new NotFound({ id: 1, msg: "x" }))).toBeErrTagged(
+  "NotFound",
+  expect.objectContaining({ id: 1 }),
+);
+
 // AsyncResult — `await` is required
 await expect(fromPromise(load(), qualify)).toBeOk();
 ```
 
-Matchers: `toBeOk`, `toBeOkWith`, `toBeErr`, `toBeErrTagged`, `toBeDefect`.
+Matchers: `toBeOk`, `toBeOkWith`, `toBeErr`, `toBeErrTagged(tag, expected?)`, `toBeDefect`.
 
 > [!WARNING]
 > For an `AsyncResult` the matcher is asynchronous — you **must** `await` the

--- a/packages/vitest/src/index.spec.ts
+++ b/packages/vitest/src/index.spec.ts
@@ -39,6 +39,29 @@ describe("toBeErr / toBeErrTagged", () => {
     expect(r).not.toBeErrTagged("Other");
     expect(err("plain")).not.toBeErrTagged("MyError");
   });
+
+  it("toBeErrTagged matches the payload exactly when given a plain object", () => {
+    const r: Result<number, MyError> = err(new MyError({ code: 42 }));
+    expect(r).toBeErrTagged("MyError", { code: 42 });
+    expect(r).not.toBeErrTagged("MyError", { code: 99 });
+    // exact: an extra/missing field fails
+    expect(r).not.toBeErrTagged("MyError", { code: 42, extra: true });
+  });
+
+  it("toBeErrTagged matches the payload partially with an asymmetric matcher", () => {
+    class Multi extends TaggedError("Multi")<{ id: number; msg: string }> {}
+    const r: Result<number, Multi> = err(new Multi({ id: 1, msg: "boom" }));
+    expect(r).toBeErrTagged("Multi", expect.objectContaining({ id: 1 }));
+    expect(r).toBeErrTagged("Multi", { id: 1, msg: "boom" });
+    expect(r).not.toBeErrTagged("Multi", expect.objectContaining({ id: 2 }));
+    // right tag, wrong payload → fails even though the tag matches
+    expect(r).not.toBeErrTagged("Other", expect.objectContaining({ id: 1 }));
+  });
+
+  it("toBeErrTagged with a payload still requires the right tag", () => {
+    const r: Result<number, MyError> = err(new MyError({ code: 42 }));
+    expect(r).not.toBeErrTagged("Other", { code: 42 });
+  });
 });
 
 describe("toBeDefect", () => {

--- a/packages/vitest/src/index.spec.ts
+++ b/packages/vitest/src/index.spec.ts
@@ -54,7 +54,7 @@ describe("toBeErr / toBeErrTagged", () => {
     expect(r).toBeErrTagged("Multi", expect.objectContaining({ id: 1 }));
     expect(r).toBeErrTagged("Multi", { id: 1, msg: "boom" });
     expect(r).not.toBeErrTagged("Multi", expect.objectContaining({ id: 2 }));
-    // right tag, wrong payload → fails even though the tag matches
+    // wrong tag → fails even when the payload sub-pattern would match
     expect(r).not.toBeErrTagged("Other", expect.objectContaining({ id: 1 }));
   });
 

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -37,6 +37,19 @@ function render(result: SomeResult, stringify: Stringify): string {
   return stringify(result);
 }
 
+// The "payload" of a TaggedError: its own enumerable properties minus the
+// `_tag` discriminant and the `name` (both set by TaggedError itself, not by
+// you). This is the data you passed to the constructor, so `toBeErrTagged`'s
+// optional second argument matches it: a plain object asserts it exactly, and an
+// asymmetric matcher (e.g. `expect.objectContaining(...)`) asserts it partially.
+function payloadOf(error: object): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(error)) {
+    if (key !== "_tag" && key !== "name") out[key] = (error as Record<string, unknown>)[key];
+  }
+  return out;
+}
+
 // Resolve `received` — awaiting it when it is an AsyncResult — then run `check`.
 // This is what lets one matcher serve both `expect(result)` and
 // `await expect(asyncResult)`. A non-Result fails with a clear message.
@@ -98,16 +111,28 @@ function toBeErr(this: MatcherState, received: unknown): MatcherResult {
   });
 }
 
-function toBeErrTagged(this: MatcherState, received: unknown, tag: string): MatcherResult {
+function toBeErrTagged(
+  this: MatcherState,
+  received: unknown,
+  tag: string,
+  expected?: unknown,
+): MatcherResult {
   const { stringify } = this.utils;
+  const { equals } = this;
+  const hasExpected = expected !== undefined;
+  const label = hasExpected
+    ? `Err tagged ${stringify(tag)} matching ${stringify(expected)}`
+    : `Err tagged ${stringify(tag)}`;
   return settle(received, stringify, (result) => {
-    const pass = isErr(result) && (result.error as { _tag?: unknown })?._tag === tag;
+    const error = isErr(result) ? result.error : undefined;
+    const tagPass = (error as { _tag?: unknown } | undefined)?._tag === tag;
+    const pass = tagPass && (!hasExpected || equals(payloadOf(error as object), expected));
     return {
       pass,
       message: () =>
         pass
-          ? `expected result not to be Err tagged ${stringify(tag)}`
-          : `expected result to be Err tagged ${stringify(tag)}, but got ${render(result, stringify)}`,
+          ? `expected result not to be ${label}`
+          : `expected result to be ${label}, but got ${render(result, stringify)}`,
     };
   });
 }
@@ -140,7 +165,13 @@ export type UnthrownMatchers<R = unknown> = {
   toBeOk: () => R;
   toBeOkWith: (value: unknown) => R;
   toBeErr: () => R;
-  toBeErrTagged: (tag: string) => R;
+  /**
+   * Assert an `Err` whose error has `_tag === tag`. Optionally pass `expected`
+   * to also match the error's payload (its own props minus `_tag`/`name`): a
+   * plain object matches exactly, an asymmetric matcher (e.g.
+   * `expect.objectContaining(...)`) matches partially.
+   */
+  toBeErrTagged: (tag: string, expected?: unknown) => R;
   toBeDefect: () => R;
 };
 


### PR DESCRIPTION
## What

`toBeErrTagged` gains an optional second argument to also assert the tagged error's **payload**:

```ts
// exact — a plain object must match every payload field
expect(err(new NotFound({ id: 1 }))).toBeErrTagged("NotFound", { id: 1 });

// partial — an asymmetric matcher checks only the listed fields
expect(err(new NotFound({ id: 1, msg: "x" }))).toBeErrTagged(
  "NotFound",
  expect.objectContaining({ id: 1 }),
);
```

## API & semantics

`toBeErrTagged(tag, expected?)`:

- **payload** = the error's own enumerable properties **minus** `_tag` and `name` (both set by `TaggedError` itself, not by you) — i.e. the data you passed to the constructor.
- `expected` is compared with Vitest's `equals()`, so the **exact vs partial** choice is driven by what you pass (consistent with `toBeOkWith`): a plain object → deep-exact; an asymmetric matcher (`expect.objectContaining`, `expect.any`, …) → partial.
- The **tag is still required** — a payload mismatch fails even when the tag matches, and a wrong tag fails even when the payload would match.
- Tag-only calls (`toBeErrTagged("NotFound")`) are unchanged.

This is independent of the native-pattern-matching work (#1) — it only touches `@unthrown/vitest` and its docs, so it can land on its own.

## Verification

- New tests for exact match, partial match (`objectContaining`), wrong payload, and "right payload but wrong tag".
- Full gate green: format · lint · typecheck · test (all packages) · build · knip; typedoc warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)