### PR TITLE
feat(core): add flatTap, a failable tap

### DIFF
--- a/.changeset/flat-tap.md
+++ b/.changeset/flat-tap.md
@@ -1,0 +1,10 @@
+---
+"unthrown": minor
+---
+
+Add `flatTap` — a **failable** `tap` on the success channel, for both `Result`
+and `AsyncResult`. It runs a `Result`-returning effect on the `Ok` value,
+discards the effect's success value (the original flows through), threads the
+effect's error (`Result<T, E | E2>`), and — like every combinator — turns a
+throw into a `Defect`. It is to `tap` what `flatMap` is to `map`: use it for a
+validation or write whose outcome matters but whose value you don't need.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,9 @@ was planned).
 ## Load-bearing runtime invariants (tests must guard these)
 
 - **Throw → defect.** Any value thrown by a callback inside a combinator
-  (`map`, `flatMap`, `mapErr`, `orElse`, `recover`, `tap*`, `recoverDefect`) is
-  caught and converted to a `Defect`. Nothing escapes a pipeline as a raw throw.
+  (`map`, `flatMap`, `flatTap`, `mapErr`, `orElse`, `recover`, `tap*`,
+  `recoverDefect`) is caught and converted to a `Defect`. Nothing escapes a
+  pipeline as a raw throw.
   This is what lets an HTTP adapter do a single `match({ ok, err, defect })`
   with **no surrounding `try/catch`**.
 - **A `Defect` flows through every method untouched EXCEPT `match()` and
