### PR TITLE
feat(core): subtract Defect from the qualify error channel

### DIFF
--- a/.changeset/qualify-subtracts-defect.md
+++ b/.changeset/qualify-subtracts-defect.md
@@ -1,0 +1,13 @@
+---
+"unthrown": minor
+---
+
+Stop `fromPromise` / `fromThrowable` from leaking `Defect` into the error
+channel. The modeled error type is now inferred as `Exclude<R, Defect>` (where
+`R` is `qualify`'s return type), so a `qualify` that returns only `defect(cause)`
+yields `AsyncResult<T, never>` / `Result<T, never>` instead of `…<T, Defect>` —
+a defect stays out-of-band and no longer pollutes downstream combinator types.
+Mixed `qualify`s keep exactly their modeled arm (e.g. `"not_found" | Defect` →
+`"not_found"`). Sound because `Defect` is `unique symbol`-branded, so no domain
+error is assignable to it. When every rejection is a defect, `fromSafePromise`
+remains the right primitive.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,11 +28,16 @@ was planned).
    nullable third-party APIs goes through `fromNullable`. Do not add `Option`.
 3. **Qualification is enforced at every boundary.** `fromPromise` / `fromThrowable`
    take a mandatory `qualify: (cause: unknown) => E | Defect`. There is no path
-   that produces `unknown` in `E`. The boundary forces a triage decision. This is
-   also why **`AsyncResult` combinator callbacks are synchronous** — a raw
-   `Promise` may never enter an `AsyncResult` method (its rejection would
-   silently become a defect, skipping the triage). Async work re-enters only
-   through `fromPromise` / `fromSafePromise` and composes via `flatMap`.
+   that produces `unknown` in `E`. The boundary forces a triage decision. The
+   modeled error type is inferred as **`Exclude<R, Defect>`** (where `R` is
+   `qualify`'s return type): the `Defect` arm is _subtracted_ from `E`, never
+   inferred into it — a defect-only `qualify` yields `E = never`, not
+   `E = Defect` (sound because `Defect` is `unique symbol`-branded, so no domain
+   error is assignable to it). This is also why **`AsyncResult` combinator
+   callbacks are synchronous** — a raw `Promise` may never enter an `AsyncResult`
+   method (its rejection would silently become a defect, skipping the triage).
+   Async work re-enters only through `fromPromise` / `fromSafePromise` and
+   composes via `flatMap`.
 4. **`TaggedError` is the error convention** (à la Effect's `Data.TaggedError`):
    a `_tag` discriminant on a class extending `Error`. Core `Result<T, E>` stays
    **generic in `E`** (unconstrained); only the tag-aware utilities require

--- a/docs/guide/boundaries.md
+++ b/docs/guide/boundaries.md
@@ -56,6 +56,12 @@ The boxed/neverthrow "original sin" is `fromPromise(p): AsyncResult<T, unknown>`
 `qualify` is mandatory, so **there is no code path that yields `unknown` in
 `E`**.
 
+The error channel is inferred as `Exclude<R, Defect>` — the `Defect` arm of
+`qualify`'s return is **subtracted**, never inferred into `E`. So a `qualify`
+that returns _only_ `defect(cause)` gives `AsyncResult<T, never>`, not
+`AsyncResult<T, Defect>` — a defect stays out-of-band. (When _every_ rejection is
+a defect, reach for `fromSafePromise` below.)
+
 ## `fromSafePromise` — when any rejection is a bug
 
 If a promise should never fail in a _modeled_ way — its rejection would be a bug,

--- a/packages/core/src/interop.spec.ts
+++ b/packages/core/src/interop.spec.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import { defect, fromNullable, fromThrowable, ok } from "./index.js";
+import {
+  type AsyncResult,
+  defect,
+  fromNullable,
+  fromPromise,
+  fromThrowable,
+  ok,
+  type Result,
+} from "./index.js";
 
 const boom = new Error("boom");
 
@@ -59,5 +67,41 @@ describe("fromThrowable", () => {
       },
     );
     expect(fn().isDefect()).toBe(true);
+  });
+
+  it("subtracts Defect from the error channel: a defect-only qualify yields E = never", () => {
+    const fn = fromThrowable(
+      (): number => 1,
+      (c) => defect(c),
+    );
+    // Compiles only if `E` is `never` — `Defect` must not leak into the channel.
+    const r: Result<number, never> = fn();
+    expect(r.unwrap()).toBe(1);
+  });
+
+  it("keeps the modeled arm while subtracting Defect: mixed qualify yields just E", () => {
+    const fn = fromThrowable(
+      (): number => 1,
+      (c) => (c === boom ? ("known" as const) : defect(c)),
+    );
+    const r: Result<number, "known"> = fn();
+    expect(r.unwrap()).toBe(1);
+  });
+});
+
+describe("fromPromise — error-channel inference", () => {
+  it("a defect-only qualify yields AsyncResult<T, never>", async () => {
+    const ar = fromPromise(Promise.reject(boom), (c) => defect(c));
+    const typed: AsyncResult<never, never> = ar;
+    expect((await typed).isDefect()).toBe(true);
+  });
+
+  it("a mixed qualify keeps only the modeled arm in E", async () => {
+    const ar = fromPromise(Promise.reject(boom), (c) =>
+      c === boom ? ("known" as const) : defect(c),
+    );
+    const typed: AsyncResult<never, "known"> = ar;
+    // `boom` matches the modeled arm, so it lands in Err — not a Defect.
+    expect((await typed).unwrapErr()).toBe("known");
   });
 });

