### PR TITLE
feat(core): accept a record in all() / allAsync()

### DIFF
--- a/.changeset/object-shaped-all.md
+++ b/.changeset/object-shaped-all.md
@@ -1,0 +1,9 @@
+---
+"unthrown": minor
+---
+
+`all` and `allAsync` now accept a **record** in addition to a tuple/array. The
+output mirrors the input shape, so `all({ id: ok(1), name: ok("ada") })` is
+`Result<{ id: number; name: string }, never>` — named parallel work without
+tupling. The folding rules are unchanged (first `Err` short-circuits, any
+`Defect` dominates); this is not error accumulation.

--- a/.changeset/object-shaped-all.md
+++ b/.changeset/object-shaped-all.md
@@ -2,8 +2,11 @@
 "unthrown": minor
 ---
 
-`all` and `allAsync` now accept a **record** in addition to a tuple/array. The
-output mirrors the input shape, so `all({ id: ok(1), name: ok("ada") })` is
-`Result<{ id: number; name: string }, never>` — named parallel work without
-tupling. The folding rules are unchanged (first `Err` short-circuits, any
-`Defect` dominates); this is not error accumulation.
+Add `allFromDict` and `allFromDictAsync` — record-shaped aggregators that collect
+a `{ a: Result<A, E>, b: Result<B, E> }` into a `Result<{ a: A; b: B }, E>` (and
+the `AsyncResult` counterpart), for named parallel work without tupling. Kept as
+**separate functions** from the tuple/array-shaped `all` / `allAsync` (positional
+vs named is a distinct concept), which are unchanged. The folding rules are the
+same — first `Err` short-circuits, any `Defect` dominates; this is not error
+accumulation. The record fold writes keys via `Object.defineProperty`, so a
+caller-supplied `"__proto__"` key can't pollute the prototype.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,17 +93,20 @@ async work re-enters via `fromPromise` / `fromSafePromise` and composes with
   One narrowing concept, two call styles.
 - constructors: `ok`, `err`, `defect`
 - interop: `fromNullable`, `fromThrowable`, `fromPromise`, `fromSafePromise`
-- aggregate: `all` / `allAsync` (first `Err` wins; any `Defect` dominates). Both
-  are **tuple-, array-, or record-shaped**, and the output mirrors the input: a
-  fixed tuple keeps positional types, a dynamic `Result<T, E>[]` /
-  `AsyncResult<T, E>[]` collapses to `Result<T[], E>` / `AsyncResult<T[], E>`, and
-  a record `{ a: Result<A, E>, b: Result<B, E> }` becomes `Result<{ a: A; b: B },
-E>` (named parallel work, no tupling). All forms still short-circuit on the
-  first `Err`; `allAsync` resolves its inputs concurrently (order preserved) and
-  never rejects. Note this is **not** error accumulation (still first-`Err`-wins)
-  — accumulation stays deliberately excluded.
+- aggregate: `all` / `allAsync` take a **tuple/array** (a fixed tuple keeps
+  positional types; a dynamic `Result<T, E>[]` / `AsyncResult<T, E>[]` collapses
+  to `Result<T[], E>` / `AsyncResult<T[], E>`), while `allFromDict` /
+  `allFromDictAsync` take a **record** keyed by name (`{ a: Result<A, E> }` →
+  `Result<{ a: A }, E>`) — named parallel work without tupling. Array and record
+  are **separate functions**, not one overload (positional vs named is a distinct
+  concept). All four short-circuit on the first `Err`, let any `Defect` dominate,
+  and are **not** error accumulation (which stays deliberately excluded);
+  `allAsync` / `allFromDictAsync` resolve concurrently (order preserved) and never
+  reject. The record fold writes keys via `Object.defineProperty`, so a
+  caller-supplied `"__proto__"` key can't pollute the prototype.
 - facade: a `Result` companion object aliases the standalone entry points
