### PR TITLE
feat: new @unthrown/standard-schema interop package

### DIFF
--- a/.changeset/standard-schema-package.md
+++ b/.changeset/standard-schema-package.md
@@ -1,0 +1,12 @@
+---
+"@unthrown/standard-schema": minor
+---
+
+New interop package: bridge any [Standard
+Schema](https://standardschema.dev) validator (Zod, Valibot, ArkType, …) to a
+`Result`. `fromSchema(schema)` returns a validator
+`(input) => Result<Output, readonly Issue[]>`; `fromSchemaAsync(schema)` returns
+the `AsyncResult` counterpart and accepts sync or async schemas. The schema's
+validation issues are the modeled error `E` (a failed validation is anticipated,
+not a defect); a validator that throws becomes a `Defect`. The only dependency
+is the types-only `@standard-schema/spec`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,10 @@ enough that the library can be "done".
 - `packages/neverthrow` → `@unthrown/neverthrow` (peerDep `neverthrow`)
 - `packages/boxed` → `@unthrown/boxed` (peerDep `@bloodyowl/boxed` — Boxed's
   maintained scope; `@swan-io/boxed` is the deprecated former name)
+- `packages/standard-schema` → `@unthrown/standard-schema` (dep on the
+  types-only `@standard-schema/spec`; bridges Zod/Valibot/ArkType validators to
+  `Result` via `fromSchema` / `fromSchemaAsync`, with the validation issues as
+  the modeled `E`)
 - `tools/tsconfig`, `tools/typedoc` → private shared config (`@unthrown/tsconfig`,
   `@unthrown/typedoc`)
 - `docs` → `@unthrown/docs`, the VitePress site (guide + TypeDoc-generated API

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -73,6 +73,7 @@ export default defineConfig({
             { text: "@unthrown/effect", link: "/api/effect/" },
             { text: "@unthrown/neverthrow", link: "/api/neverthrow/" },
             { text: "@unthrown/boxed", link: "/api/boxed/" },
+            { text: "@unthrown/standard-schema", link: "/api/standard-schema/" },
           ],
         },
       ],

--- a/docs/guide/interop.md
+++ b/docs/guide/interop.md
@@ -4,11 +4,12 @@ unthrown ships thin bridges to the three most common neighbours in the
 errors-as-values space. Each is a separate, peer-dependency package with a small
 `to*` / `from*` surface — nothing to learn beyond "which direction am I going."
 
-| Package                                    | Peer dependency    | Bridges                    |
-| ------------------------------------------ | ------------------ | -------------------------- |
-| [`@unthrown/effect`](/api/effect/)         | `effect`           | `Exit`, `Either`, `Effect` |
-| [`@unthrown/neverthrow`](/api/neverthrow/) | `neverthrow`       | `Result`, `ResultAsync`    |
-| [`@unthrown/boxed`](/api/boxed/)           | `@bloodyowl/boxed` | `Result`, `Future<Result>` |
+| Package                                              | Peer dependency    | Bridges                    |
+| ---------------------------------------------------- | ------------------ | -------------------------- |
+| [`@unthrown/effect`](/api/effect/)                   | `effect`           | `Exit`, `Either`, `Effect` |
+| [`@unthrown/neverthrow`](/api/neverthrow/)           | `neverthrow`       | `Result`, `ResultAsync`    |
+| [`@unthrown/boxed`](/api/boxed/)                     | `@bloodyowl/boxed` | `Result`, `Future<Result>` |
+| [`@unthrown/standard-schema`](/api/standard-schema/) | _(types only)_     | any Standard Schema        |
 
 ## The one rule: does the neighbour have a defect channel?
 
@@ -66,3 +67,31 @@ Future<Result>`.
 
 On the way in, an _unexpected_ rejection inside the neighbour's async type
 becomes a `Defect` — never a silently-swallowed error.
+
+## Standard Schema — validators as `Result`s
+
+[`@unthrown/standard-schema`](/api/standard-schema/) is the odd one out: there's
+no `to*` direction (you don't turn a `Result` back into a schema). It bridges
+**any** [Standard Schema](https://standardschema.dev) validator — Zod, Valibot,
+ArkType — into a validator that returns a `Result`. The schema's validation
+**issues become the modeled error `E`**, because a failed validation is an
+anticipated outcome, not a defect.
+
+```ts
+import { fromSchema, fromSchemaAsync } from "@unthrown/standard-schema";
+import { z } from "zod";
+
+const parseUser = fromSchema(z.object({ id: z.string() }));
+
+parseUser({ id: "u_1" }).unwrap(); // { id: "u_1" }
+parseUser({ id: 1 }).unwrapErr(); // readonly StandardSchemaV1.Issue[]
+```
+
+- `fromSchema(schema)` → `(input) => Result<Output, Issues>` for a synchronous
+  schema (it throws a `TypeError` if the schema is async — use the next one).
+- `fromSchemaAsync(schema)` → `(input) => AsyncResult<Output, Issues>`, accepting
+  sync **or** async schemas. A validator that _throws_ (rather than returning
+  issues) becomes a `Defect`; the `AsyncResult` never rejects.
+
+The only dependency is the tiny, types-only `@standard-schema/spec` — your
+validator library provides the runtime.

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,6 +15,7 @@
     "@unthrown/effect": "workspace:*",
     "@unthrown/neverthrow": "workspace:*",
     "@unthrown/pattern": "workspace:*",
+    "@unthrown/standard-schema": "workspace:*",
     "@unthrown/vitest": "workspace:*",
     "unthrown": "workspace:*"
   },

--- a/docs/scripts/copy-docs.ts
+++ b/docs/scripts/copy-docs.ts
@@ -10,6 +10,7 @@ import "@unthrown/vitest";
 import "@unthrown/effect";
 import "@unthrown/neverthrow";
 import "@unthrown/boxed";
+import "@unthrown/standard-schema";
 
 import { cp, mkdir, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
@@ -26,6 +27,7 @@ const packages: ReadonlyArray<{ readonly pkg: string; readonly out: string }> = 
   { pkg: "@unthrown/effect", out: "effect" },
   { pkg: "@unthrown/neverthrow", out: "neverthrow" },
   { pkg: "@unthrown/boxed", out: "boxed" },
+  { pkg: "@unthrown/standard-schema", out: "standard-schema" },
 ];
 
 await mkdir(apiDir, { recursive: true });

--- a/packages/standard-schema/README.md
+++ b/packages/standard-schema/README.md
@@ -1,0 +1,41 @@
+# @unthrown/standard-schema
+
+> [Standard Schema](https://standardschema.dev) interop for
+> [unthrown](https://github.com/btravstack/unthrown)'s `Result`.
+
+📖 **[Documentation](https://btravstack.github.io/unthrown/guide/interop)** ·
+[API Reference](https://btravstack.github.io/unthrown/api/standard-schema/)
+
+```sh
+pnpm add @unthrown/standard-schema
+```
+
+Bridge any [Standard Schema](https://standardschema.dev) validator — **Zod**,
+**Valibot**, **ArkType**, and others — to a `Result`. A schema's validation
+issues become the modeled error `E`, because a failed validation is an
+_anticipated_ outcome, not a defect.
+
+```ts
+import { fromSchema, fromSchemaAsync } from "@unthrown/standard-schema";
+import { z } from "zod";
+
+const parseUser = fromSchema(z.object({ id: z.string() }));
+
+parseUser({ id: "u_1" }).unwrap(); // { id: "u_1" }
+parseUser({ id: 1 }).unwrapErr(); // readonly StandardSchemaV1.Issue[]
+```
+
+- `fromSchema(schema)` — returns a validator `(input) => Result<Output, Issues>`
+  for a **synchronous** schema. If the schema validates asynchronously it throws
+  a `TypeError` (use `fromSchemaAsync`).
+- `fromSchemaAsync(schema)` — returns a validator
+  `(input) => AsyncResult<Output, Issues>` that accepts **sync or async**
+  schemas. A validator that _throws_ (rather than returning issues) becomes a
+  `Defect`; the `AsyncResult` never rejects.
+
+`@standard-schema/spec` is a tiny, types-only dependency — your validator
+library (Zod, Valibot, …) provides the runtime.
+
+## License
+
+[MIT](../../LICENSE) © Benoit TRAVERS

--- a/packages/standard-schema/package.json
+++ b/packages/standard-schema/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@unthrown/standard-schema",
+  "version": "0.1.0",
+  "description": "Standard Schema (Zod, Valibot, ArkType, …) interop for unthrown",
+  "keywords": [
+    "arktype",
+    "errors-as-values",
+    "result",
+    "standard-schema",
+    "typescript",
+    "unthrown",
+    "valibot",
+    "validation",
+    "zod"
+  ],
+  "homepage": "https://github.com/btravstack/unthrown#readme",
+  "bugs": {
+    "url": "https://github.com/btravstack/unthrown/issues"
+  },
+  "license": "MIT",
+  "author": "Benoit TRAVERS <benoit.travers.fr@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/btravstack/unthrown.git",
+    "directory": "packages/standard-schema"
+  },
+  "files": [
+    "dist",
+    "docs"
+  ],
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsdown src/index.ts --format cjs,esm --dts --clean",
+    "build:docs": "typedoc",
+    "dev": "tsdown src/index.ts --format cjs,esm --dts --watch",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@standard-schema/spec": "catalog:",
+    "unthrown": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@unthrown/tsconfig": "workspace:*",
+    "@unthrown/typedoc": "workspace:*",
+    "@vitest/coverage-v8": "catalog:",
+    "tsdown": "catalog:",
+    "typedoc": "catalog:",
+    "typedoc-plugin-markdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=22.19"
+  }
+}

--- a/packages/standard-schema/src/index.spec.ts
+++ b/packages/standard-schema/src/index.spec.ts
@@ -36,6 +36,11 @@ describe("fromSchema (sync)", () => {
   it("throws a TypeError when the schema validates asynchronously", () => {
     expect(() => fromSchema(stringSchema({ async: true }))("hi")).toThrow(TypeError);
   });
+
+  it("turns a throwing validator into a Defect (it never escapes)", () => {
+    const r = fromSchema(stringSchema({ throws: true }))("hi");
+    expect(r.isDefect()).toBe(true);
+  });
 });
 
 describe("fromSchemaAsync", () => {

--- a/packages/standard-schema/src/index.spec.ts
+++ b/packages/standard-schema/src/index.spec.ts
@@ -1,0 +1,59 @@
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import { describe, expect, it } from "vitest";
+
+import { fromSchema, fromSchemaAsync } from "./index.js";
+
+// A tiny hand-rolled Standard Schema validator (no validator lib needed): a
+// string schema that returns `{ value }` on a string and `{ issues }` otherwise.
+function stringSchema(opts?: {
+  async?: boolean;
+  throws?: boolean;
+}): StandardSchemaV1<unknown, string> {
+  const check = (input: unknown): StandardSchemaV1.Result<string> =>
+    typeof input === "string" ? { value: input } : { issues: [{ message: "expected a string" }] };
+  return {
+    "~standard": {
+      version: 1,
+      vendor: "test",
+      validate: (input) => {
+        if (opts?.throws) throw new Error("validator blew up");
+        return opts?.async ? Promise.resolve(check(input)) : check(input);
+      },
+    },
+  };
+}
+
+describe("fromSchema (sync)", () => {
+  it("returns Ok with the parsed value on valid input", () => {
+    expect(fromSchema(stringSchema())("hi").unwrap()).toBe("hi");
+  });
+
+  it("returns Err carrying the issues on invalid input", () => {
+    const r = fromSchema(stringSchema())(42);
+    expect(r.unwrapErr()).toEqual([{ message: "expected a string" }]);
+  });
+
+  it("throws a TypeError when the schema validates asynchronously", () => {
+    expect(() => fromSchema(stringSchema({ async: true }))("hi")).toThrow(TypeError);
+  });
+});
+
+describe("fromSchemaAsync", () => {
+  it("returns Ok on valid input for a synchronous schema", async () => {
+    expect((await fromSchemaAsync(stringSchema())("hi")).unwrap()).toBe("hi");
+  });
+
+  it("returns Ok on valid input for an asynchronous schema", async () => {
+    expect((await fromSchemaAsync(stringSchema({ async: true }))("hi")).unwrap()).toBe("hi");
+  });
+
+  it("returns Err carrying the issues on invalid input", async () => {
+    const r = await fromSchemaAsync(stringSchema({ async: true }))(42);
+    expect(r.unwrapErr()).toEqual([{ message: "expected a string" }]);
+  });
+
+  it("turns a throwing validator into a Defect (never rejects)", async () => {
+    const r = await fromSchemaAsync(stringSchema({ throws: true }))("hi");
+    expect(r.isDefect()).toBe(true);
+  });
+});

--- a/packages/standard-schema/src/index.ts
+++ b/packages/standard-schema/src/index.ts
@@ -14,7 +14,7 @@
 //   parseUser(input); // Result<{ id: string }, readonly StandardSchemaV1.Issue[]>
 
 import type { StandardSchemaV1 } from "@standard-schema/spec";
-import { err, fromSafePromise, ok } from "unthrown";
+import { defect, err, fromSafePromise, fromThrowable, ok } from "unthrown";
 import type { AsyncResult, Result } from "unthrown";
 
 /** The error channel both entry points produce: a schema's validation issues. */
@@ -29,9 +29,12 @@ export type SchemaIssues = readonly StandardSchemaV1.Issue[];
  * because a failed validation is an *anticipated* outcome, not a defect. Works
  * with any Standard Schema implementation (Zod, Valibot, ArkType, …).
  *
- * If the schema validates **asynchronously** (its `validate` returns a
- * `Promise`), a synchronous `Result` cannot represent the pending work, so this
- * throws a `TypeError` — use {@link fromSchemaAsync} instead.
+ * A validator that **throws** (rather than returning issues) becomes a `Defect`
+ * — the same boundary behaviour as `fromThrowable`, so an unexpected crash never
+ * escapes as a raw exception. If the schema validates **asynchronously**
+ * (its `validate` returns a `Promise`), a synchronous `Result` cannot represent
+ * the pending work, so this throws a `TypeError` — a deliberate usage error; use
+ * {@link fromSchemaAsync} instead.
  *
  * @typeParam S - the schema type.
  * @param schema - a Standard Schema validator.
@@ -48,14 +51,25 @@ export type SchemaIssues = readonly StandardSchemaV1.Issue[];
 export function fromSchema<S extends StandardSchemaV1>(
   schema: S,
 ): (input: unknown) => Result<StandardSchemaV1.InferOutput<S>, SchemaIssues> {
+  type Output = StandardSchemaV1.InferOutput<S>;
+  // Run `validate` at a boundary so a *throwing* validator lands in the Defect
+  // channel instead of escaping; `qualify` only ever mints a defect, so E = never.
+  const validate = fromThrowable(
+    (input: unknown) => schema["~standard"].validate(input),
+    (cause) => defect(cause),
+  );
   return (input) => {
-    const result = schema["~standard"].validate(input);
-    if (result instanceof Promise) {
+    const settled = validate(input);
+    // An async schema can't be represented synchronously — fail loud and early.
+    if (settled.isOk() && settled.value instanceof Promise) {
       throw new TypeError(
         "@unthrown/standard-schema: this schema validates asynchronously — use fromSchemaAsync instead.",
       );
     }
-    return result.issues ? err(result.issues) : ok(result.value);
+    return settled.flatMap((result) => {
+      const sync = result as StandardSchemaV1.Result<Output>;
+      return sync.issues ? err(sync.issues) : ok(sync.value);
+    });
   };
 }
 

--- a/packages/standard-schema/src/index.ts
+++ b/packages/standard-schema/src/index.ts
@@ -1,0 +1,90 @@
+// @unthrown/standard-schema — bridge any Standard Schema validator (Zod,
+// Valibot, ArkType, …) to a `Result` / `AsyncResult`.
+//
+// A Standard Schema's `validate` returns `{ value }` on success or `{ issues }`
+// on failure. `fromSchema` turns that into a validator returning
+// `Result<Output, readonly Issue[]>`; `fromSchemaAsync` is the async counterpart
+// (and also accepts synchronous schemas). The `issues` array is the modeled `E`
+// — a failed validation is an anticipated outcome, never a defect.
+//
+//   import { fromSchema } from "@unthrown/standard-schema";
+//   import { z } from "zod";
+//
+//   const parseUser = fromSchema(z.object({ id: z.string() }));
+//   parseUser(input); // Result<{ id: string }, readonly StandardSchemaV1.Issue[]>
+
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import { err, fromSafePromise, ok } from "unthrown";
+import type { AsyncResult, Result } from "unthrown";
+
+/** The error channel both entry points produce: a schema's validation issues. */
+export type SchemaIssues = readonly StandardSchemaV1.Issue[];
+
+/**
+ * Turn a **synchronous** Standard Schema into a validator returning a
+ * `Result`.
+ *
+ * @remarks
+ * Validation issues are the modeled error `E` — `Result<Output, SchemaIssues>` —
+ * because a failed validation is an *anticipated* outcome, not a defect. Works
+ * with any Standard Schema implementation (Zod, Valibot, ArkType, …).
+ *
+ * If the schema validates **asynchronously** (its `validate` returns a
+ * `Promise`), a synchronous `Result` cannot represent the pending work, so this
+ * throws a `TypeError` — use {@link fromSchemaAsync} instead.
+ *
+ * @typeParam S - the schema type.
+ * @param schema - a Standard Schema validator.
+ * @returns a function mapping an input to `Result<Output, SchemaIssues>`.
+ *
+ * @example
+ * ```ts
+ * import { fromSchema } from "@unthrown/standard-schema";
+ * const parse = fromSchema(z.string());
+ * parse("hi").unwrap(); // "hi"
+ * parse(42).unwrapErr(); // the issues array
+ * ```
+ */
+export function fromSchema<S extends StandardSchemaV1>(
+  schema: S,
+): (input: unknown) => Result<StandardSchemaV1.InferOutput<S>, SchemaIssues> {
+  return (input) => {
+    const result = schema["~standard"].validate(input);
+    if (result instanceof Promise) {
+      throw new TypeError(
+        "@unthrown/standard-schema: this schema validates asynchronously — use fromSchemaAsync instead.",
+      );
+    }
+    return result.issues ? err(result.issues) : ok(result.value);
+  };
+}
+
+/**
+ * Turn a Standard Schema (sync **or** async) into a validator returning an
+ * `AsyncResult`.
+ *
+ * @remarks
+ * The async counterpart of {@link fromSchema}: it awaits the schema's
+ * `validate`, so it accepts both synchronous and asynchronous schemas. As with
+ * every `AsyncResult`, the returned value never rejects — a validator that
+ * *throws* (rather than returning issues) becomes a `Defect`.
+ *
+ * @typeParam S - the schema type.
+ * @param schema - a Standard Schema validator.
+ * @returns a function mapping an input to `AsyncResult<Output, SchemaIssues>`.
+ *
+ * @example
+ * ```ts
+ * import { fromSchemaAsync } from "@unthrown/standard-schema";
+ * const parse = fromSchemaAsync(asyncSchema);
+ * (await parse(input)).match({ ok, err, defect });
+ * ```
+ */
+export function fromSchemaAsync<S extends StandardSchemaV1>(
+  schema: S,
+): (input: unknown) => AsyncResult<StandardSchemaV1.InferOutput<S>, SchemaIssues> {
+  return (input) =>
+    fromSafePromise(async () => schema["~standard"].validate(input)).flatMap((result) =>
+      result.issues ? err(result.issues) : ok(result.value),
+    );
+}

--- a/packages/standard-schema/tsconfig.json
+++ b/packages/standard-schema/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@unthrown/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/standard-schema/typedoc.json
+++ b/packages/standard-schema/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@unthrown/typedoc/base.json",
+  "entryPoints": ["src/index.ts"],
+  "out": "docs"
+}

--- a/packages/standard-schema/vitest.config.ts
+++ b/packages/standard-schema/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.spec.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**"],
+      // Both entry points are exercised over valid input, issues, an async
+      // schema, and a throwing validator (→ defect), covering every branch.
+      thresholds: {
+        statements: 95,
+        branches: 90,
+        functions: 100,
+        lines: 100,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ catalogs:
       specifier: 21.0.2
       version: 21.0.2
     '@standard-schema/spec':
-      specifier: 1.0.0
-      version: 1.0.0
+      specifier: 1.1.0
+      version: 1.1.0
     '@types/node':
       specifier: 24.13.2
       version: 24.13.2
@@ -318,7 +318,7 @@ importers:
     dependencies:
       '@standard-schema/spec':
         specifier: 'catalog:'
-        version: 1.0.0
+        version: 1.1.0
       unthrown:
         specifier: workspace:*
         version: link:../core
@@ -1828,9 +1828,6 @@ packages:
   '@simple-libs/stream-utils@1.2.0':
     resolution: {integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==}
     engines: {node: '>=18'}
-
-  '@standard-schema/spec@1.0.0':
-    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -4516,8 +4513,6 @@ snapshots:
       '@simple-libs/stream-utils': 1.2.0
 
   '@simple-libs/stream-utils@1.2.0': {}
-
-  '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ catalogs:
     '@commitlint/config-conventional':
       specifier: 21.0.2
       version: 21.0.2
+    '@standard-schema/spec':
+      specifier: 1.0.0
+      version: 1.0.0
     '@types/node':
       specifier: 24.13.2
       version: 24.13.2
@@ -113,6 +116,9 @@ importers:
       '@unthrown/pattern':
         specifier: workspace:*
         version: link:../packages/pattern
+      '@unthrown/standard-schema':
+        specifier: workspace:*
+        version: link:../packages/standard-schema
       '@unthrown/vitest':
         specifier: workspace:*
         version: link:../packages/vitest
@@ -292,6 +298,43 @@ importers:
       ts-pattern:
         specifier: 'catalog:'
         version: 5.9.0
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.2(oxc-resolver@11.21.3)(tsx@4.22.4)(typescript@6.0.3)
+      typedoc:
+        specifier: 'catalog:'
+        version: 0.28.19(typescript@6.0.3)
+      typedoc-plugin-markdown:
+        specifier: 'catalog:'
+        version: 4.12.0(typedoc@0.28.19(typescript@6.0.3))
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@types/node@24.13.2)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+
+  packages/standard-schema:
+    dependencies:
+      '@standard-schema/spec':
+        specifier: 'catalog:'
+        version: 1.0.0
+      unthrown:
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.2
+      '@unthrown/tsconfig':
+        specifier: workspace:*
+        version: link:../../tools/tsconfig
+      '@unthrown/typedoc':
+        specifier: workspace:*
+        version: link:../../tools/typedoc
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.8(vitest@4.1.8)
       tsdown:
         specifier: 'catalog:'
         version: 0.22.2(oxc-resolver@11.21.3)(tsx@4.22.4)(typescript@6.0.3)
@@ -1785,6 +1828,9 @@ packages:
   '@simple-libs/stream-utils@1.2.0':
     resolution: {integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==}
     engines: {node: '>=18'}
+
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -4470,6 +4516,8 @@ snapshots:
       '@simple-libs/stream-utils': 1.2.0
 
   '@simple-libs/stream-utils@1.2.0': {}
+
+  '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,7 @@ catalog:
   "@changesets/cli": 2.31.0
   "@commitlint/cli": 21.0.2
   "@bloodyowl/boxed": 3.4.0
+  "@standard-schema/spec": 1.0.0
   "@commitlint/config-conventional": 21.0.2
   "@types/node": 24.13.2
   "@vitest/coverage-v8": 4.1.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,7 @@ catalog:
   "@changesets/cli": 2.31.0
   "@commitlint/cli": 21.0.2
   "@bloodyowl/boxed": 3.4.0
-  "@standard-schema/spec": 1.0.0
+  "@standard-schema/spec": 1.1.0
   "@commitlint/config-conventional": 21.0.2
   "@types/node": 24.13.2
   "@vitest/coverage-v8": 4.1.8


### PR DESCRIPTION
New interop package bridging any [Standard Schema](https://standardschema.dev) validator (**Zod**, **Valibot**, **ArkType**, …) to a `Result`.

```ts
import { fromSchema } from "@unthrown/standard-schema";
import { z } from "zod";

const parseUser = fromSchema(z.object({ id: z.string() }));
parseUser({ id: "u_1" }).unwrap();   // { id: "u_1" }
parseUser({ id: 1 }).unwrapErr();    // readonly StandardSchemaV1.Issue[]
```

**Design:** the schema's validation issues are the modeled error `E` — a failed validation is an *anticipated* outcome, not a defect. There's no `to*` direction (you don't turn a `Result` back into a schema), so unlike the other interop packages it's `from*`-only.

- `fromSchema(schema)` → `(input) => Result<Output, readonly Issue[]>` (sync schemas; throws `TypeError` on an async schema — use the async form).
- `fromSchemaAsync(schema)` → `(input) => AsyncResult<Output, readonly Issue[]>` (sync **or** async schemas). A validator that *throws* becomes a `Defect`; the `AsyncResult` never rejects.

**Footprint:** the only dependency is the tiny **types-only** `@standard-schema/spec` — the consumer's validator library provides the runtime. Tests use a hand-rolled schema, so no validator lib is pulled into the workspace.

Wired into the catalog, the docs site (API reference + Interop guide), and `CLAUDE.md`. 7 tests, 100% line/function coverage; full gate (format/lint/knip/typecheck/test/build/docs) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)