### PR TITLE
chore: migrate repo + docs URLs to btravstack org

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@
 > Explicit errors as values for TypeScript — with a separate defect channel for
 > the unexpected, and qualification enforced at every boundary.
 
-[![CI](https://github.com/btravers/unthrown/actions/workflows/ci.yml/badge.svg)](https://github.com/btravers/unthrown/actions/workflows/ci.yml)
+[![CI](https://github.com/btravstack/unthrown/actions/workflows/ci.yml/badge.svg)](https://github.com/btravstack/unthrown/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/unthrown.svg)](https://www.npmjs.com/package/unthrown)
 [![license](https://img.shields.io/npm/l/unthrown.svg)](./LICENSE)
 
 Ordinary errors are _unthrown_ — returned as values, not flung up the stack.
 Only a true defect ever throws, and only at `unwrap`.
 
-📖 **[Documentation](https://btravers.github.io/unthrown/)** ·
-[Why unthrown?](https://btravers.github.io/unthrown/guide/why-unthrown) ·
-[Getting Started](https://btravers.github.io/unthrown/guide/getting-started)
+📖 **[Documentation](https://btravstack.github.io/unthrown/)** ·
+[Why unthrown?](https://btravstack.github.io/unthrown/guide/why-unthrown) ·
+[Getting Started](https://btravstack.github.io/unthrown/guide/getting-started)
 
 ## Why?
 
@@ -38,7 +38,7 @@ defect that short-circuits to the edge, where you log it and return a 500.
 - **Small and done-able.** Zero runtime dependencies, ESM-first, dual CJS/ESM,
   fully typed.
 
-See [Why unthrown?](https://btravers.github.io/unthrown/guide/why-unthrown) for
+See [Why unthrown?](https://btravstack.github.io/unthrown/guide/why-unthrown) for
 the comparison with `neverthrow`, `boxed`, and `effect`.
 
 ## Install

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
   ignoreDeadLinks: [/^\/api\//, /^\.\/index$/, /^\.\/[a-z-]+$/, /^\.\.\//],
 
   sitemap: {
-    hostname: "https://btravers.github.io/unthrown/",
+    hostname: "https://btravstack.github.io/unthrown/",
   },
 
   themeConfig: {
@@ -27,7 +27,7 @@ export default defineConfig({
       { text: "API", link: "/api/" },
       {
         text: "Changelog",
-        link: "https://github.com/btravers/unthrown/releases",
+        link: "https://github.com/btravstack/unthrown/releases",
       },
     ],
 
@@ -75,7 +75,7 @@ export default defineConfig({
     },
 
     socialLinks: [
-      { icon: "github", link: "https://github.com/btravers/unthrown" },
+      { icon: "github", link: "https://github.com/btravstack/unthrown" },
       { icon: "npm", link: "https://www.npmjs.com/package/unthrown" },
     ],
 
@@ -89,7 +89,7 @@ export default defineConfig({
     },
 
     editLink: {
-      pattern: "https://github.com/btravers/unthrown/edit/main/docs/:path",
+      pattern: "https://github.com/btravstack/unthrown/edit/main/docs/:path",
       text: "Edit this page on GitHub",
     },
   },
@@ -110,8 +110,8 @@ export default defineConfig({
     ["meta", { property: "og:site_name", content: "unthrown" }],
     ["meta", { property: "og:title", content: "unthrown" }],
     ["meta", { property: "og:description", content: SITE_DESCRIPTION }],
-    ["meta", { property: "og:image", content: "https://btravers.github.io/unthrown/logo.svg" }],
+    ["meta", { property: "og:image", content: "https://btravstack.github.io/unthrown/logo.svg" }],
     ["meta", { name: "twitter:card", content: "summary" }],
-    ["meta", { name: "twitter:image", content: "https://btravers.github.io/unthrown/logo.svg" }],
+    ["meta", { name: "twitter:image", content: "https://btravstack.github.io/unthrown/logo.svg" }],
   ],
 });

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ hero:
       link: /guide/why-unthrown
     - theme: alt
       text: GitHub
-      link: https://github.com/btravers/unthrown
+      link: https://github.com/btravstack/unthrown
 
 features:
   - icon: 🎯

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3,8 +3,8 @@
 > Explicit errors as values for TypeScript — with a separate defect channel for
 > the unexpected, and qualification enforced at every boundary.
 
-📖 **[Documentation](https://btravers.github.io/unthrown/)** ·
-[API Reference](https://btravers.github.io/unthrown/api/core/)
+📖 **[Documentation](https://btravstack.github.io/unthrown/)** ·
+[API Reference](https://btravstack.github.io/unthrown/api/core/)
 
 ```sh
 pnpm add unthrown
@@ -32,7 +32,7 @@ const status = await user.match({
 - **Tagged errors** — `TaggedError(tag)` + the exhaustive `matchTags` fold.
 - Zero runtime dependencies, ESM-first, dual CJS/ESM.
 
-See the [full documentation](https://btravers.github.io/unthrown/) for the guide
+See the [full documentation](https://btravstack.github.io/unthrown/) for the guide
 and complete API.
 
 ## License

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,15 +13,15 @@
     "type-safe",
     "typescript"
   ],
-  "homepage": "https://github.com/btravers/unthrown#readme",
+  "homepage": "https://github.com/btravstack/unthrown#readme",
   "bugs": {
-    "url": "https://github.com/btravers/unthrown/issues"
+    "url": "https://github.com/btravstack/unthrown/issues"
   },
   "license": "MIT",
   "author": "Benoit TRAVERS <benoit.travers.fr@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/btravers/unthrown.git",
+    "url": "https://github.com/btravstack/unthrown.git",
     "directory": "packages/core"
   },
   "files": [

--- a/packages/pattern/README.md
+++ b/packages/pattern/README.md
@@ -1,10 +1,10 @@
 # @unthrown/pattern
 
 > Thin [ts-pattern](https://github.com/gvergnaud/ts-pattern) integration for
-> [unthrown](https://github.com/btravers/unthrown)'s `Result`.
+> [unthrown](https://github.com/btravstack/unthrown)'s `Result`.
 
-📖 **[Documentation](https://btravers.github.io/unthrown/guide/pattern-matching)** ·
-[API Reference](https://btravers.github.io/unthrown/api/pattern/)
+📖 **[Documentation](https://btravstack.github.io/unthrown/guide/pattern-matching)** ·
+[API Reference](https://btravstack.github.io/unthrown/api/pattern/)
 
 ```sh
 pnpm add @unthrown/pattern ts-pattern

--- a/packages/pattern/package.json
+++ b/packages/pattern/package.json
@@ -10,15 +10,15 @@
     "typescript",
     "unthrown"
   ],
-  "homepage": "https://github.com/btravers/unthrown#readme",
+  "homepage": "https://github.com/btravstack/unthrown#readme",
   "bugs": {
-    "url": "https://github.com/btravers/unthrown/issues"
+    "url": "https://github.com/btravstack/unthrown/issues"
   },
   "license": "MIT",
   "author": "Benoit TRAVERS <benoit.travers.fr@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/btravers/unthrown.git",
+    "url": "https://github.com/btravstack/unthrown.git",
     "directory": "packages/pattern"
   },
   "files": [

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -1,10 +1,10 @@
 # @unthrown/vitest
 
-> [Vitest](https://vitest.dev) matchers for [unthrown](https://github.com/btravers/unthrown)'s
+> [Vitest](https://vitest.dev) matchers for [unthrown](https://github.com/btravstack/unthrown)'s
 > `Result` and `AsyncResult`.
 
-📖 **[Documentation](https://btravers.github.io/unthrown/guide/testing)** ·
-[API Reference](https://btravers.github.io/unthrown/api/vitest/)
+📖 **[Documentation](https://btravstack.github.io/unthrown/guide/testing)** ·
+[API Reference](https://btravstack.github.io/unthrown/api/vitest/)
 
 ```sh
 pnpm add -D @unthrown/vitest

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -11,15 +11,15 @@
     "unthrown",
     "vitest"
   ],
-  "homepage": "https://github.com/btravers/unthrown#readme",
+  "homepage": "https://github.com/btravstack/unthrown#readme",
   "bugs": {
-    "url": "https://github.com/btravers/unthrown/issues"
+    "url": "https://github.com/btravstack/unthrown/issues"
   },
   "license": "MIT",
   "author": "Benoit TRAVERS <benoit.travers.fr@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/btravers/unthrown.git",
+    "url": "https://github.com/btravstack/unthrown.git",
     "directory": "packages/vitest"
   },
   "files": [


### PR DESCRIPTION
## Summary

The project moved from the `btravers` profile to the `btravstack` organization. The new docs site is https://btravstack.github.io/unthrown/.

This updates every reference across the repo:

- **Doc site URL** (`btravers.github.io` → `btravstack.github.io`): VitePress sitemap `hostname`, og:image/twitter:image meta tags, and all README documentation links.
- **Repo URL** (`github.com/btravers/unthrown` → `github.com/btravstack/unthrown`): CI badge, releases link, GitHub social icon, "edit this page" link, hero link, and `homepage`/`bugs.url`/`repository.url` in all three package.json files (these surface on npm package pages).

## Out of scope (manual, on GitHub/npm)

- Enable GitHub Pages in the new repo for `deploy-docs.yml`.
- Recreate the `RELEASE_PAT` secret in the new repo.
- Update npm Trusted Publishers config (references the GitHub repo owner) before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)