### PR TITLE
feat: add Effect, neverthrow, and Boxed interop packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,16 @@
   "$schema": "https://unpkg.com/@changesets/config@3.0.3/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [["unthrown", "@unthrown/pattern", "@unthrown/vitest"]],
+  "fixed": [
+    [
+      "unthrown",
+      "@unthrown/pattern",
+      "@unthrown/vitest",
+      "@unthrown/effect",
+      "@unthrown/neverthrow",
+      "@unthrown/boxed"
+    ]
+  ],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/.changeset/interop-packages.md
+++ b/.changeset/interop-packages.md
@@ -1,0 +1,20 @@
+---
+"@unthrown/effect": minor
+"@unthrown/neverthrow": minor
+"@unthrown/boxed": minor
+---
+
+Add three interop packages bridging `Result`/`AsyncResult` with neighbouring
+errors-as-values libraries:
+
+- **`@unthrown/effect`** — `toExit`/`fromExit` (a bijection, since Effect's
+  `Cause` has a defect channel), `toEither`/`fromEither`, and
+  `toEffect`/`fromEffect` (including `AsyncResult ↔ Effect`).
+- **`@unthrown/neverthrow`** — `toNeverthrow`/`fromNeverthrow` and the async
+  `toNeverthrowAsync`/`fromNeverthrowAsync`.
+- **`@unthrown/boxed`** — `toBoxed`/`fromBoxed` and `toBoxedFuture`/
+  `fromBoxedFuture` (peer-dep on Boxed's maintained `@bloodyowl/boxed` scope).
+
+Converting a `Result` into a two-channel type (neverthrow, Boxed, or Effect's
+`Either`) requires a mandatory `onDefect` handler — a `Defect` is never silently
+folded into the domain error type.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,12 +138,36 @@ enough that the library can be "done".
 - `packages/core` → `unthrown` (zero runtime dependencies)
 - `packages/pattern` → `@unthrown/pattern` (peerDep `ts-pattern`)
 - `packages/vitest` → `@unthrown/vitest` (peerDep `vitest`)
+- `packages/effect` → `@unthrown/effect` (peerDep `effect`)
+- `packages/neverthrow` → `@unthrown/neverthrow` (peerDep `neverthrow`)
+- `packages/boxed` → `@unthrown/boxed` (peerDep `@bloodyowl/boxed` — Boxed's
+  maintained scope; `@swan-io/boxed` is the deprecated former name)
 - `tools/tsconfig`, `tools/typedoc` → private shared config (`@unthrown/tsconfig`,
   `@unthrown/typedoc`)
 - `docs` → `@unthrown/docs`, the VitePress site (guide + TypeDoc-generated API
   reference); deployed to GitHub Pages by `deploy-docs.yml`
 
-Never pull `ts-pattern` or `vitest` into core.
+Never pull `ts-pattern`, `vitest`, or any interop peer (`effect`, `neverthrow`,
+`@bloodyowl/boxed`) into core.
+
+### Interop packages (`packages/effect`, `packages/neverthrow`, `packages/boxed`)
+
+Thin `to*`/`from*` bridges between `Result`/`AsyncResult` and a neighbour's
+types. One rule decides their shape: **does the neighbour have a defect
+channel?**
+
+- **Effect does** (`Cause.die`), so `Result ↔ Exit` is a genuine **bijection**
+  (`Ok↔succeed`, `Err↔Cause.fail`, `Defect↔Cause.die`). `fromExit` lets a
+  `Defect` **dominate** a modeled failure in a composite cause (same rule as
+  `all`). `toEither` has no defect target, so it takes a mandatory `onDefect`.
+- **neverthrow and Boxed do not.** Coming _in_, results are only `Ok`/`Err` —
+  never a `Defect`. Going _out_, every `to*` takes a **mandatory `onDefect:
+(cause) => E`** (forced triage, Thesis #3): a defect is never silently folded
+  into `E`. There is no one-arg form.
+- A `Defect` `Result` has no public constructor (defects arise at boundaries).
+  The only place one is minted is `@unthrown/effect`'s `fromExit`, which replays
+  Effect's `die` cause through the `fromThrowable` boundary — itself a genuine
+  un-triaged-failure boundary.
 
 ## Status (all four roadmap items shipped)
 

--- a/README.md
+++ b/README.md
@@ -75,11 +75,14 @@ defect, so the edge of your program needs a single `match` and no `try`/`catch`.
 
 ## Packages
 
-| Package                                   | Description                                                                                    |
-| ----------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| [`unthrown`](./packages/core)             | The core `Result` / `AsyncResult`, interop, `TaggedError`, `matchTags`. Zero runtime deps.     |
-| [`@unthrown/vitest`](./packages/vitest)   | Vitest matchers: `toBeOk`, `toBeOkWith`, `toBeErr`, `toBeErrTagged`, `toBeDefect`.             |
-| [`@unthrown/pattern`](./packages/pattern) | Thin `ts-pattern` sugar for the natively-matchable `Result`: `P.ok`/`P.err`/`P.defect`, `tag`. |
+| Package                                         | Description                                                                                    |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| [`unthrown`](./packages/core)                   | The core `Result` / `AsyncResult`, interop, `TaggedError`, `matchTags`. Zero runtime deps.     |
+| [`@unthrown/vitest`](./packages/vitest)         | Vitest matchers: `toBeOk`, `toBeOkWith`, `toBeErr`, `toBeErrTagged`, `toBeDefect`.             |
+| [`@unthrown/pattern`](./packages/pattern)       | Thin `ts-pattern` sugar for the natively-matchable `Result`: `P.ok`/`P.err`/`P.defect`, `tag`. |
+| [`@unthrown/effect`](./packages/effect)         | Effect interop: `Result ↔ Exit` (bijection), `Either`, `Effect`.                               |
+| [`@unthrown/neverthrow`](./packages/neverthrow) | neverthrow interop: `Result ↔ Result`, `AsyncResult ↔ ResultAsync`.                            |
+| [`@unthrown/boxed`](./packages/boxed)           | Boxed interop: `Result ↔ Result`, `AsyncResult ↔ Future<Result>`.                              |
 
 ## Contributing
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -58,6 +58,7 @@ export default defineConfig({
           items: [
             { text: "Testing", link: "/guide/testing" },
             { text: "Pattern Matching", link: "/guide/pattern-matching" },
+            { text: "Interop", link: "/guide/interop" },
           ],
         },
       ],
@@ -69,6 +70,9 @@ export default defineConfig({
             { text: "unthrown", link: "/api/core/" },
             { text: "@unthrown/vitest", link: "/api/vitest/" },
             { text: "@unthrown/pattern", link: "/api/pattern/" },
+            { text: "@unthrown/effect", link: "/api/effect/" },
+            { text: "@unthrown/neverthrow", link: "/api/neverthrow/" },
+            { text: "@unthrown/boxed", link: "/api/boxed/" },
           ],
         },
       ],

--- a/docs/guide/interop.md
+++ b/docs/guide/interop.md
@@ -1,0 +1,68 @@
+# Interop
+
+unthrown ships thin bridges to the three most common neighbours in the
+errors-as-values space. Each is a separate, peer-dependency package with a small
+`to*` / `from*` surface — nothing to learn beyond "which direction am I going."
+
+| Package                                    | Peer dependency    | Bridges                    |
+| ------------------------------------------ | ------------------ | -------------------------- |
+| [`@unthrown/effect`](/api/effect/)         | `effect`           | `Exit`, `Either`, `Effect` |
+| [`@unthrown/neverthrow`](/api/neverthrow/) | `neverthrow`       | `Result`, `ResultAsync`    |
+| [`@unthrown/boxed`](/api/boxed/)           | `@bloodyowl/boxed` | `Result`, `Future<Result>` |
+
+## The one rule: does the neighbour have a defect channel?
+
+unthrown has **three** channels — `Ok`, `Err`, and the out-of-band `Defect`. Most
+libraries have only two. That single difference decides every signature.
+
+- **Coming _in_** (`from*`), a two-channel result is only ever an `Ok` or an
+  `Err` — the bridge **never** produces a `Defect`.
+- **Going _out_** (`to*`) to a two-channel type, a `Defect` has nowhere to live.
+  Rather than silently fold it into your domain error, the bridge **forces** you
+  to triage it with a mandatory `onDefect: (cause) => E` — the same
+  boundary-qualification rule unthrown enforces everywhere. There is no one-arg
+  form.
+
+```ts
+import { ok } from "unthrown";
+import { toNeverthrow } from "@unthrown/neverthrow";
+
+// onDefect is required — the compiler will not let you drop a defect.
+toNeverthrow(ok(1), (cause) => ({ _tag: "Bug", cause }));
+```
+
+## Effect — a genuine bijection
+
+Effect is the exception: it _does_ have a defect channel (`Cause.die`), so
+`Result ↔ Exit` round-trips losslessly.
+
+```ts
+import { ok, err } from "unthrown";
+import { toExit, fromEffect } from "@unthrown/effect";
+import { Effect } from "effect";
+
+toExit(ok(1)); // Exit.succeed(1)
+toExit(err("e")); // Exit.fail("e")  — a modeled Cause.fail
+// a Defect would become Exit.die(cause)
+
+// Run an Effect and collect its outcome; a die/interrupt becomes a Defect:
+await fromEffect(Effect.succeed(1)).match({ ok, err, defect: String });
+```
+
+`toEffect` also accepts an `AsyncResult` (the `AsyncResult → Effect` direction),
+and `toEither` — since `Either` has no defect channel — takes the same mandatory
+`onDefect`.
+
+## Async
+
+Every package mirrors its sync pair for the asynchronous types:
+
+- `@unthrown/effect` — `fromEffect` returns an `AsyncResult`; `toEffect` accepts
+  one.
+- `@unthrown/neverthrow` — `toNeverthrowAsync` / `fromNeverthrowAsync` bridge
+  `AsyncResult ↔ ResultAsync`.
+- `@unthrown/boxed` — `toBoxedFuture` / `fromBoxedFuture` bridge `AsyncResult ↔
+Future<Result>`.
+
+On the way in, an _unexpected_ rejection inside the neighbour's async type
+becomes a `Defect` — never a silently-swallowed error.

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,6 +11,9 @@
     "preview": "vitepress preview ."
   },
   "dependencies": {
+    "@unthrown/boxed": "workspace:*",
+    "@unthrown/effect": "workspace:*",
+    "@unthrown/neverthrow": "workspace:*",
     "@unthrown/pattern": "workspace:*",
     "@unthrown/vitest": "workspace:*",
     "unthrown": "workspace:*"

--- a/docs/scripts/copy-docs.ts
+++ b/docs/scripts/copy-docs.ts
@@ -7,6 +7,9 @@
 import "unthrown";
 import "@unthrown/pattern";
 import "@unthrown/vitest";
+import "@unthrown/effect";
+import "@unthrown/neverthrow";
+import "@unthrown/boxed";
 
 import { cp, mkdir, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
@@ -20,6 +23,9 @@ const packages: ReadonlyArray<{ readonly pkg: string; readonly out: string }> = 
   { pkg: "unthrown", out: "core" },
   { pkg: "@unthrown/vitest", out: "vitest" },
   { pkg: "@unthrown/pattern", out: "pattern" },
+  { pkg: "@unthrown/effect", out: "effect" },
+  { pkg: "@unthrown/neverthrow", out: "neverthrow" },
+  { pkg: "@unthrown/boxed", out: "boxed" },
 ];
 
 await mkdir(apiDir, { recursive: true });

--- a/packages/boxed/README.md
+++ b/packages/boxed/README.md
@@ -1,0 +1,40 @@
+# @unthrown/boxed
+
+> [Boxed](https://boxed.cool) interop for
+> [unthrown](https://github.com/btravstack/unthrown)'s `Result`.
+
+📖 **[Documentation](https://btravstack.github.io/unthrown/guide/interop)** ·
+[API Reference](https://btravstack.github.io/unthrown/api/boxed/)
+
+```sh
+pnpm add @unthrown/boxed @bloodyowl/boxed
+```
+
+Boxed's `Result` has two channels (`Ok`/`Error`) and no defect channel. Coming
+**in**, every Boxed result is an `Ok` or `Error` — never a `Defect`. Going
+**out**, a `Defect` has nowhere to live, so `toBoxed` **forces** you to triage it
+with `onDefect` — no defect is ever silently folded into your domain error type.
+
+```ts
+import { ok } from "unthrown";
+import { toBoxed, fromBoxed } from "@unthrown/boxed";
+import { Result } from "@bloodyowl/boxed";
+
+toBoxed(ok(1), (cause) => ({ _tag: "Bug", cause })); // Result.Ok(1)
+fromBoxed(Result.Ok(1)); // Result<number, never>
+```
+
+- `toBoxed(r, onDefect)` / `fromBoxed(r)` — sync `Result ↔ Result`.
+- `toBoxedFuture(ar, onDefect)` / `fromBoxedFuture(future)` — async
+  `AsyncResult ↔ Future<Result>`.
+
+> Boxed's `Option` has no analogue here — per unthrown's design, absence is
+> expressed with `T | undefined` or `Result<T, NotFound>` (see `fromNullable`),
+> not a dedicated `Option` type.
+
+`@bloodyowl/boxed` is a peer dependency. (Boxed was formerly published as
+`@swan-io/boxed`, now deprecated in favour of this maintained scope.)
+
+## License
+
+[MIT](../../LICENSE) © Benoit TRAVERS

--- a/packages/boxed/package.json
+++ b/packages/boxed/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@unthrown/boxed",
+  "version": "0.1.0",
+  "description": "Boxed interop for unthrown",
+  "keywords": [
+    "boxed",
+    "errors-as-values",
+    "future",
+    "result",
+    "swan-io",
+    "typescript",
+    "unthrown"
+  ],
+  "homepage": "https://github.com/btravstack/unthrown#readme",
+  "bugs": {
+    "url": "https://github.com/btravstack/unthrown/issues"
+  },
+  "license": "MIT",
+  "author": "Benoit TRAVERS <benoit.travers.fr@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/btravstack/unthrown.git",
+    "directory": "packages/boxed"
+  },
+  "files": [
+    "dist",
+    "docs"
+  ],
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsdown src/index.ts --format cjs,esm --dts --clean",
+    "build:docs": "typedoc",
+    "dev": "tsdown src/index.ts --format cjs,esm --dts --watch",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "unthrown": "workspace:*"
+  },
+  "devDependencies": {
+    "@bloodyowl/boxed": "catalog:",
+    "@types/node": "catalog:",
+    "@unthrown/tsconfig": "workspace:*",
+    "@unthrown/typedoc": "workspace:*",
+    "@vitest/coverage-v8": "catalog:",
+    "tsdown": "catalog:",
+    "typedoc": "catalog:",
+    "typedoc-plugin-markdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "@bloodyowl/boxed": "^3"
+  },
+  "engines": {
+    "node": ">=22.19"
+  }
+}

--- a/packages/boxed/src/index.spec.ts
+++ b/packages/boxed/src/index.spec.ts
@@ -1,0 +1,55 @@
+import { Future, Result as BoxedResult } from "@bloodyowl/boxed";
+import { err, ok, type Result } from "unthrown";
+import { describe, expect, it } from "vitest";
+
+import { fromBoxed, fromBoxedFuture, toBoxed, toBoxedFuture } from "./index.js";
+
+const boom = new Error("boom");
+const aDefect: Result<number, string> = ok(0).map<number>(() => {
+  throw boom;
+});
+
+describe("toBoxed", () => {
+  it("maps Ok and Err across", () => {
+    const okR = toBoxed(ok(1), () => "x");
+    expect(okR.isOk() && okR.get()).toBe(1);
+    const errR = toBoxed(err("nope") as Result<number, string>, () => "x");
+    expect(errR.isError() && errR.getError()).toBe("nope");
+  });
+
+  it("forces a defect to be triaged into the error channel", () => {
+    const r = toBoxed(aDefect, (cause) => `bug:${String(cause)}`);
+    expect(r.isError() && r.getError()).toBe(`bug:${String(boom)}`);
+  });
+});
+
+describe("fromBoxed", () => {
+  it("maps Result.Ok to Ok and Result.Error to Err — never a Defect", () => {
+    expect(fromBoxed(BoxedResult.Ok(1))).toMatchObject({ tag: "Ok", value: 1 });
+    expect(fromBoxed(BoxedResult.Error("nope"))).toMatchObject({ tag: "Err", error: "nope" });
+  });
+});
+
+describe("toBoxedFuture", () => {
+  it("maps Ok across and triages a defect", async () => {
+    const okR = await toBoxedFuture(ok(1).toAsync(), () => "x").toPromise();
+    expect(okR.isOk() && okR.get()).toBe(1);
+    const defR = await toBoxedFuture(
+      aDefect.toAsync(),
+      (cause) => `bug:${String(cause)}`,
+    ).toPromise();
+    expect(defR.isError() && defR.getError()).toBe(`bug:${String(boom)}`);
+  });
+});
+
+describe("fromBoxedFuture", () => {
+  it("maps a Future of Ok/Error to Ok/Err", async () => {
+    expect(await fromBoxedFuture(Future.value(BoxedResult.Ok<number, string>(1)))).toMatchObject({
+      tag: "Ok",
+      value: 1,
+    });
+    expect(
+      await fromBoxedFuture(Future.value(BoxedResult.Error<number, string>("nope"))),
+    ).toMatchObject({ tag: "Err", error: "nope" });
+  });
+});

--- a/packages/boxed/src/index.ts
+++ b/packages/boxed/src/index.ts
@@ -1,0 +1,105 @@
+// @unthrown/boxed — interop between unthrown's `Result`/`AsyncResult` and
+// Boxed's `Result`/`Future<Result>`.
+//
+// Boxed's `Result` has two channels (`Ok`/`Error`) and no defect channel.
+// Coming *in*, every Boxed result is an `Ok` or `Error` — never a `Defect`.
+// Going *out*, a `Defect` has nowhere to live, so `toBoxed` forces you to triage
+// it with `onDefect` (Thesis #3): no defect is ever silently folded into your
+// domain error type.
+//
+//   import { ok } from "unthrown";
+//   import { toBoxed, fromBoxed } from "@unthrown/boxed";
+//
+//   toBoxed(ok(1), (cause) => ({ _tag: "Bug", cause })); // Result.Ok(1)
+//   fromBoxed(Result.Ok(1));                              // Result<number, never>
+
+import { Future, Result as BoxedResult } from "@bloodyowl/boxed";
+import { err, fromSafePromise, ok } from "unthrown";
+import type { AsyncResult, Result } from "unthrown";
+
+/**
+ * Convert a `Result` into a Boxed `Result`, triaging any defect.
+ *
+ * @remarks
+ * Boxed's `Result` has no defect channel, so `onDefect` **must** fold a
+ * `Defect`'s cause into a modeled error `E` (an `Error`). `Ok → Result.Ok`,
+ * `Err → Result.Error`, `Defect → Result.Error(onDefect(cause))`.
+ *
+ * @typeParam T - the success value type.
+ * @typeParam E - the modeled error type.
+ * @param result - the result to convert.
+ * @param onDefect - folds a defect's unknown cause into a modeled `E`.
+ */
+export function toBoxed<T, E>(
+  result: Result<T, E>,
+  onDefect: (cause: unknown) => E,
+): BoxedResult<T, E> {
+  return result.match<BoxedResult<T, E>>({
+    ok: (value) => BoxedResult.Ok(value),
+    err: (error) => BoxedResult.Error(error),
+    defect: (cause) => BoxedResult.Error(onDefect(cause)),
+  });
+}
+
+/**
+ * Convert a Boxed `Result` into a `Result`.
+ *
+ * @remarks
+ * `Result.Ok → Ok`, `Result.Error → Err`. Boxed's `Result` carries no defect, so
+ * the result is never a `Defect`.
+ *
+ * @typeParam T - the success value type.
+ * @typeParam E - the modeled error type.
+ * @param result - the Boxed result to convert.
+ */
+export function fromBoxed<T, E>(result: BoxedResult<T, E>): Result<T, E> {
+  return result.match({
+    Ok: (value) => ok(value),
+    Error: (error) => err(error),
+  });
+}
+
+/**
+ * Convert an `AsyncResult` into a Boxed `Future<Result>`, triaging any
+ * defect.
+ *
+ * @remarks
+ * The async counterpart of {@link toBoxed}: `onDefect` is required for the same
+ * reason. The `AsyncResult` is awaited (it never rejects) and its settled
+ * `Result` is converted, then resolved into the `Future`.
+ *
+ * @typeParam T - the success value type.
+ * @typeParam E - the modeled error type.
+ * @param asyncResult - the async result to convert.
+ * @param onDefect - folds a defect's unknown cause into a modeled `E`.
+ */
+export function toBoxedFuture<T, E>(
+  asyncResult: AsyncResult<T, E>,
+  onDefect: (cause: unknown) => E,
+): Future<BoxedResult<T, E>> {
+  return Future.make<BoxedResult<T, E>>((resolve) => {
+    void settle(asyncResult).then((result) => {
+      resolve(toBoxed(result, onDefect));
+    });
+  });
+}
+
+/**
+ * Convert a Boxed `Future<Result>` into an `AsyncResult`.
+ *
+ * @remarks
+ * The async counterpart of {@link fromBoxed}. A `Result.Error` stays an `Err`;
+ * an *unexpected* rejection of the underlying promise becomes a `Defect`. The
+ * returned `AsyncResult` never throws when awaited.
+ *
+ * @typeParam T - the success value type.
+ * @typeParam E - the modeled error type.
+ * @param future - the Boxed future to convert.
+ */
+export function fromBoxedFuture<T, E>(future: Future<BoxedResult<T, E>>): AsyncResult<T, E> {
+  return fromSafePromise(future.toPromise()).flatMap((result) => fromBoxed(result));
+}
+
+function settle<T, E>(asyncResult: AsyncResult<T, E>): Promise<Result<T, E>> {
+  return (async () => await asyncResult)();
+}

--- a/packages/boxed/tsconfig.json
+++ b/packages/boxed/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@unthrown/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/boxed/typedoc.json
+++ b/packages/boxed/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@unthrown/typedoc/base.json",
+  "entryPoints": ["src/index.ts"],
+  "out": "docs"
+}

--- a/packages/boxed/vitest.config.ts
+++ b/packages/boxed/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.spec.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**"],
+      // Every conversion is exercised both directions, including the forced
+      // `onDefect` triage on the way out and the `Future` async pair.
+      thresholds: {
+        statements: 95,
+        branches: 90,
+        functions: 100,
+        lines: 100,
+      },
+    },
+  },
+});