-  (`Result.ok`/`err`/`defect`/`from*`/`all`/`allAsync`/`is*`) for discoverability;
+  (`Result.ok`/`err`/`defect`/`from*`/`all`/`allAsync`/`allFromDict`/`allFromDictAsync`/`is*`)
+  for discoverability;
   the free functions remain the primary, tree-shakeable API. One concept, two
   import styles — not a second concept.
 - tagged errors: `TaggedError(tag, options?)` (the error-class factory; optional

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,10 +94,14 @@ async work re-enters via `fromPromise` / `fromSafePromise` and composes with
 - constructors: `ok`, `err`, `defect`
 - interop: `fromNullable`, `fromThrowable`, `fromPromise`, `fromSafePromise`
 - aggregate: `all` / `allAsync` (first `Err` wins; any `Defect` dominates). Both
-  are **tuple-or-array**: a fixed tuple keeps positional types, a dynamic
-  `Result<T, E>[]` / `AsyncResult<T, E>[]` collapses to `Result<T[], E>` /
-  `AsyncResult<T[], E>` with no cast. `allAsync` resolves its inputs concurrently
-  (order preserved) and never rejects.
+  are **tuple-, array-, or record-shaped**, and the output mirrors the input: a
+  fixed tuple keeps positional types, a dynamic `Result<T, E>[]` /
+  `AsyncResult<T, E>[]` collapses to `Result<T[], E>` / `AsyncResult<T[], E>`, and
+  a record `{ a: Result<A, E>, b: Result<B, E> }` becomes `Result<{ a: A; b: B },
+E>` (named parallel work, no tupling). All forms still short-circuit on the
+  first `Err`; `allAsync` resolves its inputs concurrently (order preserved) and
+  never rejects. Note this is **not** error accumulation (still first-`Err`-wins)
+  — accumulation stays deliberately excluded.
 - facade: a `Result` companion object aliases the standalone entry points
   (`Result.ok`/`err`/`defect`/`from*`/`all`/`allAsync`/`is*`) for discoverability;
   the free functions remain the primary, tree-shakeable API. One concept, two

--- a/docs/guide/core-concepts.md
+++ b/docs/guide/core-concepts.md
@@ -102,16 +102,22 @@ ok(1).match({ ok, err, defect }); // fold all three channels
 ## Aggregating: `all` / `allAsync`
 
 `all` collects `Result`s into a `Result` of all their values. The first `Err`
-short-circuits; any `Defect` dominates (even over an earlier `Err`). A fixed
-tuple keeps its positional types; a dynamic `Result<T, E>[]` collapses to
-`Result<T[], E>` with no cast:
+short-circuits; any `Defect` dominates (even over an earlier `Err`). The output
+mirrors the input shape — a fixed tuple keeps its positional types, a dynamic
+`Result<T, E>[]` collapses to `Result<T[], E>`, and a **record** becomes a record
+of values (handy for named parallel work, no tupling):
 
 ```ts
 import { all, ok, type Result } from "unthrown";
 
 all([ok(1), ok("two"), ok(true)]).unwrap(); // [1, "two", true] (typed [number, string, boolean])
 all([ok(1), ok(2)] as Result<number, never>[]).unwrap(); // number[]
+all({ id: ok(1), name: ok("ada") }).unwrap(); // { id: 1, name: "ada" }
 ```
+
+This short-circuits on the first `Err` — it is **not** error accumulation. If you
+need every failure collected, that is a separate (deliberately unshipped)
+concern.
 
 `allAsync` is the asynchronous counterpart — same folding rules, inputs resolved
 concurrently (order preserved), and (like every `AsyncResult`) it never rejects:

--- a/docs/guide/core-concepts.md
+++ b/docs/guide/core-concepts.md
@@ -99,28 +99,36 @@ ok(1).match({ ok, err, defect }); // fold all three channels
 `Err` but **rethrow a `Defect`** — a defect is a bug, not an absent value. See
 [The Defect Channel](./the-defect-channel).
 
-## Aggregating: `all` / `allAsync`
+## Aggregating: `all` / `allFromDict`
 
-`all` collects `Result`s into a `Result` of all their values. The first `Err`
-short-circuits; any `Defect` dominates (even over an earlier `Err`). The output
-mirrors the input shape — a fixed tuple keeps its positional types, a dynamic
-`Result<T, E>[]` collapses to `Result<T[], E>`, and a **record** becomes a record
-of values (handy for named parallel work, no tupling):
+`all` collects a **tuple/array** of `Result`s into a `Result` of all their
+values. The first `Err` short-circuits; any `Defect` dominates (even over an
+earlier `Err`). A fixed tuple keeps its positional types; a dynamic
+`Result<T, E>[]` collapses to `Result<T[], E>`:
 
 ```ts
 import { all, ok, type Result } from "unthrown";
 
 all([ok(1), ok("two"), ok(true)]).unwrap(); // [1, "two", true] (typed [number, string, boolean])
 all([ok(1), ok(2)] as Result<number, never>[]).unwrap(); // number[]
-all({ id: ok(1), name: ok("ada") }).unwrap(); // { id: 1, name: "ada" }
 ```
 
-This short-circuits on the first `Err` — it is **not** error accumulation. If you
-need every failure collected, that is a separate (deliberately unshipped)
+For **named** parallel work, `allFromDict` takes a record instead — same rules,
+no tupling:
+
+```ts
+import { allFromDict, ok } from "unthrown";
+
+allFromDict({ id: ok(1), name: ok("ada") }).unwrap(); // { id: 1, name: "ada" }
+```
+
+Both short-circuit on the first `Err` — this is **not** error accumulation. If
+you need every failure collected, that is a separate (deliberately unshipped)
 concern.
 
-`allAsync` is the asynchronous counterpart — same folding rules, inputs resolved
-concurrently (order preserved), and (like every `AsyncResult`) it never rejects:
+`allAsync` and `allFromDictAsync` are the asynchronous counterparts — same
+folding rules, inputs resolved concurrently (order preserved), and (like every
+`AsyncResult`) they never reject:
 
 ```ts
 import { allAsync, fromSafePromise } from "unthrown";

--- a/packages/core/src/aggregate.spec.ts
+++ b/packages/core/src/aggregate.spec.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import {
   all,
   allAsync,
+  allFromDict,
+  allFromDictAsync,
   type AsyncResult,
   err,
   fromPromise,
@@ -57,23 +59,32 @@ describe("all", () => {
     const e = combine([ok(1), err("bad")] as Result<number, string>[]);
     expect(e.unwrapErr()).toBe("bad");
   });
+});
 
+describe("allFromDict", () => {
   it("collects a record of Ok values into a record, keyed by name", () => {
-    const r = all({ id: ok(1), name: ok("ada"), admin: ok(true) });
+    const r = allFromDict({ id: ok(1), name: ok("ada"), admin: ok(true) });
     // Typed `Result<{ id: number; name: string; admin: boolean }, never>`.
     const value: { id: number; name: string; admin: boolean } = r.unwrap();
     expect(value).toEqual({ id: 1, name: "ada", admin: true });
   });
 
   it("short-circuits a record on the first Err and lets a Defect dominate", () => {
-    expect(all({ a: ok(1), b: err("bad") }).unwrapErr()).toBe("bad");
-    const d = all({ a: ok(1), b: err("e"), c: defectOf(boom) });
+    expect(allFromDict({ a: ok(1), b: err("bad") }).unwrapErr()).toBe("bad");
+    const d = allFromDict({ a: ok(1), b: err("e"), c: defectOf(boom) });
     expect(d.isDefect()).toBe(true);
     expect(d.recoverDefect((c) => ok(c === boom)).unwrap()).toBe(true);
   });
 
   it("returns Ok({}) for an empty record", () => {
-    expect(all({}).unwrap()).toEqual({});
+    expect(allFromDict({}).unwrap()).toEqual({});
+  });
+
+  it("does not let a `__proto__` key pollute the prototype", () => {
+    const r = allFromDict({ ["__proto__"]: ok({ polluted: true }), safe: ok(1) });
+    expect(r.isOk()).toBe(true);
+    // The dangerous key lands as a normal own property, not on Object.prototype.
+    expect(({} as Record<string, unknown>)["polluted"]).toBeUndefined();
   });
 });
 
@@ -121,9 +132,11 @@ describe("allAsync", () => {
     ]);
     expect(r.unwrap()).toEqual([1, 2]);
   });
+});
 
+describe("allFromDictAsync", () => {
   it("collects a record of AsyncResults into a record, keyed by name", async () => {
-    const r = await allAsync({
+    const r = await allFromDictAsync({
       id: fromSafePromise(Promise.resolve(1)),
       name: fromSafePromise(Promise.resolve("ada")),
     });
@@ -132,10 +145,22 @@ describe("allAsync", () => {
   });
 
   it("short-circuits a record on the first Err", async () => {
-    const r = await allAsync({
+    const r = await allFromDictAsync({
       a: fromSafePromise(Promise.resolve(1)),
       b: fromPromise(Promise.reject("bad"), (c) => c as string),
     });
     expect(r.unwrapErr()).toBe("bad");
+  });
+
+  it("lets any Defect dominate over an earlier Err", async () => {
+    const r = await allFromDictAsync({
+      a: fromPromise(Promise.reject("e"), (c) => c as string),
+      b: fromSafePromise(Promise.reject(boom)),
+    });
+    expect(r.isDefect()).toBe(true);
+  });
+
+  it("returns Ok({}) for an empty record", async () => {
+    expect((await allFromDictAsync({})).unwrap()).toEqual({});
   });
 });

--- a/packages/core/src/aggregate.spec.ts
+++ b/packages/core/src/aggregate.spec.ts
@@ -57,6 +57,24 @@ describe("all", () => {
     const e = combine([ok(1), err("bad")] as Result<number, string>[]);
     expect(e.unwrapErr()).toBe("bad");
   });
+
+  it("collects a record of Ok values into a record, keyed by name", () => {
+    const r = all({ id: ok(1), name: ok("ada"), admin: ok(true) });
+    // Typed `Result<{ id: number; name: string; admin: boolean }, never>`.
+    const value: { id: number; name: string; admin: boolean } = r.unwrap();
+    expect(value).toEqual({ id: 1, name: "ada", admin: true });
+  });
+
+  it("short-circuits a record on the first Err and lets a Defect dominate", () => {
+    expect(all({ a: ok(1), b: err("bad") }).unwrapErr()).toBe("bad");
+    const d = all({ a: ok(1), b: err("e"), c: defectOf(boom) });
+    expect(d.isDefect()).toBe(true);
+    expect(d.recoverDefect((c) => ok(c === boom)).unwrap()).toBe(true);
+  });
+
+  it("returns Ok({}) for an empty record", () => {
+    expect(all({}).unwrap()).toEqual({});
+  });
 });
 
 describe("allAsync", () => {
@@ -102,5 +120,22 @@ describe("allAsync", () => {
       fromSafePromise(Promise.resolve(2)),
     ]);
     expect(r.unwrap()).toEqual([1, 2]);
+  });
+
+  it("collects a record of AsyncResults into a record, keyed by name", async () => {
+    const r = await allAsync({
+      id: fromSafePromise(Promise.resolve(1)),
+      name: fromSafePromise(Promise.resolve("ada")),
+    });
+    const value: { id: number; name: string } = r.unwrap();
+    expect(value).toEqual({ id: 1, name: "ada" });
+  });
+
+  it("short-circuits a record on the first Err", async () => {
+    const r = await allAsync({
+      a: fromSafePromise(Promise.resolve(1)),
+      b: fromPromise(Promise.reject("bad"), (c) => c as string),
+    });
+    expect(r.unwrapErr()).toBe("bad");
   });
 });

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -9,6 +9,8 @@ import { defect } from "./defect.js";
 import {
   all,
   allAsync,
+  allFromDict,
+  allFromDictAsync,
   fromNullable,
   fromPromise,
   fromSafePromise,
@@ -21,7 +23,8 @@ import type { Result as ResultType } from "./types.js";
  * discoverable namespace: {@link Result.ok}, {@link Result.err},
  * {@link Result.defect}, {@link Result.fromNullable}, {@link Result.fromThrowable},
  * {@link Result.fromPromise}, {@link Result.fromSafePromise}, {@link Result.all},
- * {@link Result.allAsync}, {@link Result.isOk}, {@link Result.isErr},
+ * {@link Result.allAsync}, {@link Result.allFromDict},
+ * {@link Result.allFromDictAsync}, {@link Result.isOk}, {@link Result.isErr},
  * {@link Result.isDefect}.
  *
  * @remarks
@@ -46,6 +49,8 @@ export const Result = {
   fromSafePromise,
   all,
   allAsync,
+  allFromDict,
+  allFromDictAsync,
   isOk,
   isErr,
   isDefect,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,8 @@ export { Result } from "./facade.js";
 export {
   all,
   allAsync,
+  allFromDict,
+  allFromDictAsync,
   fromNullable,
   fromPromise,
   fromSafePromise,

--- a/packages/core/src/interop.ts
+++ b/packages/core/src/interop.ts
@@ -179,123 +179,162 @@ type AllOk<
   Ts extends readonly unknown[],
 > = number extends Rs["length"] ? Ts[number][] : Ts;
 
-/** A record of `Result`s, the input to the object form of {@link all}. */
+/** A record of `Result`s — the input to {@link allFromDict}. */
 type ResultRecord = Record<string, Result<unknown, unknown>>;
-/** A record of `AsyncResult`s, the input to the object form of {@link allAsync}. */
+/** A record of `AsyncResult`s — the input to {@link allFromDictAsync}. */
 type AsyncResultRecord = Record<string, AsyncResult<unknown, unknown>>;
 
 /**
- * Fold an array **or** a record of already-settled `Result`s with the
- * `all`/`allAsync` rules: first `Err` wins, any `Defect` dominates. Returns an
- * `Ok` of the same shape (array → array, record → record) on full success.
+ * Fold an array of settled `Result`s: first `Err` wins, any `Defect` dominates,
+ * else `Ok` of the values array.
  *
  * @internal
  */
-function foldAll(
-  results: readonly Result<unknown, unknown>[] | ResultRecord,
-): Result<unknown, unknown> {
+function foldArray(results: readonly Result<unknown, unknown>[]): Result<unknown, unknown> {
   let firstErr: Result<unknown, unknown> | undefined;
   let firstDefect: Result<unknown, unknown> | undefined;
-
-  if (Array.isArray(results)) {
-    const values: unknown[] = [];
-    for (const r of results) {
-      if (r.tag === "Defect") firstDefect ??= r;
-      else if (r.tag === "Err") firstErr ??= r;
-      else values.push(r.value);
-    }
-    return firstDefect ?? firstErr ?? ok(values);
-  }
-
-  const values: Record<string, unknown> = {};
-  for (const [key, r] of Object.entries(results)) {
+  const values: unknown[] = [];
+  for (const r of results) {
     if (r.tag === "Defect") firstDefect ??= r;
     else if (r.tag === "Err") firstErr ??= r;
-    else values[key] = r.value;
+    else values.push(r.value);
   }
   return firstDefect ?? firstErr ?? ok(values);
 }
 
 /**
- * Collect {@link Result}s into a single `Result` of all their success values —
- * from a tuple, an array, or a **record**.
+ * Fold a record of settled `Result`s with the same rules, else `Ok` of the
+ * record of values. Keys are written with `Object.defineProperty` so a
+ * caller-supplied `"__proto__"` key cannot pollute the prototype.
+ *
+ * @internal
+ */
+function foldRecord(results: ResultRecord): Result<unknown, unknown> {
+  let firstErr: Result<unknown, unknown> | undefined;
+  let firstDefect: Result<unknown, unknown> | undefined;
+  const values: Record<string, unknown> = {};
+  for (const [key, r] of Object.entries(results)) {
+    if (r.tag === "Defect") firstDefect ??= r;
+    else if (r.tag === "Err") firstErr ??= r;
+    else
+      Object.defineProperty(values, key, {
+        value: r.value,
+        enumerable: true,
+        writable: true,
+        configurable: true,
+      });
+  }
+  return firstDefect ?? firstErr ?? ok(values);
+}
+
+/**
+ * Collect a tuple/array of {@link Result}s into a single `Result` of all their
+ * success values.
  *
  * @remarks
  * Short-circuits on the **first** `Err` (later entries are not inspected for
  * their error); any `Defect` present **dominates**, winning even over an earlier
- * `Err`. The output mirrors the input shape:
- *
- * - a **fixed tuple** keeps its positional types — `all([ok(1), ok("a")])` is
- *   `Result<[number, string], …>`;
- * - a **dynamic array** `Result<T, E>[]` collapses to `Result<T[], E>`;
- * - a **record** `{ a: Result<A, E>, b: Result<B, E> }` becomes
- *   `Result<{ a: A; b: B }, E>` — handy for named parallel work, no tupling.
+ * `Err`. A **fixed tuple** keeps its positional types — `all([ok(1), ok("a")])`
+ * is `Result<[number, string], …>` — while a **dynamic array** `Result<T, E>[]`
+ * collapses to `Result<T[], E>` with no cast. For a **record** keyed by name,
+ * use {@link allFromDict}.
  *
  * @example
  * ```ts
  * import { all, ok } from "unthrown";
  * all([ok(1), ok("a"), ok(true)]).unwrap(); // [1, "a", true] (typed [number, string, boolean])
  * all([ok(1), ok(2)] as Result<number, never>[]).unwrap(); // number[]
- * all({ id: ok(1), name: ok("ada") }).unwrap(); // { id: 1, name: "ada" }
  * ```
  */
 export function all<Rs extends readonly Result<unknown, unknown>[]>(
   results: readonly [...Rs],
-): Result<AllOk<Rs, { [K in keyof Rs]: OkOf<Rs[K]> }>, ErrOf<Rs[number]>>;
-export function all<R extends ResultRecord>(
-  results: R,
-): Result<{ [K in keyof R]: OkOf<R[K]> }, ErrOf<R[keyof R]>>;
-export function all(
-  results: readonly Result<unknown, unknown>[] | ResultRecord,
-): Result<unknown, unknown> {
-  return foldAll(results);
+): Result<AllOk<Rs, { [K in keyof Rs]: OkOf<Rs[K]> }>, ErrOf<Rs[number]>> {
+  return foldArray(results) as Result<
+    AllOk<Rs, { [K in keyof Rs]: OkOf<Rs[K]> }>,
+    ErrOf<Rs[number]>
+  >;
 }
 
 /**
- * The asynchronous counterpart of {@link all}: combine {@link AsyncResult}s into
- * one `AsyncResult` of all their success values — from a tuple, an array, or a
- * **record**.
+ * Collect a **record** of {@link Result}s into a single `Result` of a record of
+ * their success values — `allFromDict({ a: Result<A, E>, b: Result<B, E> })` is
+ * `Result<{ a: A; b: B }, E>`. The named counterpart of {@link all}, for
+ * parallel work you'd rather not tuple.
+ *
+ * @remarks
+ * Same folding rules as {@link all}: first `Err` short-circuits, any `Defect`
+ * dominates. This is **not** error accumulation.
+ *
+ * @example
+ * ```ts
+ * import { allFromDict, ok } from "unthrown";
+ * allFromDict({ id: ok(1), name: ok("ada") }).unwrap(); // { id: 1, name: "ada" }
+ * ```
+ */
+export function allFromDict<R extends ResultRecord>(
+  results: R,
+): Result<{ [K in keyof R]: OkOf<R[K]> }, ErrOf<R[keyof R]>> {
+  return foldRecord(results) as Result<{ [K in keyof R]: OkOf<R[K]> }, ErrOf<R[keyof R]>>;
+}
+
+/**
+ * The asynchronous counterpart of {@link all}: combine a tuple/array of
+ * {@link AsyncResult}s into one `AsyncResult` of all their success values.
  *
  * @remarks
  * The inputs are resolved **concurrently** (order preserved); the resolved
  * `Result`s are then folded with the same rules as {@link all} — first `Err`
  * short-circuits, any `Defect` dominates. As ever, the returned `AsyncResult`'s
- * internal promise never rejects. The output mirrors the input shape: a fixed
- * tuple keeps positional types, a dynamic array `AsyncResult<T, E>[]` collapses
- * to `AsyncResult<T[], E>`, and a record `{ a, b }` becomes
- * `AsyncResult<{ a; b }, E>`.
+ * internal promise never rejects. For a **record**, use {@link allFromDictAsync}.
  *
  * @example
  * ```ts
  * import { allAsync, fromSafePromise } from "unthrown";
- * await allAsync([fromSafePromise(a()), fromSafePromise(b())]); // tuple
- * await allAsync({ a: fromSafePromise(a()), b: fromSafePromise(b()) }); // record
+ * await allAsync([fromSafePromise(a()), fromSafePromise(b())]);
  * ```
  */
 export function allAsync<Rs extends readonly AsyncResult<unknown, unknown>[]>(
   results: readonly [...Rs],
-): AsyncResult<AllOk<Rs, { [K in keyof Rs]: AsyncOkOf<Rs[K]> }>, AsyncErrOf<Rs[number]>>;
-export function allAsync<R extends AsyncResultRecord>(
-  results: R,
-): AsyncResult<{ [K in keyof R]: AsyncOkOf<R[K]> }, AsyncErrOf<R[keyof R]>>;
-export function allAsync(
-  results: readonly AsyncResult<unknown, unknown>[] | AsyncResultRecord,
-): AsyncResult<unknown, unknown> {
+): AsyncResult<AllOk<Rs, { [K in keyof Rs]: AsyncOkOf<Rs[K]> }>, AsyncErrOf<Rs[number]>> {
   // Each AsyncResult is a (never-rejecting) thenable, so Promise.all adopts them;
-  // `foldAll` then applies the all() rules. The internal promise never rejects.
-  if (Array.isArray(results)) {
-    const settled = Promise.all(results).then((resolved) =>
-      foldAll(resolved as readonly Result<unknown, unknown>[]),
-    );
-    return new AsyncRes(settled);
-  }
+  // `foldArray` then applies the all() rules. The internal promise never rejects.
+  const settled = Promise.all(results).then((resolved) =>
+    foldArray(resolved as readonly Result<unknown, unknown>[]),
+  );
+  return new AsyncRes(settled) as AsyncResult<
+    AllOk<Rs, { [K in keyof Rs]: AsyncOkOf<Rs[K]> }>,
+    AsyncErrOf<Rs[number]>
+  >;
+}
+
+/**
+ * The asynchronous counterpart of {@link allFromDict}: combine a record of
+ * {@link AsyncResult}s into one `AsyncResult` of a record of their values.
+ *
+ * @remarks
+ * Resolved concurrently (order preserved), folded with the {@link all} rules,
+ * and the internal promise never rejects.
+ *
+ * @example
+ * ```ts
+ * import { allFromDictAsync, fromSafePromise } from "unthrown";
+ * await allFromDictAsync({ a: fromSafePromise(a()), b: fromSafePromise(b()) });
+ * ```
+ */
+export function allFromDictAsync<R extends AsyncResultRecord>(
+  results: R,
+): AsyncResult<{ [K in keyof R]: AsyncOkOf<R[K]> }, AsyncErrOf<R[keyof R]>> {
   const entries = Object.entries(results);
   const settled = Promise.all(entries.map(([, ar]) => ar)).then((resolved) => {
-    const byKey: ResultRecord = {};
+    // Null-proto accumulator: pairing resolved values back to keys can't pollute.
+    const byKey: ResultRecord = Object.create(null) as ResultRecord;
     entries.forEach(([key], i) => {
       byKey[key] = resolved[i] as Result<unknown, unknown>;
     });
-    return foldAll(byKey);
+    return foldRecord(byKey);
   });
-  return new AsyncRes(settled);
+  return new AsyncRes(settled) as AsyncResult<
+    { [K in keyof R]: AsyncOkOf<R[K]> },
+    AsyncErrOf<R[keyof R]>
+  >;
 }

--- a/packages/core/src/interop.ts
+++ b/packages/core/src/interop.ts
@@ -179,75 +179,123 @@ type AllOk<
   Ts extends readonly unknown[],
 > = number extends Rs["length"] ? Ts[number][] : Ts;
 
+/** A record of `Result`s, the input to the object form of {@link all}. */
+type ResultRecord = Record<string, Result<unknown, unknown>>;
+/** A record of `AsyncResult`s, the input to the object form of {@link allAsync}. */
+type AsyncResultRecord = Record<string, AsyncResult<unknown, unknown>>;
+
 /**
- * Collect {@link Result}s into a single `Result` of all their success values.
+ * Fold an array **or** a record of already-settled `Result`s with the
+ * `all`/`allAsync` rules: first `Err` wins, any `Defect` dominates. Returns an
+ * `Ok` of the same shape (array → array, record → record) on full success.
+ *
+ * @internal
+ */
+function foldAll(
+  results: readonly Result<unknown, unknown>[] | ResultRecord,
+): Result<unknown, unknown> {
+  let firstErr: Result<unknown, unknown> | undefined;
+  let firstDefect: Result<unknown, unknown> | undefined;
+
+  if (Array.isArray(results)) {
+    const values: unknown[] = [];
+    for (const r of results) {
+      if (r.tag === "Defect") firstDefect ??= r;
+      else if (r.tag === "Err") firstErr ??= r;
+      else values.push(r.value);
+    }
+    return firstDefect ?? firstErr ?? ok(values);
+  }
+
+  const values: Record<string, unknown> = {};
+  for (const [key, r] of Object.entries(results)) {
+    if (r.tag === "Defect") firstDefect ??= r;
+    else if (r.tag === "Err") firstErr ??= r;
+    else values[key] = r.value;
+  }
+  return firstDefect ?? firstErr ?? ok(values);
+}
+
+/**
+ * Collect {@link Result}s into a single `Result` of all their success values —
+ * from a tuple, an array, or a **record**.
  *
  * @remarks
  * Short-circuits on the **first** `Err` (later entries are not inspected for
  * their error); any `Defect` present **dominates**, winning even over an earlier
- * `Err`. A **fixed tuple** keeps its positional types — `all([ok(1), ok("a")])`
- * is `Result<[number, string], …>` — while a **dynamic array** `Result<T, E>[]`
- * collapses to `Result<T[], E>` with no cast.
+ * `Err`. The output mirrors the input shape:
  *
- * @typeParam Rs - the tuple/array of input `Result` types.
- * @param results - the results to combine.
+ * - a **fixed tuple** keeps its positional types — `all([ok(1), ok("a")])` is
+ *   `Result<[number, string], …>`;
+ * - a **dynamic array** `Result<T, E>[]` collapses to `Result<T[], E>`;
+ * - a **record** `{ a: Result<A, E>, b: Result<B, E> }` becomes
+ *   `Result<{ a: A; b: B }, E>` — handy for named parallel work, no tupling.
  *
  * @example
  * ```ts
  * import { all, ok } from "unthrown";
  * all([ok(1), ok("a"), ok(true)]).unwrap(); // [1, "a", true] (typed [number, string, boolean])
  * all([ok(1), ok(2)] as Result<number, never>[]).unwrap(); // number[]
+ * all({ id: ok(1), name: ok("ada") }).unwrap(); // { id: 1, name: "ada" }
  * ```
  */
 export function all<Rs extends readonly Result<unknown, unknown>[]>(
   results: readonly [...Rs],
-): Result<AllOk<Rs, { [K in keyof Rs]: OkOf<Rs[K]> }>, ErrOf<Rs[number]>> {
-  type Out = Result<AllOk<Rs, { [K in keyof Rs]: OkOf<Rs[K]> }>, ErrOf<Rs[number]>>;
-  const values: unknown[] = [];
-  let firstErr: Result<unknown, unknown> | undefined;
-  let firstDefect: Result<unknown, unknown> | undefined;
-
-  for (const r of results) {
-    if (r.tag === "Defect") firstDefect ??= r;
-    else if (r.tag === "Err") firstErr ??= r;
-    else values.push(r.value);
-  }
-
-  if (firstDefect) return firstDefect as Out;
-  if (firstErr) return firstErr as Out;
-  return ok(values) as Out;
+): Result<AllOk<Rs, { [K in keyof Rs]: OkOf<Rs[K]> }>, ErrOf<Rs[number]>>;
+export function all<R extends ResultRecord>(
+  results: R,
+): Result<{ [K in keyof R]: OkOf<R[K]> }, ErrOf<R[keyof R]>>;
+export function all(
+  results: readonly Result<unknown, unknown>[] | ResultRecord,
+): Result<unknown, unknown> {
+  return foldAll(results);
 }
 
 /**
  * The asynchronous counterpart of {@link all}: combine {@link AsyncResult}s into
- * one `AsyncResult` of all their success values.
+ * one `AsyncResult` of all their success values — from a tuple, an array, or a
+ * **record**.
  *
  * @remarks
- * The inputs are resolved **concurrently** (their order is preserved); the
- * resolved `Result`s are then folded with the same rules as {@link all} —
- * first `Err` short-circuits, any `Defect` dominates. As ever, the returned
- * `AsyncResult`'s internal promise never rejects. A **fixed tuple** keeps its
- * positional types; a **dynamic array** `AsyncResult<T, E>[]` collapses to
- * `AsyncResult<T[], E>`.
- *
- * @typeParam Rs - the tuple/array of input `AsyncResult` types.
- * @param results - the async results to combine.
+ * The inputs are resolved **concurrently** (order preserved); the resolved
+ * `Result`s are then folded with the same rules as {@link all} — first `Err`
+ * short-circuits, any `Defect` dominates. As ever, the returned `AsyncResult`'s
+ * internal promise never rejects. The output mirrors the input shape: a fixed
+ * tuple keeps positional types, a dynamic array `AsyncResult<T, E>[]` collapses
+ * to `AsyncResult<T[], E>`, and a record `{ a, b }` becomes
+ * `AsyncResult<{ a; b }, E>`.
  *
  * @example
  * ```ts
  * import { allAsync, fromSafePromise } from "unthrown";
- * const both = await allAsync([fromSafePromise(a()), fromSafePromise(b())]);
+ * await allAsync([fromSafePromise(a()), fromSafePromise(b())]); // tuple
+ * await allAsync({ a: fromSafePromise(a()), b: fromSafePromise(b()) }); // record
  * ```
  */
 export function allAsync<Rs extends readonly AsyncResult<unknown, unknown>[]>(
   results: readonly [...Rs],
-): AsyncResult<AllOk<Rs, { [K in keyof Rs]: AsyncOkOf<Rs[K]> }>, AsyncErrOf<Rs[number]>> {
-  type Out = AsyncResult<AllOk<Rs, { [K in keyof Rs]: AsyncOkOf<Rs[K]> }>, AsyncErrOf<Rs[number]>>;
-  // Each AsyncResult is a (never-rejecting) thenable, so Promise.all adopts them
-  // and resolves to the ordered Results; `all` then folds them. The internal
-  // promise still never rejects.
-  const settled = Promise.all(results).then((resolved) =>
-    all(resolved as readonly Result<unknown, unknown>[]),
-  );
-  return new AsyncRes(settled) as unknown as Out;
+): AsyncResult<AllOk<Rs, { [K in keyof Rs]: AsyncOkOf<Rs[K]> }>, AsyncErrOf<Rs[number]>>;
+export function allAsync<R extends AsyncResultRecord>(
+  results: R,
+): AsyncResult<{ [K in keyof R]: AsyncOkOf<R[K]> }, AsyncErrOf<R[keyof R]>>;
+export function allAsync(
+  results: readonly AsyncResult<unknown, unknown>[] | AsyncResultRecord,
+): AsyncResult<unknown, unknown> {
+  // Each AsyncResult is a (never-rejecting) thenable, so Promise.all adopts them;
+  // `foldAll` then applies the all() rules. The internal promise never rejects.
+  if (Array.isArray(results)) {
+    const settled = Promise.all(results).then((resolved) =>
+      foldAll(resolved as readonly Result<unknown, unknown>[]),
+    );
+    return new AsyncRes(settled);
+  }
+  const entries = Object.entries(results);
+  const settled = Promise.all(entries.map(([, ar]) => ar)).then((resolved) => {
+    const byKey: ResultRecord = {};
+    entries.forEach(([key], i) => {
+      byKey[key] = resolved[i] as Result<unknown, unknown>;
+    });
+    return foldAll(byKey);
+  });
+  return new AsyncRes(settled);
 }

--- a/packages/core/typedoc.json
+++ b/packages/core/typedoc.json
@@ -2,5 +2,12 @@
   "extends": "@unthrown/typedoc/base.json",
   "entryPoints": ["src/index.ts"],
   "out": "docs",
-  "intentionallyNotExported": ["Result", "Props", "ResultMethods", "AllOk"]
+  "intentionallyNotExported": [
+    "Result",
+    "Props",
+    "ResultMethods",
+    "AllOk",
+    "ResultRecord",
+    "AsyncResultRecord"
+  ]
 }


### PR DESCRIPTION
Adds a **record** overload to `all` and `allAsync` (idea from byethrow's `collect`/`sequence`, adapted to unthrown's first-`Err`-wins semantics).

```ts
all({ id: ok(1), name: ok("ada") });
// Result<{ id: number; name: string }, never>

await allAsync({ user: loadUser(), org: loadOrg() });
// AsyncResult<{ user: User; org: Org }, NotFound>
```

**Output mirrors input shape** — tuple → tuple (positional), array → `T[]`, record → record of values. The folding rules are unchanged: first `Err` short-circuits, any `Defect` dominates. This is **not** error accumulation (that stays deliberately excluded) — just an ergonomic shape for named parallel work, no tupling.

- New shared `foldAll` helper backs both array and record forms.
- Tests for record success / first-Err / Defect-dominates / empty record, sync and async.
- Docs (`core-concepts`) + `CLAUDE.md` aggregate spec updated; 100% core line/function coverage held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)