### PR TITLE
feat(core): narrowing guard methods, allAsync, decoupled TaggedError name

### DIFF
--- a/.changeset/sharpen-aggregate-guards-tags.md
+++ b/.changeset/sharpen-aggregate-guards-tags.md
@@ -1,0 +1,22 @@
+---
+"unthrown": minor
+---
+
+Sharpen three corners of the core surface:
+
+- **Narrowing guard methods.** `.isOk()` / `.isErr()` / `.isDefect()` are now
+  `this is …` type predicates, so `if (r.isErr()) r.error` compiles — the
+  methods narrow exactly like the standalone `isOk` / `isErr` / `isDefect`
+  guards. No more boolean-only footgun for code coming from neverthrow.
+- **`allAsync` + tuple-or-array `all`.** New `allAsync` combines `AsyncResult`s
+  (resolved concurrently, order preserved; first `Err` wins, any `Defect`
+  dominates; never rejects). Both `all` and `allAsync` now accept a **dynamic
+  array** — `Result<T, E>[]` / `AsyncResult<T, E>[]` collapses to
+  `Result<T[], E>` / `AsyncResult<T[], E>` with no cast — while a fixed tuple
+  still keeps its positional types. Adds the `AsyncOkOf` / `AsyncErrOf` type
+  helpers.
+- **Decoupled `TaggedError` name.** `TaggedError(tag, { name })` sets
+  `Error.name` independently of the `_tag` discriminant, so a tag can be
+  namespaced for collision-safety (`"@my-lib/RetryableError"`) without that
+  prefix leaking into stack traces. Defaults to `tag`, so existing calls are
+  unchanged.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,18 +82,27 @@ async work re-enters via `fromPromise` / `fromSafePromise` and composes with
 - defect: `recoverDefect`, `tapDefect`
 - eliminate: `match`, `unwrap`, `unwrapErr`, `unwrapOr`, `unwrapOrElse`,
   `getOrNull`, `getOrUndefined`
-- guards: methods `isOk`/`isErr`/`isDefect` (boolean) + standalone
-  `isOk`/`isErr`/`isDefect` (narrow to `OkView`/`ErrView`/`DefectView`)
+- guards: methods `isOk`/`isErr`/`isDefect` **and** standalone
+  `isOk`/`isErr`/`isDefect` both narrow (to `OkView`/`ErrView`/`DefectView`) — the
+  methods are `this is …` type predicates, so `if (r.isErr()) r.error` compiles.
+  One narrowing concept, two call styles.
 - constructors: `ok`, `err`, `defect`
 - interop: `fromNullable`, `fromThrowable`, `fromPromise`, `fromSafePromise`
-- aggregate: `all` (first `Err` wins; any `Defect` dominates)
+- aggregate: `all` / `allAsync` (first `Err` wins; any `Defect` dominates). Both
+  are **tuple-or-array**: a fixed tuple keeps positional types, a dynamic
+  `Result<T, E>[]` / `AsyncResult<T, E>[]` collapses to `Result<T[], E>` /
+  `AsyncResult<T[], E>` with no cast. `allAsync` resolves its inputs concurrently
+  (order preserved) and never rejects.
 - facade: a `Result` companion object aliases the standalone entry points
-  (`Result.ok`/`err`/`defect`/`from*`/`all`/`is*`) for discoverability; the free
-  functions remain the primary, tree-shakeable API. One concept, two import
-  styles — not a second concept.
-- tagged errors: `TaggedError(tag)` (the error-class factory) and
-  `matchTags(result, handlers)` (an exhaustive `{ Ok, Defect } & per-tag` fold);
-  see the `TaggedError` convention in Thesis #4.
+  (`Result.ok`/`err`/`defect`/`from*`/`all`/`allAsync`/`is*`) for discoverability;
+  the free functions remain the primary, tree-shakeable API. One concept, two
+  import styles — not a second concept.
+- tagged errors: `TaggedError(tag, options?)` (the error-class factory; optional
+  `options.name` sets `Error.name` independently of the `_tag` discriminant, so a
+  tag can be namespaced for collision-safety without leaking into the display
+  name) and `matchTags(result, handlers)` (an exhaustive `{ Ok, Defect } &
+per-tag` fold; has an async overload resolving to `Promise<R>`); see the
+  `TaggedError` convention in Thesis #4.
 
 Deliberately **excluded** for now: `gen`/do-notation (heaviest possible
 addition; revisit only if sequential code demands it), accumulation/`Validation`,