--- a/packages/effect/README.md
+++ b/packages/effect/README.md
@@ -1,0 +1,45 @@
+# @unthrown/effect
+
+> [Effect](https://effect.website) interop for
+> [unthrown](https://github.com/btravstack/unthrown)'s `Result`.
+
+📖 **[Documentation](https://btravstack.github.io/unthrown/guide/interop)** ·
+[API Reference](https://btravstack.github.io/unthrown/api/effect/)
+
+```sh
+pnpm add @unthrown/effect effect
+```
+
+Effect is the one neighbour that shares unthrown's three-channel shape: an
+`Exit<A, E>` is a success or a `Cause`, and a `Cause` distinguishes a modeled
+failure (`Cause.fail` ↔ `Err`) from an unexpected one (`Cause.die` ↔ `Defect`).
+So `Result ↔ Exit` is a genuine **bijection**.
+
+```ts
+import { ok, err } from "unthrown";
+import { toExit, fromEffect, toEither } from "@unthrown/effect";
+import { Effect } from "effect";
+
+toExit(ok(1)); // Exit.succeed(1)
+toExit(err("e")); // Exit.fail("e")        — a modeled Cause.fail
+
+// Run an Effect and collect its outcome (die/interrupt become a Defect):
+await fromEffect(Effect.succeed(1)).match({ ok, err, defect: String });
+```
+
+- `toExit` / `fromExit` — the bijection: `Ok↔succeed`, `Err↔Cause.fail`,
+  `Defect↔Cause.die`. On the way back a die/interruption becomes a `Defect`, and
+  a `Defect` **dominates** a modeled failure in a composite cause (same rule as
+  `all`).
+- `toEither` / `fromEither` — `Either` has no defect channel, so `toEither(r,
+onDefect)` **forces** you to triage the defect into `E` (Thesis #3). `fromEither`
+  never yields a `Defect`.
+- `toEffect` / `fromEffect` — `toEffect` lifts a `Result` **or** `AsyncResult`
+  into an `Effect<T, E>` (`Defect → Effect.die`); `fromEffect` runs an
+  environment-free `Effect<T, E>` to an `AsyncResult<T, E>`.
+
+`effect` is a peer dependency.
+
+## License
+
+[MIT](../../LICENSE) © Benoit TRAVERS

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@unthrown/effect",
+  "version": "0.1.0",
+  "description": "Effect interop for unthrown",
+  "keywords": [
+    "effect",
+    "either",
+    "errors-as-values",
+    "exit",
+    "result",
+    "typescript",
+    "unthrown"
+  ],
+  "homepage": "https://github.com/btravstack/unthrown#readme",
+  "bugs": {
+    "url": "https://github.com/btravstack/unthrown/issues"
+  },
+  "license": "MIT",
+  "author": "Benoit TRAVERS <benoit.travers.fr@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/btravstack/unthrown.git",
+    "directory": "packages/effect"
+  },
+  "files": [
+    "dist",
+    "docs"
+  ],
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsdown src/index.ts --format cjs,esm --dts --clean",
+    "build:docs": "typedoc",
+    "dev": "tsdown src/index.ts --format cjs,esm --dts --watch",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "unthrown": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@unthrown/tsconfig": "workspace:*",
+    "@unthrown/typedoc": "workspace:*",
+    "@vitest/coverage-v8": "catalog:",
+    "effect": "catalog:",
+    "tsdown": "catalog:",
+    "typedoc": "catalog:",
+    "typedoc-plugin-markdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "^3"
+  },
+  "engines": {
+    "node": ">=22.19"
+  }
+}

--- a/packages/effect/src/index.spec.ts
+++ b/packages/effect/src/index.spec.ts
@@ -1,0 +1,114 @@
+import { Cause, Effect, Either, Exit, FiberId, Option } from "effect";
+import { err, ok, type Result } from "unthrown";
+import { describe, expect, it } from "vitest";
+
+import { fromEffect, fromEither, fromExit, toEffect, toEither, toExit } from "./index.js";
+
+const boom = new Error("boom");
+const aDefect: Result<number, string> = ok(0).map<number>(() => {
+  throw boom;
+});
+
+describe("toExit", () => {
+  it("maps Ok to a success", () => {
+    const exit = toExit(ok(1));
+    expect(Exit.isSuccess(exit) ? exit.value : undefined).toBe(1);
+  });
+
+  it("maps Err to a modeled failure (Cause.fail)", () => {
+    const exit = toExit(err("nope") as Result<number, string>);
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      expect(Option.getOrNull(Cause.failureOption(exit.cause))).toBe("nope");
+    }
+  });
+
+  it("maps a Defect to a die (Cause.die)", () => {
+    const exit = toExit(aDefect);
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      expect(Option.getOrNull(Cause.dieOption(exit.cause))).toBe(boom);
+    }
+  });
+});
+
+describe("fromExit", () => {
+  it("maps a success to Ok", () => {
+    expect(fromExit(Exit.succeed(1))).toMatchObject({ tag: "Ok", value: 1 });
+  });
+
+  it("maps a modeled failure to Err", () => {
+    expect(fromExit(Exit.fail("nope"))).toMatchObject({ tag: "Err", error: "nope" });
+  });
+
+  it("maps a die to a Defect", () => {
+    expect(fromExit(Exit.die(boom))).toMatchObject({ tag: "Defect", cause: boom });
+  });
+
+  it("maps a pure interruption to a Defect", () => {
+    const exit = Exit.failCause(Cause.interrupt(FiberId.none)) as Exit.Exit<number, string>;
+    expect(fromExit(exit).tag).toBe("Defect");
+  });
+
+  it("lets a Defect dominate a modeled failure in a composite cause", () => {
+    const exit = Exit.failCause(Cause.sequential(Cause.fail("nope"), Cause.die(boom)));
+    expect(fromExit(exit as Exit.Exit<number, string>)).toMatchObject({
+      tag: "Defect",
+      cause: boom,
+    });
+  });
+
+  it("round-trips Ok/Err/Defect through toExit", () => {
+    expect(fromExit(toExit(ok(1)))).toMatchObject({ tag: "Ok", value: 1 });
+    expect(fromExit(toExit(err("nope") as Result<number, string>))).toMatchObject({
+      tag: "Err",
+      error: "nope",
+    });
+    expect(fromExit(toExit(aDefect))).toMatchObject({ tag: "Defect", cause: boom });
+  });
+});
+
+describe("toEither", () => {
+  it("maps Ok to Right and Err to Left", () => {
+    expect(Either.getOrNull(toEither(ok(1), () => "x"))).toBe(1);
+    const left = toEither(err("nope") as Result<number, string>, () => "x");
+    expect(Either.isLeft(left) ? left.left : undefined).toBe("nope");
+  });
+
+  it("forces a defect to be triaged into the error channel", () => {
+    const left = toEither(aDefect, (cause) => `bug:${String(cause)}`);
+    expect(Either.isLeft(left) ? left.left : undefined).toBe(`bug:${String(boom)}`);
+  });
+});
+
+describe("fromEither", () => {
+  it("maps Right to Ok and Left to Err — never a Defect", () => {
+    expect(fromEither(Either.right(1))).toMatchObject({ tag: "Ok", value: 1 });
+    expect(fromEither(Either.left("nope"))).toMatchObject({ tag: "Err", error: "nope" });
+  });
+});
+
+describe("toEffect", () => {
+  it("maps a Result's three channels to succeed/fail/die", () => {
+    expect(Effect.runSyncExit(toEffect(ok(1)))).toStrictEqual(Exit.succeed(1));
+    expect(Effect.runSyncExit(toEffect(err("nope") as Result<number, string>))).toStrictEqual(
+      Exit.fail("nope"),
+    );
+    const exit = Effect.runSyncExit(toEffect(aDefect));
+    expect(Exit.isFailure(exit) && Option.getOrNull(Cause.dieOption(exit.cause))).toBe(boom);
+  });
+
+  it("accepts an AsyncResult (the AsyncResult -> Effect direction)", async () => {
+    expect(await Effect.runPromise(toEffect(ok(1).toAsync()))).toBe(1);
+    const exit = await Effect.runPromiseExit(toEffect(aDefect.toAsync()));
+    expect(Exit.isFailure(exit) && Option.getOrNull(Cause.dieOption(exit.cause))).toBe(boom);
+  });
+});
+
+describe("fromEffect", () => {
+  it("collects succeed/fail/die into Ok/Err/Defect", async () => {
+    expect(await fromEffect(Effect.succeed(1))).toMatchObject({ tag: "Ok", value: 1 });
+    expect(await fromEffect(Effect.fail("nope"))).toMatchObject({ tag: "Err", error: "nope" });
+    expect(await fromEffect(Effect.die(boom))).toMatchObject({ tag: "Defect", cause: boom });
+  });
+});

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -1,0 +1,194 @@
+// @unthrown/effect — interop between unthrown's `Result`/`AsyncResult` and
+// Effect's `Exit`, `Either`, and `Effect`.
+//
+// Effect is the one neighbour that shares unthrown's three-channel shape: an
+// `Exit<A, E>` is `Success` | `Failure(Cause)`, and a `Cause` distinguishes a
+// modeled failure (`Cause.fail`, ↔ `Err`) from an unexpected one (`Cause.die`,
+// ↔ `Defect`). So `Result ↔ Exit` is a genuine bijection — the showcase here.
+//
+//   import { ok } from "unthrown";
+//   import { toExit, fromEffect } from "@unthrown/effect";
+//
+//   toExit(ok(1));                 // Exit.succeed(1)
+//   await fromEffect(Effect.succeed(1)).match({ ok, err, defect });
+//
+// `Either` has only two channels, so converting a `Result` *into* an `Either`
+// forces you to triage the defect with `onDefect` (Thesis #3): there is no
+// silent path that drops it.
+
+import { Cause, Effect, Either, Exit, Option } from "effect";
+import { defect, err, fromSafePromise, fromThrowable, ok } from "unthrown";
+import type { AsyncResult, Result } from "unthrown";
+
+/**
+ * Convert a `Result` into an Effect `Exit` — a **bijection**, since both
+ * carry three channels.
+ *
+ * @remarks
+ * `Ok → Exit.succeed`, `Err → Exit.fail` (a modeled `Cause.fail`), and
+ * `Defect → Exit.die` (an unexpected `Cause.die`). Round-trips with
+ * {@link fromExit}.
+ *
+ * @typeParam T - the success value type.
+ * @typeParam E - the modeled error type.
+ * @param result - the result to convert.
+ *
+ * @example
+ * ```ts
+ * import { ok } from "unthrown";
+ * import { toExit } from "@unthrown/effect";
+ * toExit(ok(1)); // Exit.succeed(1)
+ * ```
+ */
+export function toExit<T, E>(result: Result<T, E>): Exit.Exit<T, E> {
+  return result.match<Exit.Exit<T, E>>({
+    ok: (value) => Exit.succeed(value),
+    err: (error) => Exit.fail(error),
+    defect: (cause) => Exit.die(cause),
+  });
+}
+
+/**
+ * Convert an Effect `Exit` into a `Result` — the inverse of
+ * {@link toExit}.
+ *
+ * @remarks
+ * `Exit.Success → Ok`. For a failure, the enclosing `Cause` is reduced:
+ *
+ * - a `Cause.die` becomes a `Defect`,
+ * - otherwise a `Cause.fail` becomes the modeled `Err`,
+ * - a pure interruption (or empty cause) becomes a `Defect`.
+ *
+ * A `Defect` **dominates** a modeled failure in a composite cause — the same
+ * rule unthrown's `all` uses, on the principle that an unexpected failure is the
+ * more severe signal.
+ *
+ * @typeParam T - the success value type.
+ * @typeParam E - the modeled error type.
+ * @param exit - the exit to convert.
+ */
+export function fromExit<T, E>(exit: Exit.Exit<T, E>): Result<T, E> {
+  return Exit.match(exit, {
+    onSuccess: (value) => ok(value),
+    onFailure: (cause) => {
+      const die = Cause.dieOption(cause);
+      if (Option.isSome(die)) return dieToResult<T, E>(die.value);
+      const failure = Cause.failureOption(cause);
+      if (Option.isSome(failure)) return err(failure.value);
+      // No modeled failure and no die: a pure interruption (or empty cause).
+      return dieToResult<T, E>(Cause.squash(cause));
+    },
+  });
+}
+
+/**
+ * Convert a `Result` into an Effect `Either`, triaging any defect.
+ *
+ * @remarks
+ * `Either` has no defect channel, so a `Defect` cannot pass through silently —
+ * `onDefect` **must** fold its cause into a modeled error `E` (a `Left`). This
+ * is the boundary-qualification rule (Thesis #3) applied on the way out:
+ * `Ok → Right`, `Err → Left`, `Defect → Left(onDefect(cause))`.
+ *
+ * @typeParam T - the success value type.
+ * @typeParam E - the modeled error type.
+ * @param result - the result to convert.
+ * @param onDefect - folds a defect's unknown cause into a modeled `E`.
+ */
+export function toEither<T, E>(
+  result: Result<T, E>,
+  onDefect: (cause: unknown) => E,
+): Either.Either<T, E> {
+  return result.match<Either.Either<T, E>>({
+    ok: (value) => Either.right(value),
+    err: (error) => Either.left(error),
+    defect: (cause) => Either.left(onDefect(cause)),
+  });
+}
+
+/**
+ * Convert an Effect `Either` into a `Result`.
+ *
+ * @remarks
+ * `Right → Ok`, `Left → Err`. An `Either` carries no defect, so the result is
+ * never a `Defect`.
+ *
+ * @typeParam T - the success value type.
+ * @typeParam E - the modeled error type.
+ * @param either - the either to convert.
+ */
+export function fromEither<T, E>(either: Either.Either<T, E>): Result<T, E> {
+  return Either.match(either, {
+    onLeft: (error) => err(error),
+    onRight: (value) => ok(value),
+  });
+}
+
+/**
+ * Lift a `Result` or `AsyncResult` into an `Effect`.
+ *
+ * @remarks
+ * `Ok → Effect.succeed`, `Err → Effect.fail`, `Defect → Effect.die`. The
+ * resulting `Effect` needs no environment (`R = never`). An `AsyncResult` is
+ * awaited inside the effect (it never rejects), so this is the `AsyncResult →
+ * Effect` direction too.
+ *
+ * @typeParam T - the success value type.
+ * @typeParam E - the modeled error type.
+ * @param source - the result, or async result, to lift.
+ */
+export function toEffect<T, E>(source: Result<T, E>): Effect.Effect<T, E>;
+export function toEffect<T, E>(source: AsyncResult<T, E>): Effect.Effect<T, E>;
+export function toEffect<T, E>(source: Result<T, E> | AsyncResult<T, E>): Effect.Effect<T, E> {
+  if (isAsyncResult(source)) {
+    return Effect.flatMap(
+      Effect.promise(() => settle(source)),
+      (result) => resultToEffect(result),
+    );
+  }
+  return resultToEffect(source);
+}
+
+/**
+ * Run an `Effect` and collect its outcome as an `AsyncResult`.
+ *
+ * @remarks
+ * The effect must need no environment (`R = never`). It is run to an `Exit`
+ * (which never rejects), then folded with {@link fromExit}: success → `Ok`, a
+ * modeled failure → `Err`, a die/interruption → `Defect`. The returned
+ * `AsyncResult` never throws when awaited.
+ *
+ * @typeParam T - the success value type.
+ * @typeParam E - the modeled error type.
+ * @param effect - the effect to run.
+ */
+export function fromEffect<T, E>(effect: Effect.Effect<T, E>): AsyncResult<T, E> {
+  return fromSafePromise(Effect.runPromiseExit(effect)).flatMap((exit) => fromExit(exit));
+}
+
+function resultToEffect<T, E>(result: Result<T, E>): Effect.Effect<T, E> {
+  return result.match<Effect.Effect<T, E>>({
+    ok: (value) => Effect.succeed(value),
+    err: (error) => Effect.fail(error),
+    defect: (cause) => Effect.die(cause),
+  });
+}
+
+// Effect's `die`/interruption channel is an un-triaged failure crossing into
+// unthrown; replaying it through the throwable boundary lands it in the `Defect`
+// state — the sanctioned (boundary-only) way to mint a defect `Result`.
+function dieToResult<T, E>(cause: unknown): Result<T, E> {
+  return fromThrowable<[], never, never>((): never => {
+    throw cause;
+  }, defect)();
+}
+
+function settle<T, E>(asyncResult: AsyncResult<T, E>): Promise<Result<T, E>> {
+  return (async () => await asyncResult)();
+}
+
+function isAsyncResult<T, E>(
+  source: Result<T, E> | AsyncResult<T, E>,
+): source is AsyncResult<T, E> {
+  return typeof (source as { then?: unknown }).then === "function";
+}

