### PR TITLE
docs: sync to shipped APIs + fix format pre-commit hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,15 +158,19 @@ Never pull `ts-pattern` or `vitest` into core.
    a zero-dependency exhaustive fold whose handler object is
    `{ Ok, Defect } & { [K in E["_tag"]]: (e: Extract<E, {_tag: K}>) => R }`.
 3. ✅ **`packages/vitest`** — Done. Custom matchers `toBeOk`, `toBeOkWith`,
-   `toBeErr`, `toBeErrTagged`, `toBeDefect`, registered via `expect.extend` and
-   augmenting Vitest's `Matchers` interface. They detect a thenable `AsyncResult`
-   and await internally, so a test reads `await expect(asyncResult).toBeOk()`
-   (the required `await` is documented loudly — a forgotten one passes silently).
-4. ✅ **`packages/pattern`** — Done. Thin `ts-pattern` integration: `tag(t)`
-   sugar (the `{ _tag: t }` pattern, narrowing to the variant + payload) and
-   `toMatchable(result)` exposing the ok/err/defect channels as a `_kind`
-   discriminated union. Kept small — the power is ts-pattern's; `matchTags`
-   covers the everyday exhaustive case.
+   `toBeErr`, `toBeErrTagged` (optional second arg also matches the tagged
+   error's payload — exact for a plain object, partial for an asymmetric matcher
+   like `expect.objectContaining`), `toBeDefect`, registered via `expect.extend`
+   and augmenting Vitest's `Matchers` interface. They detect a thenable
+   `AsyncResult` and await internally, so a test reads
+   `await expect(asyncResult).toBeOk()` (the required `await` is documented loudly
+   — a forgotten one passes silently).
+4. ✅ **`packages/pattern`** — Done. Because `Result` is a discriminated union
+   (Thesis #1 / Public surface), `ts-pattern` matches it natively — this package
+   is thin sugar: pattern constructors `P.ok`/`P.err`/`P.defect` (returning the
+   `{ tag: … }` object patterns) plus `tag(t)` (the `{ _tag: t }` pattern,
+   narrowing to the variant + payload). Kept small — the power is ts-pattern's;
+   `matchTags` covers the everyday exhaustive case.
 
 Also shipped: a root `README` + `LICENSE`, per-package READMEs, and the VitePress
 docs site (guide + generated API reference). **Remaining work is manual** and

--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ defect, so the edge of your program needs a single `match` and no `try`/`catch`.
 
 ## Packages
 
-| Package                                   | Description                                                                                |
-| ----------------------------------------- | ------------------------------------------------------------------------------------------ |
-| [`unthrown`](./packages/core)             | The core `Result` / `AsyncResult`, interop, `TaggedError`, `matchTags`. Zero runtime deps. |
-| [`@unthrown/vitest`](./packages/vitest)   | Vitest matchers: `toBeOk`, `toBeOkWith`, `toBeErr`, `toBeErrTagged`, `toBeDefect`.         |
-| [`@unthrown/pattern`](./packages/pattern) | Thin `ts-pattern` integration: `toMatchable`, `tag`.                                       |
+| Package                                   | Description                                                                                    |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| [`unthrown`](./packages/core)             | The core `Result` / `AsyncResult`, interop, `TaggedError`, `matchTags`. Zero runtime deps.     |
+| [`@unthrown/vitest`](./packages/vitest)   | Vitest matchers: `toBeOk`, `toBeOkWith`, `toBeErr`, `toBeErrTagged`, `toBeDefect`.             |
+| [`@unthrown/pattern`](./packages/pattern) | Thin `ts-pattern` sugar for the natively-matchable `Result`: `P.ok`/`P.err`/`P.defect`, `tag`. |
 
 ## Contributing
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -12,5 +12,5 @@ This reference is generated from the source with
   `matchTags`).
 - [**@unthrown/vitest**](./vitest/) — custom Vitest matchers (`toBeOk`,
   `toBeOkWith`, `toBeErr`, `toBeErrTagged`, `toBeDefect`).