@@ -82,7 +83,9 @@ Its **combinator callbacks are synchronous** (no raw `Promise` — see Thesis #3
 async work re-enters via `fromPromise` / `fromSafePromise` and composes with
 `flatMap`. `await` collapses an `AsyncResult` to a `Result` (then match it).
 
-- success: `map`, `flatMap`, `tap`, `as`
+- success: `map`, `flatMap`, `tap`, `flatTap` (a failable `tap` — runs a
+  `Result`-returning effect, keeps the original value, threads the effect's
+  error), `as`
 - error: `mapErr`, `orElse`, `recover`, `tapErr`
 - defect: `recoverDefect`, `tapDefect`
 - eliminate: `match`, `unwrap`, `unwrapErr`, `unwrapOr`, `unwrapOrElse`,

--- a/docs/guide/core-concepts.md
+++ b/docs/guide/core-concepts.md
@@ -23,7 +23,7 @@ reachable once you've narrowed to a variant.
 
 Every `Result` shares one method surface, grouped by the channel it touches:
 
-- **success** (runs on `Ok`): `map`, `flatMap`, `tap`, `as`
+- **success** (runs on `Ok`): `map`, `flatMap`, `tap`, `flatTap`, `as`
 - **error** (runs on `Err`): `mapErr`, `orElse`, `recover`, `tapErr`
 - **defect** (the only door to a `Defect`): `recoverDefect`, `tapDefect`
 - **eliminate**: `match`, `unwrap`, `unwrapErr`, `unwrapOr`, `unwrapOrElse`,
@@ -36,6 +36,19 @@ through untouched:
 ok(2).map((n) => n + 1); // Ok(3)
 err("e").map((n) => n + 1); // Err("e") — callback skipped
 ok(2).mapErr((e) => `${e}!`); // Ok(2) — callback skipped
+```
+
+`tap` and `flatTap` both run a side effect and keep the original value — the
+difference is whether the effect can fail. `tap` takes a `void` callback;
+`flatTap` takes a **`Result`-returning** one, discards its success value, and
+threads its error (a validation or write whose _outcome_ matters but whose
+_value_ you don't need):
+
+```ts
+ok(user)
+  .flatTap((u) => writeAudit(u)) // returns Result<void, WriteError>
+  .map((u) => u.name);
+// → still the original user on success; short-circuits to WriteError on failure
 ```
 
 ## Constructors and the `Result` facade

--- a/packages/core/src/async-result.spec.ts
+++ b/packages/core/src/async-result.spec.ts
@@ -118,6 +118,13 @@ describe("AsyncResult success channel", () => {
     expect(r.unwrap()).toBe(5);
   });
 
+  it("flatTap does not run the effect on Err or Defect", async () => {
+    const f = vi.fn(() => ok(1));
+    expect((await asyncErr("e").flatTap(f)).unwrapErr()).toBe("e");
+    expect((await asyncDefect().flatTap(f)).isDefect()).toBe(true);
+    expect(f).not.toHaveBeenCalled();
+  });
+
   it("as replaces the Ok value, and passes Err/Defect through", async () => {
     expect((await asyncOk(1).as("x")).unwrap()).toBe("x");
     expect((await asyncErr("e").as("x")).unwrapErr()).toBe("e");

--- a/packages/core/src/async-result.spec.ts
+++ b/packages/core/src/async-result.spec.ts
@@ -66,6 +66,7 @@ describe("AsyncResult: a throw in any combinator becomes a Defect", () => {
     expect((await asyncOk(1).map(t)).isDefect()).toBe(true);
     expect((await asyncOk(1).flatMap(t)).isDefect()).toBe(true);
     expect((await asyncOk(1).tap(t)).isDefect()).toBe(true);
+    expect((await asyncOk(1).flatTap(t)).isDefect()).toBe(true);
     expect((await asyncErr("e").mapErr(t)).isDefect()).toBe(true);
     expect((await asyncErr("e").orElse(t)).isDefect()).toBe(true);
     expect((await asyncErr("e").recover(t)).isDefect()).toBe(true);
@@ -100,6 +101,20 @@ describe("AsyncResult success channel", () => {
     const seen: number[] = [];
     const r = await asyncOk(5).tap((n) => seen.push(n));
     expect(seen).toEqual([5]);
+    expect(r.unwrap()).toBe(5);
+  });
+
+  it("flatTap keeps the original value when the effect succeeds", async () => {
+    const r = await asyncOk(5).flatTap((n) => ok(n * 100));
+    expect(r.unwrap()).toBe(5); // original, not 500
+  });
+
+  it("flatTap short-circuits to the effect's Err", async () => {
+    expect((await asyncOk(5).flatTap(() => err("denied"))).unwrapErr()).toBe("denied");
+  });
+
+  it("flatTap composes an async effect via a qualified boundary, keeping the value", async () => {
+    const r = await asyncOk(5).flatTap(() => fromSafePromise(Promise.resolve("logged")));
     expect(r.unwrap()).toBe(5);
   });
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -76,6 +76,17 @@ class Res<T, E> {
     }
   }
 
+  flatTap<E2>(this: Result<T, E>, f: (value: T) => Result<unknown, E2>): Result<T, E | E2> {
+    if (this.tag !== "Ok") return this as unknown as Result<T, E | E2>;
+    try {
+      const r = f(this.value);
+      // Keep the original value on success; an Err/Defect from `f` short-circuits.
+      return (r.tag === "Ok" ? this : r) as unknown as Result<T, E | E2>;
+    } catch (cause) {
+      return defectRes(cause);
+    }
+  }
+
   as<U>(this: Result<T, E>, value: U): Result<U, E> {
     if (this.tag !== "Ok") return this as unknown as Result<U, E>;
     return okRes(value);
@@ -303,6 +314,23 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
           return r;
         } catch (cause) {
           return defectRes<T, E>(cause);
+        }
+      }),
+    );
+  }
+
+  flatTap<E2>(
+    f: (value: T) => Result<unknown, E2> | AsyncResult<unknown, E2>,
+  ): AsyncResult<T, E | E2> {
+    return new AsyncRes<T, E | E2>(
+      this.promise.then(async (r) => {
+        if (r.tag !== "Ok") return r as unknown as Result<T, E | E2>;
+        try {
+          const inner = (await f(r.value)) as Result<unknown, E2>;
+          // Keep the original value on success; an Err/Defect from `f` wins.
+          return (inner.tag === "Ok" ? r : inner) as unknown as Result<T, E | E2>;
+        } catch (cause) {
+          return defectRes(cause);
         }
       }),
     );

--- a/packages/core/src/invariants.spec.ts
+++ b/packages/core/src/invariants.spec.ts
@@ -19,6 +19,7 @@ describe("Invariant 1: throw inside any combinator becomes a Defect", () => {
     expect(ok(1).map(t).isDefect()).toBe(true);
     expect(ok(1).flatMap(t).isDefect()).toBe(true);
     expect(ok(1).tap(t).isDefect()).toBe(true);
+    expect(ok(1).flatTap(t).isDefect()).toBe(true);
     expect(err("e").mapErr(t).isDefect()).toBe(true);
     expect(err("e").orElse(t).isDefect()).toBe(true);
     expect(err("e").recover(t).isDefect()).toBe(true);
@@ -35,6 +36,7 @@ describe("Invariant 2: a Defect flows through every method except match() and re
       defectOf(boom).map(f),
       defectOf(boom).flatMap(f),
       defectOf(boom).tap(f),
+      defectOf(boom).flatTap(f),
       defectOf(boom).as(1),
       defectOf(boom).mapErr(f),
       defectOf(boom).orElse(f),

--- a/packages/core/src/result.spec.ts
+++ b/packages/core/src/result.spec.ts
@@ -106,6 +106,45 @@ describe("Result.tap", () => {
   });
 });
 
+describe("Result.flatTap", () => {
+  it("runs the failable effect on Ok and keeps the original value on success", () => {
+    const seen: number[] = [];
+    const r = ok(5).flatTap((n) => {
+      seen.push(n);
+      return ok("ignored");
+    });
+    expect(seen).toEqual([5]);
+    expect(r.unwrap()).toBe(5); // original value preserved, not "ignored"
+  });
+
+  it("short-circuits to the effect's Err", () => {
+    const r = ok(5).flatTap(() => err("denied"));
+    expect(r.unwrapErr()).toBe("denied");
+  });
+
+  it("propagates a Defect from the effect", () => {
+    const r = ok(5).flatTap(() => defectOf(boom));
+    expect(r.isDefect()).toBe(true);
+  });
+
+  it("does not run on Err or Defect", () => {
+    const f = vi.fn(() => ok(1));
+    expect(err("e").flatTap(f).isErr()).toBe(true);
+    expect(defectOf(boom).flatTap(f).isDefect()).toBe(true);
+    expect(f).not.toHaveBeenCalled();
+  });
+
+  it("converts a throw into a Defect", () => {
+    expect(
+      ok(1)
+        .flatTap(() => {
+          throw boom;
+        })
+        .isDefect(),
+    ).toBe(true);
+  });
+});
+
 describe("Result.as", () => {
   it("replaces the Ok value", () => {
     expect(ok(1).as("x").unwrap()).toBe("x");

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -285,7 +285,8 @@ export type Awaitable<T> = {
  * {@link fromPromise} forces. To do further async work, re-enter through a
  * qualified boundary and compose it: `ar.flatMap((v) => fromPromise(work(v),
  * qualify))`. The eliminators (`unwrap`, …) return promises; the binds
- * (`flatMap`, `orElse`, `recoverDefect`) additionally accept an `AsyncResult`.
+ * (`flatMap`, `flatTap`, `orElse`, `recoverDefect`) additionally accept an
+ * `AsyncResult`.
  *
  * To pattern-match an `AsyncResult`, `await` it first: `match(await ar)`.
  *

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -41,6 +41,23 @@ export type ResultMethods<T, E> = {
    */
   tap(f: (value: T) => void): Result<T, E>;
   /**
+   * Run a **failable** side effect on the success value, keeping the original
+   * value but threading the effect's error.
+   *
+   * @remarks
+   * This is to {@link ResultMethods.tap | tap} what
+   * {@link ResultMethods.flatMap | flatMap} is to {@link ResultMethods.map | map}:
+   * `f` returns a `Result`, but its **success value is discarded** — on success
+   * the original value flows through (`Result<T, E | E2>`), while an `Err` (or
+   * `Defect`) from `f` short-circuits. Runs only on `Ok`; `Err` and `Defect` pass
+   * through. If `f` throws, the throw becomes a `Defect`. Use it for a validation
+   * or write whose _result_ matters but whose _value_ you don't need.
+   *
+   * @typeParam E2 - the error type the effect may introduce.
+   * @param f - the failable side effect; its `Ok` value is ignored.
+   */
+  flatTap<E2>(f: (value: T) => Result<unknown, E2>): Result<T, E | E2>;
+  /**
    * Replace the success value with a constant `value`.
    *
    * Runs only on `Ok`; `Err` and `Defect` pass through.
@@ -285,6 +302,14 @@ export type AsyncResult<T, E> = Awaitable<Result<T, E>> & {
   flatMap<U, E2>(f: (value: T) => Result<U, E2> | AsyncResult<U, E2>): AsyncResult<U, E | E2>;
   /** Asynchronous `tap`. `f` is synchronous; a throw becomes a `Defect`. */
   tap(f: (value: T) => void): AsyncResult<T, E>;
+  /**
+   * Asynchronous `flatTap` — a failable tap that keeps the original value. `f`
+   * may return a `Result` **or** an `AsyncResult`; its `Ok` value is discarded,
+   * an `Err`/`Defect` short-circuits, and a throw becomes a `Defect`.
+   */
+  flatTap<E2>(
+    f: (value: T) => Result<unknown, E2> | AsyncResult<unknown, E2>,
+  ): AsyncResult<T, E | E2>;
   /** Asynchronous `as`. */
   as<U>(value: U): AsyncResult<U, E>;
 


### PR DESCRIPTION
Adds **`flatTap`** to the success channel of `Result` and `AsyncResult` (idea from byethrow's `andThrough`, named in unthrown's vocabulary — it is to `tap` what `flatMap` is to `map`; precedent in Cats Effect's `flatTap`).

```ts
ok(user)
  .flatTap((u) => writeAudit(u)) // Result<void, WriteError>
  .map((u) => u.name);
// → original user flows through on success; short-circuits to WriteError on failure
```

**Semantics:** runs only on `Ok`; runs a `Result`-returning effect; **discards the effect's success value** (the original flows through); threads the effect's error (`Result<T, E | E2>`); an `Err`/`Defect` from the effect short-circuits; a throw becomes a `Defect` like every combinator. `Err`/`Defect` inputs pass through untouched.

For a validation or write whose _outcome_ matters but whose _value_ you don't need — the gap `tap` (can't fail) and `flatMap` (replaces the value) both leave.

- `Result.flatTap` + `AsyncResult.flatTap` (async accepts a `Result` or `AsyncResult`).
- Guarded by the invariant suite (throw→Defect, Defect-passthrough); 100% core line/function coverage held.
- Docs (`core-concepts`) + `CLAUDE.md` updated.

**Naming:** I went with `flatTap`; happy to rename (`tapResult`?) if you prefer. Shipped only the success-side version — an error-channel analogue (byethrow's `orThrough`) could follow if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)