--- a/packages/effect/tsconfig.json
+++ b/packages/effect/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@unthrown/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/effect/typedoc.json
+++ b/packages/effect/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@unthrown/typedoc/base.json",
+  "entryPoints": ["src/index.ts"],
+  "out": "docs"
+}

--- a/packages/effect/vitest.config.ts
+++ b/packages/effect/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.spec.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**"],
+      // The interop surface is fully exercised, including every Cause-reduction
+      // branch of `fromExit` (fail, die, interrupt) and the forced-triage path
+      // of `toEither`.
+      thresholds: {
+        statements: 95,
+        branches: 90,
+        functions: 100,
+        lines: 100,
+      },
+    },
+  },
+});

--- a/packages/neverthrow/README.md
+++ b/packages/neverthrow/README.md
@@ -1,0 +1,36 @@
+# @unthrown/neverthrow
+
+> [neverthrow](https://github.com/supermacro/neverthrow) interop for
+> [unthrown](https://github.com/btravstack/unthrown)'s `Result`.
+
+📖 **[Documentation](https://btravstack.github.io/unthrown/guide/interop)** ·
+[API Reference](https://btravstack.github.io/unthrown/api/neverthrow/)
+
+```sh
+pnpm add @unthrown/neverthrow neverthrow
+```
+
+neverthrow has two channels (`Ok`/`Err`) and no defect channel. Coming **in**,
+every neverthrow result is an `Ok` or `Err` — never a `Defect`. Going **out**, a
+`Defect` has nowhere to live, so `toNeverthrow` **forces** you to triage it with
+`onDefect` — no defect is ever silently folded into your domain error type.
+
+```ts
+import { ok } from "unthrown";
+import { toNeverthrow, fromNeverthrow } from "@unthrown/neverthrow";
+import { ok as ntOk } from "neverthrow";
+
+toNeverthrow(ok(1), (cause) => ({ _tag: "Bug", cause })); // neverthrow Ok(1)
+fromNeverthrow(ntOk(1)); // Result<number, never>
+```
+
+- `toNeverthrow(r, onDefect)` / `fromNeverthrow(r)` — sync `Result ↔ Result`.
+- `toNeverthrowAsync(ar, onDefect)` / `fromNeverthrowAsync(ra)` — async
+  `AsyncResult ↔ ResultAsync`. An unexpected rejection inside a `ResultAsync`
+  becomes a `Defect` on the way in.
+
+`neverthrow` is a peer dependency.
+
+## License
+
+[MIT](../../LICENSE) © Benoit TRAVERS

--- a/packages/neverthrow/package.json
+++ b/packages/neverthrow/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@unthrown/neverthrow",
+  "version": "0.1.0",
+  "description": "neverthrow interop for unthrown",
+  "keywords": [
+    "errors-as-values",
+    "neverthrow",
+    "result",
+    "resultasync",
+    "typescript",
+    "unthrown"
+  ],
+  "homepage": "https://github.com/btravstack/unthrown#readme",
+  "bugs": {
+    "url": "https://github.com/btravstack/unthrown/issues"
+  },
+  "license": "MIT",
+  "author": "Benoit TRAVERS <benoit.travers.fr@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/btravstack/unthrown.git",
+    "directory": "packages/neverthrow"
+  },
+  "files": [
+    "dist",
+    "docs"
+  ],
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsdown src/index.ts --format cjs,esm --dts --clean",
+    "build:docs": "typedoc",
+    "dev": "tsdown src/index.ts --format cjs,esm --dts --watch",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "unthrown": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@unthrown/tsconfig": "workspace:*",
+    "@unthrown/typedoc": "workspace:*",
+    "@vitest/coverage-v8": "catalog:",
+    "neverthrow": "catalog:",
+    "tsdown": "catalog:",
+    "typedoc": "catalog:",
+    "typedoc-plugin-markdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "neverthrow": "^8"
+  },
+  "engines": {
+    "node": ">=22.19"
+  }
+}

--- a/packages/neverthrow/src/index.spec.ts
+++ b/packages/neverthrow/src/index.spec.ts
@@ -1,0 +1,60 @@
+import {
+  errAsync,
+  okAsync,
+  ResultAsync,
+  err as neverthrowErr,
+  ok as neverthrowOk,
+} from "neverthrow";
+import { err, ok, type Result } from "unthrown";
+import { describe, expect, it } from "vitest";
+
+import { fromNeverthrow, fromNeverthrowAsync, toNeverthrow, toNeverthrowAsync } from "./index.js";
+
+const boom = new Error("boom");
+const aDefect: Result<number, string> = ok(0).map<number>(() => {
+  throw boom;
+});
+
+describe("toNeverthrow", () => {
+  it("maps Ok and Err across", () => {
+    const okR = toNeverthrow(ok(1), () => "x");
+    expect(okR.isOk() && okR.value).toBe(1);
+    const errR = toNeverthrow(err("nope") as Result<number, string>, () => "x");
+    expect(errR.isErr() && errR.error).toBe("nope");
+  });
+
+  it("forces a defect to be triaged into the error channel", () => {
+    const r = toNeverthrow(aDefect, (cause) => `bug:${String(cause)}`);
+    expect(r.isErr() && r.error).toBe(`bug:${String(boom)}`);
+  });
+});
+
+describe("fromNeverthrow", () => {
+  it("maps ok to Ok and err to Err — never a Defect", () => {
+    expect(fromNeverthrow(neverthrowOk(1))).toMatchObject({ tag: "Ok", value: 1 });
+    expect(fromNeverthrow(neverthrowErr("nope"))).toMatchObject({ tag: "Err", error: "nope" });
+  });
+});
+
+describe("toNeverthrowAsync", () => {
+  it("maps Ok across and triages a defect", async () => {
+    const okR = await toNeverthrowAsync(ok(1).toAsync(), () => "x");
+    expect(okR.isOk() && okR.value).toBe(1);
+    const defR = await toNeverthrowAsync(aDefect.toAsync(), (cause) => `bug:${String(cause)}`);
+    expect(defR.isErr() && defR.error).toBe(`bug:${String(boom)}`);
+  });
+});
+
+describe("fromNeverthrowAsync", () => {
+  it("maps okAsync/errAsync, and an unexpected rejection to a Defect", async () => {
+    expect(await fromNeverthrowAsync(okAsync(1))).toMatchObject({ tag: "Ok", value: 1 });
+    expect(await fromNeverthrowAsync(errAsync("nope"))).toMatchObject({
+      tag: "Err",
+      error: "nope",
+    });
+    const rejecting: ResultAsync<number, string> = ResultAsync.fromSafePromise(
+      Promise.reject(boom),
+    );
+    expect(await fromNeverthrowAsync(rejecting)).toMatchObject({ tag: "Defect", cause: boom });
+  });
+});

--- a/packages/neverthrow/src/index.ts
+++ b/packages/neverthrow/src/index.ts
@@ -1,0 +1,107 @@
+// @unthrown/neverthrow — interop between unthrown's `Result`/`AsyncResult` and
+// neverthrow's `Result`/`ResultAsync`.
+//
+// neverthrow has two channels (`Ok`/`Err`), so it cannot represent unthrown's
+// third one. Coming *in*, every neverthrow result is an `Ok` or `Err` — never a
+// `Defect`. Going *out*, a `Defect` has nowhere to live, so `toNeverthrow`
+// forces you to triage it with `onDefect` (Thesis #3): no defect is ever
+// silently folded into your domain error type.
+//
+//   import { ok } from "unthrown";
+//   import { toNeverthrow, fromNeverthrow } from "@unthrown/neverthrow";
+//
+//   toNeverthrow(ok(1), (cause) => ({ _tag: "Bug", cause }));
+//   fromNeverthrow(neverthrowOk(1)); // Result<number, never>
+
+import {
+  err as neverthrowErr,
+  ok as neverthrowOk,
+  ResultAsync as NeverthrowResultAsync,
+} from "neverthrow";
+import type { Result as NeverthrowResult } from "neverthrow";
+import { err, fromSafePromise, ok } from "unthrown";
+import type { AsyncResult, Result } from "unthrown";
+
+/**
+ * Convert a `Result` into a neverthrow `Result`, triaging any defect.
+ *
+ * @remarks
+ * neverthrow has no defect channel, so `onDefect` **must** fold a `Defect`'s
+ * cause into a modeled error `E` (an `Err`). `Ok → ok`, `Err → err`,
+ * `Defect → err(onDefect(cause))`.
+ *
+ * @typeParam T - the success value type.
+ * @typeParam E - the modeled error type.
+ * @param result - the result to convert.
+ * @param onDefect - folds a defect's unknown cause into a modeled `E`.
+ */
+export function toNeverthrow<T, E>(
+  result: Result<T, E>,
+  onDefect: (cause: unknown) => E,
+): NeverthrowResult<T, E> {
+  return result.match<NeverthrowResult<T, E>>({
+    ok: (value) => neverthrowOk(value),
+    err: (error) => neverthrowErr(error),
+    defect: (cause) => neverthrowErr(onDefect(cause)),
+  });
+}
+
+/**
+ * Convert a neverthrow `Result` into a `Result`.
+ *
+ * @remarks
+ * `ok → Ok`, `err → Err`. neverthrow carries no defect, so the result is never a
+ * `Defect`.
+ *
+ * @typeParam T - the success value type.
+ * @typeParam E - the modeled error type.
+ * @param result - the neverthrow result to convert.
+ */
+export function fromNeverthrow<T, E>(result: NeverthrowResult<T, E>): Result<T, E> {
+  return result.isOk() ? ok(result.value) : err(result.error);
+}
+
+/**
+ * Convert an `AsyncResult` into a neverthrow `ResultAsync`, triaging any
+ * defect.
+ *
+ * @remarks
+ * The async counterpart of {@link toNeverthrow}: `onDefect` is required for the
+ * same reason. The `AsyncResult` is awaited (it never rejects) and each settled
+ * `Result` is converted.
+ *
+ * @typeParam T - the success value type.
+ * @typeParam E - the modeled error type.
+ * @param asyncResult - the async result to convert.
+ * @param onDefect - folds a defect's unknown cause into a modeled `E`.
+ */
+export function toNeverthrowAsync<T, E>(
+  asyncResult: AsyncResult<T, E>,
+  onDefect: (cause: unknown) => E,
+): NeverthrowResultAsync<T, E> {
+  return NeverthrowResultAsync.fromSafePromise(settle(asyncResult)).andThen((result) =>
+    toNeverthrow(result, onDefect),
+  );
+}
+
+/**
+ * Convert a neverthrow `ResultAsync` into an `AsyncResult`.
+ *
+ * @remarks
+ * The async counterpart of {@link fromNeverthrow}. A modeled `Err` stays an
+ * `Err`; an *unexpected* rejection inside the neverthrow chain becomes a
+ * `Defect`. The returned `AsyncResult` never throws when awaited.
+ *
+ * @typeParam T - the success value type.
+ * @typeParam E - the modeled error type.
+ * @param resultAsync - the neverthrow async result to convert.
+ */
+export function fromNeverthrowAsync<T, E>(
+  resultAsync: NeverthrowResultAsync<T, E>,
+): AsyncResult<T, E> {
+  return fromSafePromise(Promise.resolve(resultAsync)).flatMap((result) => fromNeverthrow(result));
+}
+
+function settle<T, E>(asyncResult: AsyncResult<T, E>): Promise<Result<T, E>> {
+  return (async () => await asyncResult)();
+}

--- a/packages/neverthrow/tsconfig.json
+++ b/packages/neverthrow/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@unthrown/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/neverthrow/typedoc.json
+++ b/packages/neverthrow/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@unthrown/typedoc/base.json",
+  "entryPoints": ["src/index.ts"],
+  "out": "docs"
+}