-- [**@unthrown/pattern**](./pattern/) — the thin `ts-pattern` integration
-  (`toMatchable`, `tag`).
+- [**@unthrown/pattern**](./pattern/) — thin `ts-pattern` sugar for the
+  natively-matchable `Result` (`P.ok`/`P.err`/`P.defect`, `tag`).

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -10,7 +10,11 @@ pre-commit:
       # Mirror oxfmt's `ignorePatterns` (generated docs/api + vitepress output):
       # handing oxfmt ONLY ignored files makes it exit non-zero, which would fail
       # a commit touching only those. Excluding them here skips the step instead.
-      exclude: "{pnpm-lock.yaml,docs/api/*,docs/.vitepress/cache/*,docs/.vitepress/dist/*}"
+      exclude:
+        - "pnpm-lock.yaml"
+        - "docs/api/*"
+        - "docs/.vitepress/cache/*"
+        - "docs/.vitepress/dist/*"
       run: pnpm oxfmt {staged_files}
       stage_fixed: true
     lint:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,12 +2,19 @@ pre-commit:
   parallel: true
   commands:
     format:
-      glob: "**/*.{ts,tsx,js,jsx,json,yaml,yml,md}"
-      exclude: "pnpm-lock.yaml"
+      # `*.x` (not `**/*.x`): lefthook's `*` spans `/`, so this matches files at
+      # ANY depth including the repo root. `**/*.x` requires a leading directory,
+      # so root files (`CLAUDE.md`, `README.md`, root `*.json`) silently never
+      # matched and were never formatted on commit.
+      glob: "*.{ts,tsx,js,jsx,json,yaml,yml,md}"
+      # Mirror oxfmt's `ignorePatterns` (generated docs/api + vitepress output):
+      # handing oxfmt ONLY ignored files makes it exit non-zero, which would fail
+      # a commit touching only those. Excluding them here skips the step instead.
+      exclude: "{pnpm-lock.yaml,docs/api/*,docs/.vitepress/cache/*,docs/.vitepress/dist/*}"
       run: pnpm oxfmt {staged_files}
       stage_fixed: true
     lint:
-      glob: "**/*.{ts,tsx,js,jsx}"
+      glob: "*.{ts,tsx,js,jsx}"
       run: pnpm oxlint {staged_files}
 
 commit-msg:


### PR DESCRIPTION
Follow-up housekeeping after #1 and #2 merged.

## 1. Sync docs to the shipped APIs

Three places still described the **removed** `@unthrown/pattern` `toMatchable`/`_kind` adapter:

- `CLAUDE.md` — Status item 4 (the authoritative spec)
- `README.md` — packages table
- `docs/api/index.md` — API index

Now they describe what shipped: native `ts-pattern` matching with `P.ok`/`P.err`/`P.defect` + `tag`, and `toBeErrTagged`'s new optional payload argument (Status item 3). `grep` confirms no `toMatchable`/`_kind` references remain.

## 2. Fix a latent pre-commit `format` hook bug

Found while committing the above. The hook's glob was `**/*.{…}`, but lefthook's `*` already spans `/`, and `**/*.x` **requires a leading directory** — so root files (`CLAUDE.md`, `README.md`, root `*.json`) silently never matched and were **never formatted on commit**. Worse, the only root-level docs change that *did* reach `oxfmt` was the generated `docs/api/index.md`, which `oxfmt` ignores — and `oxfmt` exits non-zero when handed only-ignored files, so the commit failed outright.

Fix:
- Glob → `*.{…}` (matches any depth incl. the repo root) for both `format` and `lint`.
- `exclude` now mirrors `oxfmt`'s `ignorePatterns` (generated `docs/api`, vitepress output), so a commit touching only those **skips** the step (like `lint` does) instead of failing.

Verified by dry-running the hook on two scenarios: a mixed root+`docs/api` change (formats the root files, exit 0) and a `docs/api`-only change (skips, exit 0).

Doc + tooling only; `format --check` · `lint` · `build` (incl. the VitePress site) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)