### PR TITLE
fix(ci): strip trailing whitespace from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,4 +29,3 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
-    


### PR DESCRIPTION
The **Format** job on `main` is red ([run 28250988066](https://github.com/btravstack/unthrown/actions/runs/28250988066)): `.github/dependabot.yml` (added in the Dependabot config commit) had a trailing-whitespace line that `oxfmt --check` rejects.

This removes that line so `pnpm format --check` passes. No other changes; the rest of the CI matrix was already green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)