--- a/packages/neverthrow/vitest.config.ts
+++ b/packages/neverthrow/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.spec.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**"],
+      // Every conversion is exercised both directions, including the forced
+      // `onDefect` triage and the defensive defect path on the way back in.
+      thresholds: {
+        statements: 95,
+        branches: 90,
+        functions: 100,
+        lines: 100,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@bloodyowl/boxed':
+      specifier: 3.4.0
+      version: 3.4.0
     '@changesets/cli':
       specifier: 2.31.0
       version: 2.31.0
@@ -21,12 +24,18 @@ catalogs:
     '@vitest/coverage-v8':
       specifier: 4.1.8
       version: 4.1.8
+    effect:
+      specifier: 3.21.4
+      version: 3.21.4
     knip:
       specifier: 6.16.1
       version: 6.16.1
     lefthook:
       specifier: 2.1.9
       version: 2.1.9
+    neverthrow:
+      specifier: 8.2.0
+      version: 8.2.0
     oxfmt:
       specifier: 0.54.0
       version: 0.54.0
@@ -92,6 +101,15 @@ importers:
 
   docs:
     dependencies:
+      '@unthrown/boxed':
+        specifier: workspace:*
+        version: link:../packages/boxed
+      '@unthrown/effect':
+        specifier: workspace:*
+        version: link:../packages/effect
+      '@unthrown/neverthrow':
+        specifier: workspace:*
+        version: link:../packages/neverthrow
       '@unthrown/pattern':
         specifier: workspace:*
         version: link:../packages/pattern
@@ -112,6 +130,43 @@ importers:
         specifier: 'catalog:'
         version: 1.6.4(@algolia/client-search@5.55.1)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3)
 