--- a/packages/core/src/interop.ts
+++ b/packages/core/src/interop.ts
@@ -42,9 +42,15 @@ export function fromNullable<T, E>(
  * {@link Defect} (via {@link defect}) — there is no path that leaves `unknown`
  * in `E`. A throw inside `qualify` itself is treated as a `Defect`.
  *
+ * The modeled error type is `Exclude<R, Defect>` — the `Defect` arm of
+ * `qualify`'s return is **subtracted** from `E`, never inferred into it. So a
+ * `qualify` that returns *only* `defect(cause)` yields `E = never` (a defect is
+ * out-of-band and must not pollute the error channel); reach for
+ * {@link fromSafePromise} when every failure is a defect.
+ *
  * @typeParam A - the wrapped function's argument tuple.
  * @typeParam T - the wrapped function's return type.
- * @typeParam E - the modeled error type.
+ * @typeParam R - `qualify`'s return type (`E | Defect`); `E` is `Exclude<R, Defect>`.
  * @param fn - the throwing function to wrap.
  * @param qualify - triages a thrown cause into `E` or a `Defect`.
  * @returns a function with the same arguments returning `Result<T, E>`.
@@ -56,15 +62,17 @@ export function fromNullable<T, E>(
  * parse("{}").unwrap();
  * ```
  */
-export function fromThrowable<A extends unknown[], T, E>(
+export function fromThrowable<A extends unknown[], T, R>(
   fn: (...args: A) => T,
-  qualify: (cause: unknown) => E | Defect,
-): (...args: A) => Result<T, E> {
+  qualify: (cause: unknown) => R,
+): (...args: A) => Result<T, Exclude<R, Defect>> {
+  type E = Exclude<R, Defect>;
+  const triage = qualify as (cause: unknown) => E | Defect;
   return (...args: A): Result<T, E> => {
     try {
       return ok(fn(...args)) as Result<T, E>;
     } catch (cause) {
-      return qualifyToResult<T, E>(cause, qualify);
+      return qualifyToResult<T, E>(cause, triage);
     }
   };
 }
@@ -79,8 +87,13 @@ export function fromThrowable<A extends unknown[], T, E>(
  * `await`-ing it always yields a `Result`. A throw inside `qualify` is itself a
  * `Defect`.
  *
+ * The modeled error type is `Exclude<R, Defect>` — the `Defect` arm of
+ * `qualify`'s return is **subtracted** from `E`, never inferred into it. So a
+ * `qualify` that returns *only* `defect(cause)` yields `E = never`; when every
+ * rejection is a defect, prefer {@link fromSafePromise}.
+ *
  * @typeParam T - the resolved value type.
- * @typeParam E - the modeled error type.
+ * @typeParam R - `qualify`'s return type (`E | Defect`); `E` is `Exclude<R, Defect>`.
  * @param promise - the promise, or a thunk returning one.
  * @param qualify - triages a rejection cause into `E` or a `Defect`.
  *
@@ -92,14 +105,16 @@ export function fromThrowable<A extends unknown[], T, E>(
  * );
  * ```
  */
-export function fromPromise<T, E>(
+export function fromPromise<T, R>(
   promise: Promise<T> | (() => Promise<T>),
-  qualify: (cause: unknown) => E | Defect,
-): AsyncResult<T, E> {
+  qualify: (cause: unknown) => R,
+): AsyncResult<T, Exclude<R, Defect>> {
+  type E = Exclude<R, Defect>;
+  const triage = qualify as (cause: unknown) => E | Defect;
   const p = typeof promise === "function" ? Promise.resolve().then(promise) : promise;
   const settled: Promise<Result<T, E>> = p.then(
     (value) => okRes<T, E>(value),
-    (cause) => qualifyToResult<T, E>(cause, qualify),
+    (cause) => qualifyToResult<T, E>(cause, triage),
   );
   return new AsyncRes<T, E>(settled);
 }

--- a/packages/core/src/interop.ts
+++ b/packages/core/src/interop.ts
@@ -50,7 +50,8 @@ export function fromNullable<T, E>(
  *
  * @typeParam A - the wrapped function's argument tuple.
  * @typeParam T - the wrapped function's return type.
- * @typeParam R - `qualify`'s return type (`E | Defect`); `E` is `Exclude<R, Defect>`.
+ * @typeParam R - `qualify`'s return type; the modeled error `E` is
+ * `Exclude<R, Defect>` (its `Defect` arm, if any, is subtracted).
  * @param fn - the throwing function to wrap.
  * @param qualify - triages a thrown cause into `E` or a `Defect`.
  * @returns a function with the same arguments returning `Result<T, E>`.
@@ -93,7 +94,8 @@ export function fromThrowable<A extends unknown[], T, R>(
  * rejection is a defect, prefer {@link fromSafePromise}.
  *
  * @typeParam T - the resolved value type.
- * @typeParam R - `qualify`'s return type (`E | Defect`); `E` is `Exclude<R, Defect>`.
+ * @typeParam R - `qualify`'s return type; the modeled error `E` is
+ * `Exclude<R, Defect>` (its `Defect` arm, if any, is subtracted).
  * @param promise - the promise, or a thunk returning one.
  * @param qualify - triages a rejection cause into `E` or a `Defect`.
  *

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -178,9 +178,9 @@ function resultToEffect<T, E>(result: Result<T, E>): Effect.Effect<T, E> {
 // unthrown; replaying it through the throwable boundary lands it in the `Defect`
 // state — the sanctioned (boundary-only) way to mint a defect `Result`.
 function dieToResult<T, E>(cause: unknown): Result<T, E> {
-  return fromThrowable<[], never, never>((): never => {
+  return fromThrowable((): never => {
     throw cause;
-  }, defect)();
+  }, defect)() as Result<T, E>;
 }
 
 function settle<T, E>(asyncResult: AsyncResult<T, E>): Promise<Result<T, E>> {

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -178,7 +178,9 @@ function resultToEffect<T, E>(result: Result<T, E>): Effect.Effect<T, E> {
 // unthrown; replaying it through the throwable boundary lands it in the `Defect`
 // state — the sanctioned (boundary-only) way to mint a defect `Result`.
 function dieToResult<T, E>(cause: unknown): Result<T, E> {
-  return fromThrowable((): never => {
+  // The thunk always throws, so its `T` return is honest; `qualify` is `defect`,
+  // so the modeled error is `never` — widened to `E` here (there is no `Err`).
+  return fromThrowable((): T => {
     throw cause;
   }, defect)() as Result<T, E>;
 }


### PR DESCRIPTION
Closes #15.

## Problem
`fromPromise` / `fromThrowable` inferred the modeled error `E` from `qualify`'s full `E | Defect` return. When a `qualify` returned **only** `defect(cause)`, nothing constrained `E`, so the opaque `Defect` marker leaked into the error channel — `AsyncResult<T, Defect>` instead of `AsyncResult<T, never>` — and polluted every downstream combinator type. The resulting `E | Defect`-not-assignable-to-`E` error also pointed at the wrong place.

## Fix
Infer the modeled error as **`Exclude<R, Defect>`**, where `R` is `qualify`'s return type — the `Defect` arm is *subtracted* from `E`, never inferred into it:

| `qualify` returns | `E` before | `E` after |
|---|---|---|
| `defect(c)` only | `Defect` (leaked) | `never` |
| `"not_found" \| Defect` | `"not_found" \| Defect` | `"not_found"` |
| `"not_found"` only | `"not_found"` | `"not_found"` |

Sound because `Defect` is `unique symbol`-branded, so no domain error is assignable to it (`Exclude` can't over-subtract). The boundary still routes each cause via `isDefectMarker` at runtime — unchanged.

The issue's repro now type-checks:
```ts
function makeAsyncResult<T, E>(work: () => Promise<Result<T, E>>): AsyncResult<T, E> {
  return fromPromise(work, (cause) => defect(cause)).flatMap((inner) => inner); // ✅
}
```

`fromSafePromise` remains the right primitive when *every* rejection is a defect.

## Notes
- The signature's third type param changes meaning (`E` → `R` = qualify's return). The only in-repo explicit-type-arg caller — `@unthrown/effect`'s `dieToResult` — is updated to infer.
- Tests: added `fromThrowable`/`fromPromise` cases asserting `E = never` for a defect-only qualify and the modeled arm for a mixed one.
- Docs: `boundaries.md` note + `CLAUDE.md` Thesis #3. Minor changeset.

## Gate
`format --check`, `lint`, `knip`, `typecheck`, `test`, `build`, core `build:docs` (typedoc-warning-free) all green; core keeps **100% line/function coverage**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)