--- a/docs/guide/core-concepts.md
+++ b/docs/guide/core-concepts.md
@@ -63,17 +63,22 @@ zero-cost alias (a separate export — `import { ok }` never pulls it in).
 ## Guards that narrow
 
 `isOk` / `isErr` / `isDefect` are type guards. After a successful guard, the
-relevant field becomes accessible:
+relevant field becomes accessible. They come in two styles that narrow
+identically — standalone functions and methods (the methods are `this is …`
+predicates):
 
 ```ts
 import { isOk, isErr } from "unthrown";
 
 const r: Result<number, string> = ok(7);
 
+// standalone function
 if (isOk(r)) {
   r.value; // number
 }
-if (isErr(r)) {
+
+// method — narrows too
+if (r.isErr()) {
   r.error; // string
 }
 ```
@@ -94,15 +99,27 @@ ok(1).match({ ok, err, defect }); // fold all three channels
 `Err` but **rethrow a `Defect`** — a defect is a bug, not an absent value. See
 [The Defect Channel](./the-defect-channel).
 
-## Aggregating: `all`
+## Aggregating: `all` / `allAsync`
 
-`all` collects a tuple of `Result`s into a `Result` of the tuple of values. The
-first `Err` short-circuits; any `Defect` dominates (even over an earlier `Err`):
+`all` collects `Result`s into a `Result` of all their values. The first `Err`
+short-circuits; any `Defect` dominates (even over an earlier `Err`). A fixed
+tuple keeps its positional types; a dynamic `Result<T, E>[]` collapses to
+`Result<T[], E>` with no cast:
 
 ```ts
-import { all, ok } from "unthrown";
+import { all, ok, type Result } from "unthrown";
 
-all([ok(1), ok("two"), ok(true)]).unwrap(); // [1, "two", true]
+all([ok(1), ok("two"), ok(true)]).unwrap(); // [1, "two", true] (typed [number, string, boolean])
+all([ok(1), ok(2)] as Result<number, never>[]).unwrap(); // number[]
+```
+
+`allAsync` is the asynchronous counterpart — same folding rules, inputs resolved
+concurrently (order preserved), and (like every `AsyncResult`) it never rejects:
+
+```ts
+import { allAsync, fromSafePromise } from "unthrown";
+
+const [a, b] = (await allAsync([fromSafePromise(loadA()), fromSafePromise(loadB())])).unwrap();
 ```
 
 → Continue to [The Defect Channel](./the-defect-channel).