+  packages/boxed:
+    dependencies:
+      unthrown:
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@bloodyowl/boxed':
+        specifier: 'catalog:'
+        version: 3.4.0(typescript@6.0.3)
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.2
+      '@unthrown/tsconfig':
+        specifier: workspace:*
+        version: link:../../tools/tsconfig
+      '@unthrown/typedoc':
+        specifier: workspace:*
+        version: link:../../tools/typedoc
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.8(vitest@4.1.8)
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.2(oxc-resolver@11.21.3)(tsx@4.22.4)(typescript@6.0.3)
+      typedoc:
+        specifier: 'catalog:'
+        version: 0.28.19(typescript@6.0.3)
+      typedoc-plugin-markdown:
+        specifier: 'catalog:'
+        version: 4.12.0(typedoc@0.28.19(typescript@6.0.3))
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@types/node@24.13.2)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+
   packages/core:
     devDependencies:
       '@types/node':
@@ -126,6 +181,80 @@ importers:
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.8(vitest@4.1.8)
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.2(oxc-resolver@11.21.3)(tsx@4.22.4)(typescript@6.0.3)
+      typedoc:
+        specifier: 'catalog:'
+        version: 0.28.19(typescript@6.0.3)
+      typedoc-plugin-markdown:
+        specifier: 'catalog:'
+        version: 4.12.0(typedoc@0.28.19(typescript@6.0.3))
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@types/node@24.13.2)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+
+  packages/effect:
+    dependencies:
+      unthrown:
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.2
+      '@unthrown/tsconfig':
+        specifier: workspace:*
+        version: link:../../tools/tsconfig
+      '@unthrown/typedoc':
+        specifier: workspace:*
+        version: link:../../tools/typedoc
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.8(vitest@4.1.8)
+      effect:
+        specifier: 'catalog:'
+        version: 3.21.4
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.2(oxc-resolver@11.21.3)(tsx@4.22.4)(typescript@6.0.3)
+      typedoc:
+        specifier: 'catalog:'
+        version: 0.28.19(typescript@6.0.3)
+      typedoc-plugin-markdown:
+        specifier: 'catalog:'
+        version: 4.12.0(typedoc@0.28.19(typescript@6.0.3))
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@types/node@24.13.2)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+
+  packages/neverthrow:
+    dependencies:
+      unthrown:
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.2
+      '@unthrown/tsconfig':
+        specifier: workspace:*
+        version: link:../../tools/tsconfig
+      '@unthrown/typedoc':
+        specifier: workspace:*
+        version: link:../../tools/typedoc
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.8(vitest@4.1.8)
+      neverthrow:
+        specifier: 'catalog:'
+        version: 8.2.0
       tsdown:
         specifier: 'catalog:'
         version: 0.22.2(oxc-resolver@11.21.3)(tsx@4.22.4)(typescript@6.0.3)
