### PR TITLE
Pin shared theme import to @v1.0.0 (fixes dark mode)

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -6,4 +6,4 @@
  * Pinned to an immutable commit SHA for reproducible builds — to pull in
  * upstream token changes, bump the SHA below. Do not fork colors here.
  */
-@import "https://cdn.jsdelivr.net/gh/btravstack/btravstack.github.io@7ad56793ed403bd626ac85476752f9b7cf7c6983/theme/vitepress.css";
+@import "https://cdn.jsdelivr.net/gh/btravstack/btravstack.github.io@v1.0.0/theme/vitepress.css";


### PR DESCRIPTION
custom.css pinned the jsDelivr import to an old landing commit (7ad5679) whose vitepress.css predates the dark-mode fix, so dark mode fell back to VitePress's default indigo brand and Inter font. Repoint to the immutable @v1.0.0 tag, which serves the corrected adapter (theme-aware brand/surfaces/fonts via raised-specificity selectors).