--- a/docs/guide/tagged-errors.md
+++ b/docs/guide/tagged-errors.md
@@ -24,6 +24,23 @@ The class extends `Error` (so `instanceof Error` holds and stacks work), the
 `_tag` is authoritative (a payload can't overwrite it), and a `message` field in
 the payload is forwarded to `Error`.
 
+### Namespacing the tag without renaming the error
+
+`_tag` is the discriminant `matchTags` dispatches on; `Error.name` is the
+human-facing label in stack traces and logs. By default they're the same, but a
+second `options.name` argument decouples them — so you can namespace a tag for
+collision-safety without that prefix leaking into the display name:
+
+```ts
+class RetryableError extends TaggedError("@my-lib/RetryableError", {
+  name: "RetryableError",
+})<{ message: string }> {}
+
+const e = new RetryableError({ message: "boom" });
+e._tag; // "@my-lib/RetryableError" — namespaced discriminant
+e.name; // "RetryableError"          — clean stack-trace label
+```
+
 A tagged union of these makes a precise error type:
 
 ```ts

--- a/packages/core/src/aggregate.spec.ts
+++ b/packages/core/src/aggregate.spec.ts
@@ -23,8 +23,12 @@ describe("all", () => {
     expect(r.unwrap()).toEqual([1, "two", true]);
   });
 
-  it("returns Ok([]) for an empty tuple", () => {
-    expect(all([]).unwrap()).toEqual([]);
+  it("returns Ok([]) for an empty tuple, typed as the empty tuple (not never[])", () => {
+    const r = all([]);
+    // Compiles only if the empty input keeps tuple typing `Result<[], never>`
+    // rather than collapsing to `Result<never[], never>`.
+    const empty: Result<[], never> = r;
+    expect(empty.unwrap()).toEqual([]);
   });
 
   it("short-circuits on the first Err", () => {

--- a/packages/core/src/aggregate.spec.ts
+++ b/packages/core/src/aggregate.spec.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "vitest";
 
-import { all, err, ok, type Result } from "./index.js";
+import {
+  all,
+  allAsync,
+  type AsyncResult,
+  err,
+  fromPromise,
+  fromSafePromise,
+  ok,
+  type Result,
+} from "./index.js";
 
 const boom = new Error("boom");
 const defectOf = (cause: unknown): Result<number, never> =>
@@ -33,5 +42,61 @@ describe("all", () => {
     const first = new Error("first");
     const r = all([defectOf(first), defectOf(new Error("second"))]);
     expect(r.recoverDefect((c) => ok(c === first)).unwrap()).toBe(true);
+  });
+
+  it("collapses a dynamic Result[] to Result<T[], E> without a cast", () => {
+    // The array overload: no `as` needed, even in a generic-feeling shape.
+    const combine = <T, E>(rs: Result<T, E>[]): Result<T[], E> => all(rs);
+    const r = combine([ok(1), ok(2), ok(3)] as Result<number, string>[]);
+    expect(r.unwrap()).toEqual([1, 2, 3]);
+
+    const e = combine([ok(1), err("bad")] as Result<number, string>[]);
+    expect(e.unwrapErr()).toBe("bad");
+  });
+});
+
+describe("allAsync", () => {
+  it("collects a tuple of AsyncResult Ok values, preserving positional types", async () => {
+    const r = await allAsync([
+      fromSafePromise(Promise.resolve(1)),
+      fromSafePromise(Promise.resolve("two")),
+      fromSafePromise(Promise.resolve(true)),
+    ]);
+    expect(r.unwrap()).toEqual([1, "two", true]);
+  });
+
+  it("returns Ok([]) for an empty input", async () => {
+    expect((await allAsync([])).unwrap()).toEqual([]);
+  });
+
+  it("short-circuits on the first Err", async () => {
+    const r = await allAsync([
+      fromPromise(Promise.reject("first"), (c) => c as string),
+      fromPromise(Promise.reject("second"), (c) => c as string),
+    ]);
+    expect(r.unwrapErr()).toBe("first");
+  });
+
+  it("lets any Defect dominate, even over an earlier Err", async () => {
+    const r = await allAsync([
+      fromPromise(Promise.reject("e"), (c) => c as string),
+      fromSafePromise(Promise.reject(boom)),
+    ]);
+    expect(r.isDefect()).toBe(true);
+    expect((await r.toAsync().recoverDefect((c) => ok(c === boom))).unwrap()).toBe(true);
+  });
+
+  it("never rejects — await always yields a Result", async () => {
+    const r = await allAsync([fromSafePromise(Promise.reject(boom))]);
+    expect(r.isDefect()).toBe(true);
+  });
+
+  it("collapses a dynamic AsyncResult[] to AsyncResult<T[], E> without a cast", async () => {
+    const combine = <T, E>(rs: AsyncResult<T, E>[]): AsyncResult<T[], E> => allAsync(rs);
+    const r = await combine([
+      fromSafePromise(Promise.resolve(1)),
+      fromSafePromise(Promise.resolve(2)),
+    ]);
+    expect(r.unwrap()).toEqual([1, 2]);
   });
 });

--- a/packages/core/src/constructors.spec.ts
+++ b/packages/core/src/constructors.spec.ts
@@ -69,6 +69,36 @@ describe("standalone guards narrow and expose the relevant field", () => {
   });
 });
 
+describe("method guards narrow (parity with the standalone guards)", () => {
+  it("r.isOk() narrows to OkView and exposes value", () => {
+    const r: Result<number, string> = ok(7);
+    if (r.isOk()) {
+      // Only compiles because `.isOk()` is a `this is OkView` predicate.
+      expect(r.value).toBe(7);
+    } else {
+      expect.fail("expected Ok");
+    }
+  });
+
+  it("r.isErr() narrows to ErrView and exposes error", () => {
+    const r: Result<number, string> = err("bad");
+    if (r.isErr()) {
+      expect(r.error).toBe("bad");
+    } else {
+      expect.fail("expected Err");
+    }
+  });
+
+  it("r.isDefect() narrows to DefectView and exposes cause", () => {
+    const r: Result<number, string> = defectOf(boom);
+    if (r.isDefect()) {
+      expect(r.cause).toBe(boom);
+    } else {
+      expect.fail("expected Defect");
+    }
+  });
+});
+
 describe("UnwrapError", () => {
   it("carries the offending error and is an Error instance", () => {
     const e = new UnwrapError("payload");

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -200,13 +200,13 @@ class Res<T, E> {
     return undefined;
   }
 
-  isOk(this: Result<T, E>): boolean {
+  isOk(this: Result<T, E>): this is OkView<T, E> {
     return this.tag === "Ok";
   }
-  isErr(this: Result<T, E>): boolean {
+  isErr(this: Result<T, E>): this is ErrView<E, T> {
     return this.tag === "Err";
   }
-  isDefect(this: Result<T, E>): boolean {
+  isDefect(this: Result<T, E>): this is DefectView<T, E> {
     return this.tag === "Defect";
   }
 

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -6,7 +6,14 @@
 
 import { err, isDefect, isErr, isOk, ok } from "./constructors.js";
 import { defect } from "./defect.js";
-import { all, fromNullable, fromPromise, fromSafePromise, fromThrowable } from "./interop.js";
+import {
+  all,
+  allAsync,
+  fromNullable,
+  fromPromise,
+  fromSafePromise,
+  fromThrowable,
+} from "./interop.js";
 import type { Result as ResultType } from "./types.js";
 
 /**
@@ -14,7 +21,8 @@ import type { Result as ResultType } from "./types.js";
  * discoverable namespace: {@link Result.ok}, {@link Result.err},
  * {@link Result.defect}, {@link Result.fromNullable}, {@link Result.fromThrowable},
  * {@link Result.fromPromise}, {@link Result.fromSafePromise}, {@link Result.all},
- * {@link Result.isOk}, {@link Result.isErr}, {@link Result.isDefect}.
+ * {@link Result.allAsync}, {@link Result.isOk}, {@link Result.isErr},
+ * {@link Result.isDefect}.
  *
  * @remarks
  * Purely additive sugar — each member **is** the corresponding free function.
@@ -37,6 +45,7 @@ export const Result = {
   fromPromise,
   fromSafePromise,
   all,
+  allAsync,
   isOk,
   isErr,
   isDefect,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,9 +2,26 @@ export { err, isDefect, isErr, isOk, ok } from "./constructors.js";
 export { UnwrapError } from "./core.js";
 export { defect } from "./defect.js";
 export { Result } from "./facade.js";
-export { all, fromNullable, fromPromise, fromSafePromise, fromThrowable } from "./interop.js";
+export {
+  all,
+  allAsync,
+  fromNullable,
+  fromPromise,
+  fromSafePromise,
+  fromThrowable,
+} from "./interop.js";
 export { matchTags, TaggedError } from "./tagged.js";
 
 export type { Defect } from "./defect.js";
 export type { TaggedErrorConstructor, TaggedErrorInstance, TagHandlers } from "./tagged.js";
-export type { AsyncResult, Awaitable, DefectView, ErrOf, ErrView, OkOf, OkView } from "./types.js";
+export type {
+  AsyncErrOf,
+  AsyncOkOf,
+  AsyncResult,
+  Awaitable,
+  DefectView,
+  ErrOf,
+  ErrView,
+  OkOf,
+  OkView,
+} from "./types.js";

--- a/packages/core/src/interop.ts
+++ b/packages/core/src/interop.ts
@@ -142,19 +142,25 @@ function qualifyToResult<T, E>(
 
 /**
  * The success channel of {@link all} / {@link allAsync}: a **positional tuple**
- * for a fixed-length input, or a homogeneous **array** for a dynamic one.
+ * for a fixed-length input (including the empty tuple), or a homogeneous
+ * **array** for a dynamic one.
+ *
+ * @remarks
+ * The split keys off the input's `length`: a fixed tuple has a literal length
+ * (`number extends Rs["length"]` is false → keep the positional `Ts`), while a
+ * general array has `length: number` (→ collapse to `Ts[number][]`). Checking
+ * length rather than `Rs extends [unknown, ...unknown[]]` keeps `all([])` typed
+ * as `Result<[], …>` instead of `Result<never[], …>`.
  *
  * @typeParam Rs - the tuple/array of input `Result` types.
  * @typeParam Ts - per-element extracted success types (`OkOf` for `all`,
  * `AsyncOkOf` for `allAsync`).
  * @internal
  */
-type AllOk<Rs extends readonly unknown[], Ts extends readonly unknown[]> = Rs extends readonly [
-  unknown,
-  ...unknown[],
-]
-  ? Ts
-  : Ts[number][];
+type AllOk<
+  Rs extends readonly unknown[],
+  Ts extends readonly unknown[],
+> = number extends Rs["length"] ? Ts[number][] : Ts;
 
 /**
  * Collect {@link Result}s into a single `Result` of all their success values.

--- a/packages/core/src/interop.ts
+++ b/packages/core/src/interop.ts
@@ -5,7 +5,7 @@
 import { AsyncRes, defectRes, errRes, okRes } from "./core.js";
 import { type Defect, isDefectMarker } from "./defect.js";
 import { err, ok } from "./constructors.js";
-import type { AsyncResult, ErrOf, OkOf, Result } from "./types.js";
+import type { AsyncErrOf, AsyncOkOf, AsyncResult, ErrOf, OkOf, Result } from "./types.js";
 
 /**
  * Bridge a nullable value into a {@link Result}: absence becomes a **modeled**
@@ -141,27 +141,45 @@ function qualifyToResult<T, E>(
 }
 
 /**
- * Collect a tuple of {@link Result}s into a single `Result` of the tuple of
- * success values.
+ * The success channel of {@link all} / {@link allAsync}: a **positional tuple**
+ * for a fixed-length input, or a homogeneous **array** for a dynamic one.
+ *
+ * @typeParam Rs - the tuple/array of input `Result` types.
+ * @typeParam Ts - per-element extracted success types (`OkOf` for `all`,
+ * `AsyncOkOf` for `allAsync`).
+ * @internal
+ */
+type AllOk<Rs extends readonly unknown[], Ts extends readonly unknown[]> = Rs extends readonly [
+  unknown,
+  ...unknown[],
+]
+  ? Ts
+  : Ts[number][];
+
+/**
+ * Collect {@link Result}s into a single `Result` of all their success values.
  *
  * @remarks
  * Short-circuits on the **first** `Err` (later entries are not inspected for
  * their error); any `Defect` present **dominates**, winning even over an earlier
- * `Err`. Positional types are preserved, so `all([ok(1), ok("a")])` is
- * `Result<[number, string], …>`.
+ * `Err`. A **fixed tuple** keeps its positional types — `all([ok(1), ok("a")])`
+ * is `Result<[number, string], …>` — while a **dynamic array** `Result<T, E>[]`
+ * collapses to `Result<T[], E>` with no cast.
  *
- * @typeParam Rs - the tuple of input `Result` types.
+ * @typeParam Rs - the tuple/array of input `Result` types.
  * @param results - the results to combine.
  *
  * @example
  * ```ts
  * import { all, ok } from "unthrown";
- * all([ok(1), ok("a"), ok(true)]).unwrap(); // [1, "a", true]
+ * all([ok(1), ok("a"), ok(true)]).unwrap(); // [1, "a", true] (typed [number, string, boolean])
+ * all([ok(1), ok(2)] as Result<number, never>[]).unwrap(); // number[]
  * ```
  */
 export function all<Rs extends readonly Result<unknown, unknown>[]>(
   results: readonly [...Rs],
-): Result<{ [K in keyof Rs]: OkOf<Rs[K]> }, ErrOf<Rs[number]>> {
+): Result<AllOk<Rs, { [K in keyof Rs]: OkOf<Rs[K]> }>, ErrOf<Rs[number]>> {
+  type Out = Result<AllOk<Rs, { [K in keyof Rs]: OkOf<Rs[K]> }>, ErrOf<Rs[number]>>;
   const values: unknown[] = [];
   let firstErr: Result<unknown, unknown> | undefined;
   let firstDefect: Result<unknown, unknown> | undefined;
@@ -172,8 +190,41 @@ export function all<Rs extends readonly Result<unknown, unknown>[]>(
     else values.push(r.value);
   }
 
-  if (firstDefect)
-    return firstDefect as Result<{ [K in keyof Rs]: OkOf<Rs[K]> }, ErrOf<Rs[number]>>;
-  if (firstErr) return firstErr as Result<{ [K in keyof Rs]: OkOf<Rs[K]> }, ErrOf<Rs[number]>>;
-  return ok(values as { [K in keyof Rs]: OkOf<Rs[K]> });
+  if (firstDefect) return firstDefect as Out;
+  if (firstErr) return firstErr as Out;
+  return ok(values) as Out;
+}
+
+/**
+ * The asynchronous counterpart of {@link all}: combine {@link AsyncResult}s into
+ * one `AsyncResult` of all their success values.
+ *
+ * @remarks
+ * The inputs are resolved **concurrently** (their order is preserved); the
+ * resolved `Result`s are then folded with the same rules as {@link all} —
+ * first `Err` short-circuits, any `Defect` dominates. As ever, the returned
+ * `AsyncResult`'s internal promise never rejects. A **fixed tuple** keeps its
+ * positional types; a **dynamic array** `AsyncResult<T, E>[]` collapses to
+ * `AsyncResult<T[], E>`.
+ *
+ * @typeParam Rs - the tuple/array of input `AsyncResult` types.
+ * @param results - the async results to combine.
+ *
+ * @example
+ * ```ts
+ * import { allAsync, fromSafePromise } from "unthrown";
+ * const both = await allAsync([fromSafePromise(a()), fromSafePromise(b())]);
+ * ```
+ */
+export function allAsync<Rs extends readonly AsyncResult<unknown, unknown>[]>(
+  results: readonly [...Rs],
+): AsyncResult<AllOk<Rs, { [K in keyof Rs]: AsyncOkOf<Rs[K]> }>, AsyncErrOf<Rs[number]>> {
+  type Out = AsyncResult<AllOk<Rs, { [K in keyof Rs]: AsyncOkOf<Rs[K]> }>, AsyncErrOf<Rs[number]>>;
+  // Each AsyncResult is a (never-rejecting) thenable, so Promise.all adopts them
+  // and resolves to the ordered Results; `all` then folds them. The internal
+  // promise still never rejects.
+  const settled = Promise.all(results).then((resolved) =>
+    all(resolved as readonly Result<unknown, unknown>[]),
+  );
+  return new AsyncRes(settled) as unknown as Out;
 }

--- a/packages/core/src/tagged.spec.ts
+++ b/packages/core/src/tagged.spec.ts
@@ -48,6 +48,31 @@ describe("TaggedError", () => {
     const errors: ApiError[] = [new NotFound(), new Forbidden({ user: "a" })];
     expect(errors.map((e) => e._tag)).toEqual(["NotFound", "Forbidden"]);
   });
+
+  it("defaults Error.name to the tag", () => {
+    class Plain extends TaggedError("Plain") {}
+    expect(new Plain().name).toBe("Plain");
+  });
+
+  it("decouples Error.name from a namespaced _tag via options.name", () => {
+    class Retryable extends TaggedError("@my-lib/Retryable", { name: "Retryable" })<{
+      message: string;
+    }> {}
+    const e = new Retryable({ message: "boom" });
+    expect(e._tag).toBe("@my-lib/Retryable"); // namespaced discriminant
+    expect(e.name).toBe("Retryable"); // clean display name
+    expect(e.message).toBe("boom");
+  });
+
+  it("still dispatches on the namespaced _tag in matchTags", () => {
+    class Retryable extends TaggedError("@my-lib/Retryable", { name: "Retryable" }) {}
+    const out = matchTags(err(new Retryable()) as Result<number, Retryable>, {
+      Ok: (n) => `ok:${n}`,
+      Defect: () => "defect",
+      "@my-lib/Retryable": (e) => `retry:${e.name}`,
+    });
+    expect(out).toBe("retry:Retryable");
+  });
 });
 
 describe("matchTags", () => {

--- a/packages/core/src/tagged.ts
+++ b/packages/core/src/tagged.ts
@@ -39,8 +39,26 @@ export type TaggedErrorConstructor<Tag extends string> = {
  * field in the payload is forwarded to `Error`. The `_tag` always reflects
  * `tag` and cannot be overridden by the payload.
  *
+ * `_tag` is the discriminant used by {@link matchTags}; `Error.name` is the
+ * human-facing label in stack traces and logs. By default they coincide, but
+ * they can be **decoupled** with `options.name` — so a tag can be namespaced for
+ * collision-safety (`"@my-lib/RetryableError"`) without that slash-prefixed
+ * string leaking into `Error.name`:
+ *
+ * ```ts
+ * class RetryableError extends TaggedError("@my-lib/RetryableError", {
+ *   name: "RetryableError",
+ * })<{ message: string }> {}
+ *
+ * const e = new RetryableError({ message: "boom" });
+ * e._tag; // "@my-lib/RetryableError" — namespaced discriminant
+ * e.name; // "RetryableError"          — clean display name
+ * ```
+ *
  * @typeParam Tag - the string literal discriminant.
- * @param tag - the discriminant value, also used as the error `name`.
+ * @param tag - the discriminant value; also the default error `name`.
+ * @param options - optional overrides. `options.name` sets `Error.name`
+ * independently of `tag` (defaults to `tag`).
  *
  * @example
  * ```ts
@@ -51,7 +69,11 @@ export type TaggedErrorConstructor<Tag extends string> = {
  * new HttpError({ status: 500 }).status; // 500
  * ```
  */
-export function TaggedError<Tag extends string>(tag: Tag): TaggedErrorConstructor<Tag> {
+export function TaggedError<Tag extends string>(
+  tag: Tag,
+  options?: { readonly name?: string },
+): TaggedErrorConstructor<Tag> {
+  const displayName = options?.name ?? tag;
   class TaggedErrorBase extends Error {
     readonly _tag!: Tag;
 
@@ -59,9 +81,9 @@ export function TaggedError<Tag extends string>(tag: Tag): TaggedErrorConstructo
       super(typeof props?.["message"] === "string" ? (props["message"] as string) : undefined);
       if (props) Object.assign(this, props);
       // The tag is authoritative — assign it after the payload so it can't be
-      // clobbered, and set `name` for readable stack traces.
+      // clobbered. `name` is the display label, independent of the discriminant.
       (this as { _tag: Tag })._tag = tag;
-      this.name = tag;
+      this.name = displayName;
       Object.setPrototypeOf(this, new.target.prototype);
     }
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -174,12 +174,12 @@ export type ResultMethods<T, E> = {
    */
   getOrUndefined(): T | undefined;
 
-  /** Whether this result is `Ok`. */
-  isOk(): boolean;
-  /** Whether this result is `Err`. */
-  isErr(): boolean;
-  /** Whether this result is a `Defect`. */
-  isDefect(): boolean;
+  /** Whether this result is `Ok` — narrows `this` to its {@link OkView} on `true`. */
+  isOk(): this is OkView<T, E>;
+  /** Whether this result is `Err` — narrows `this` to its {@link ErrView} on `true`. */
+  isErr(): this is ErrView<E, T>;
+  /** Whether this result is a `Defect` — narrows `this` to its {@link DefectView} on `true`. */
+  isDefect(): this is DefectView<T, E>;
 
   /** Lift this synchronous `Result` into an {@link AsyncResult}. */
   toAsync(): AsyncResult<T, E>;
@@ -336,3 +336,15 @@ export type OkOf<R> = R extends { readonly tag: "Ok"; readonly value: infer T } 
  * @typeParam R - the `Result` type to inspect.
  */
 export type ErrOf<R> = R extends { readonly tag: "Err"; readonly error: infer E } ? E : never;
+/**
+ * Extract the success type `T` from an {@link AsyncResult}.
+ *
+ * @typeParam R - the `AsyncResult` type to inspect.
+ */
+export type AsyncOkOf<R> = R extends AsyncResult<infer T, unknown> ? T : never;
+/**
+ * Extract the error type `E` from an {@link AsyncResult}.
+ *
+ * @typeParam R - the `AsyncResult` type to inspect.
+ */
+export type AsyncErrOf<R> = R extends AsyncResult<unknown, infer E> ? E : never;

--- a/packages/core/typedoc.json
+++ b/packages/core/typedoc.json
@@ -2,5 +2,5 @@
   "extends": "@unthrown/typedoc/base.json",
   "entryPoints": ["src/index.ts"],
   "out": "docs",
-  "intentionallyNotExported": ["Result", "Props", "ResultMethods"]
+  "intentionallyNotExported": ["Result", "Props", "ResultMethods", "AllOk"]
 }


### PR DESCRIPTION
Resolves the open enhancement issues (#11, #12, #13). #14 was already implemented.

## #13 — `.isOk()` / `.isErr()` / `.isDefect()` now narrow
Retyped the three methods as `this is …` type predicates, so `if (r.isErr()) r.error` compiles. They now narrow identically to the standalone `isOk`/`isErr`/`isDefect` guards — collapsing the two parallel APIs and removing the boolean-only footgun for code coming from neverthrow. Runtime is unchanged (still returns a boolean).

## #12 — `allAsync` + tuple-or-array `all`
- New **`allAsync`**: combines `AsyncResult`s, resolved **concurrently** (order preserved), folded with the same rules as `all` (first `Err` wins, any `Defect` dominates). Like every `AsyncResult`, it never rejects.
- Both `all` and `allAsync` are now **tuple-or-array**: a fixed tuple keeps positional types, while a dynamic `Result<T, E>[]` / `AsyncResult<T, E>[]` collapses to `Result<T[], E>` / `AsyncResult<T[], E>` **with no cast** (the hand-rolled `combineAsync` helper + `as` from the issue are no longer needed).
- Adds the `AsyncOkOf` / `AsyncErrOf` type helpers; exports `allAsync` from the public API and the `Result` facade.

## #11 — `TaggedError` name decoupled from `_tag`
`TaggedError(tag, { name })` sets `Error.name` independently of the `_tag` discriminant, so a tag can be namespaced for collision-safety (`"@my-lib/RetryableError"`) without that slash-prefixed string leaking into stack traces and logs. Backward compatible — `name` defaults to `tag`.

## #14 — already shipped
`matchTags` already has the async overload (resolving to `Promise<R>`) and a test; no change needed. Can be closed.

## Tests & docs
- +13 tests (108 → **121**, all passing): method-guard narrowing, `TaggedError` name decoupling + namespaced-tag dispatch, and a full `allAsync` block + array-overload coverage.
- Updated `CLAUDE.md` (spec), the core-concepts guide (guards + aggregating), and the tagged-errors guide (namespacing section).
- Added a `unthrown` minor changeset.

## Gate — all green
`format --check`, `lint`, `knip`, `typecheck`, `test`, `build`, and core `build:docs` (typedoc-warning-free) all pass; core keeps **100% line/function coverage**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)