@@ -353,6 +482,14 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@bloodyowl/boxed@3.4.0':
+    resolution: {integrity: sha512-SjA78UNak5c3wjOI4Aeul++sYK/gG0lIp91K+DRzwTgVzTJ/yy5wUoznRNMexvock3iiy7lfdXbz2n/zSa5iBQ==}
+    peerDependencies:
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@changesets/apply-release-plan@7.1.1':
     resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
@@ -2046,6 +2183,9 @@ packages:
       oxc-resolver:
         optional: true
 
+  effect@3.21.4:
+    resolution: {integrity: sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ==}
+
   emoji-regex-xs@1.0.0:
     resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
 
@@ -2112,6 +2252,10 @@ packages:
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2553,6 +2697,10 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  neverthrow@8.2.0:
+    resolution: {integrity: sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ==}
+    engines: {node: '>=18'}
+
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
     engines: {node: '>=12.20.0'}
@@ -2678,6 +2826,9 @@ packages:
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
@@ -3281,7 +3432,7 @@ snapshots:
 
   '@babel/generator@8.0.0-rc.6':
     dependencies:
-      '@babel/parser': 8.0.0-rc.6
+      '@babel/parser': 8.0.0
       '@babel/types': 8.0.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
@@ -3323,6 +3474,10 @@ snapshots:
       '@babel/helper-validator-identifier': 8.0.2
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@bloodyowl/boxed@3.4.0(typescript@6.0.3)':
+    optionalDependencies:
+      typescript: 6.0.3
 
   '@changesets/apply-release-plan@7.1.1':
     dependencies:
@@ -4710,6 +4865,11 @@ snapshots:
     optionalDependencies:
       oxc-resolver: 11.21.3
 
+  effect@3.21.4:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
+
   emoji-regex-xs@1.0.0: {}
 
   emoji-regex@10.6.0: {}
@@ -4803,6 +4963,10 @@ snapshots:
   expect-type@1.3.0: {}
 
   extendable-error@0.1.7: {}
+
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
 
   fast-deep-equal@3.1.3: {}
 
@@ -5207,6 +5371,10 @@ snapshots:
 
   nanoid@3.3.15: {}
 
+  neverthrow@8.2.0:
+    optionalDependencies:
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+
   obug@2.1.3: {}
 
   oniguruma-to-es@3.1.1:
@@ -5372,6 +5540,8 @@ snapshots:
   property-information@7.2.0: {}
 
   punycode.js@2.3.1: {}
+
+  pure-rand@6.1.0: {}
 
   quansync@0.2.11: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,11 +12,14 @@ packages:
 catalog:
   "@changesets/cli": 2.31.0
   "@commitlint/cli": 21.0.2
+  "@bloodyowl/boxed": 3.4.0
   "@commitlint/config-conventional": 21.0.2
   "@types/node": 24.13.2
   "@vitest/coverage-v8": 4.1.8
+  effect: 3.21.4
   knip: 6.16.1
   lefthook: 2.1.9
+  neverthrow: 8.2.0
   oxfmt: 0.54.0
   oxlint: 1.69.0
   ts-pattern: 5.9.0


### PR DESCRIPTION
## Summary

Three new peer-dependency packages bridging unthrown's `Result`/`AsyncResult` with the most common neighbours in the errors-as-values space.

| Package | Peer dep | Surface |
|---|---|---|
| `@unthrown/effect` | `effect` | `toExit`/`fromExit` (bijection), `toEither`/`fromEither`, `toEffect`/`fromEffect` (incl. `AsyncResult → Effect`) |
| `@unthrown/neverthrow` | `neverthrow` | `toNeverthrow`/`fromNeverthrow` + async pair |
| `@unthrown/boxed` | `@bloodyowl/boxed` | `toBoxed`/`fromBoxed` + `Future` pair |

## Design

One rule decides every signature: **does the neighbour have a defect channel?**

- **Effect does** (`Cause.die`), so `Result ↔ Exit` is a genuine **bijection** (`Ok↔succeed`, `Err↔Cause.fail`, `Defect↔Cause.die`). `fromExit` lets a `Defect` **dominate** a modeled failure in a composite cause — the same rule as `all`.
- **neverthrow & Boxed don't.** Coming *in*, results are only `Ok`/`Err` — never a `Defect`. Going *out*, every `to*` takes a **mandatory `onDefect: (cause) => E`** (forced triage, Thesis #3). No one-arg form — a defect is never silently folded into the domain error type.
- A `Defect` `Result` has no public constructor (defects arise at boundaries). The only place one is minted is `fromExit`, which replays Effect's `die` cause through the `fromThrowable` boundary — leaving core untouched.

## Notable

- **Boxed scope:** targets the maintained **`@bloodyowl/boxed`** (Boxed was transferred from the now-deprecated `@swan-io/boxed`; same author/API).
- **100% coverage** on all three packages (effect 15 tests, neverthrow 5, boxed 5).
- Full gate green: format, lint, typecheck, knip, test, build, and TypeDoc warning-free.

## Also wired

Root README table · `CLAUDE.md` monorepo layout + an "Interop packages" design section · new `/guide/interop` page · VitePress API nav + `copy-docs.ts` + docs deps · changeset `fixed` group (all six packages version in lockstep) · a `minor` changeset (suite → `0.2.0`).

## Follow-up (not in this PR)

These are brand-new npm names — `@unthrown/effect`, `@unthrown/neverthrow`, `@unthrown/boxed` don't exist on the registry yet, so each needs the same first-publish bootstrap (manual publish to create it, then add a Trusted Publisher) when `0.2.0` is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)