### PR TITLE
docs: Choosing a Combinator guide + Recipes cookbook

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -47,6 +47,8 @@ export default defineConfig({
             { text: "The Defect Channel", link: "/guide/the-defect-channel" },
             { text: "Boundaries & Qualification", link: "/guide/boundaries" },
             { text: "Async Results", link: "/guide/async-results" },
+            { text: "Choosing a Combinator", link: "/guide/choosing-a-combinator" },
+            { text: "Recipes", link: "/guide/recipes" },
           ],
         },
         {

--- a/docs/guide/choosing-a-combinator.md
+++ b/docs/guide/choosing-a-combinator.md
@@ -1,0 +1,58 @@
+# Choosing a combinator
+
+The method surface is small, but "which one do I reach for?" comes up constantly.
+This page is the cheat sheet. Every combinator runs its callback **only on its own
+channel** and turns a thrown callback into a `Defect`.
+
+## By intent
+
+| I want to…                                     | use                | channel |
+| ---------------------------------------------- | ------------------ | ------- |
+| transform the success value                    | `map`              | Ok      |
+| run a dependent, `Result`-returning step       | `flatMap`          | Ok      |
+| run a side effect, keep the value              | `tap`              | Ok      |
+| run a **failable** side effect, keep the value | `flatTap`          | Ok      |
+| replace the value with a constant              | `as`               | Ok      |
+| transform the error                            | `mapErr`           | Err     |
+| try a fallback that returns a `Result`         | `orElse`           | Err     |
+| turn an error into a success value             | `recover`          | Err     |
+| run a side effect on the error                 | `tapErr`           | Err     |
+| recover from a defect (rare)                   | `recoverDefect`    | Defect  |
+| observe a defect, e.g. log it                  | `tapDefect`        | Defect  |
+| handle all three channels at the edge          | `match`            | all     |
+| combine many `Result`s                         | `all` / `allAsync` | —       |
+
+## The pairs that are easy to confuse
+
+**`map` vs `flatMap`** — does your callback return a plain value or a `Result`?
+A `(value) => U` is `map`; a `(value) => Result<U, E2>` is `flatMap` (otherwise
+you get a nested `Result<Result<…>>`).
+
+**`tap` vs `flatTap`** — both keep the original value. `tap` takes a `void`
+callback that can't fail; `flatTap` takes a `Result`-returning one and threads
+its error (a validation or write whose _outcome_ matters but whose _value_ you
+don't need).
+
+**`flatMap` vs `flatTap`** — both take a `Result`-returning callback. `flatMap`
+**replaces** the value with the callback's; `flatTap` **discards** the callback's
+value and keeps the original.
+
+**`orElse` vs `recover`** — both run on `Err`. `recover` produces a plain success
+value (emptying the error channel to `never`); `orElse` produces another
+`Result` (which may still be an `Err`).
+
+**`recover` vs `recoverDefect`** — `recover` handles a modeled `Err`;
+`recoverDefect` is the **only** combinator that can touch a `Defect`. Neither is
+the other's fallback: a defect flows past `recover` untouched.
+
+## When to leave the pipeline
+
+Reach for an eliminator once you're done chaining:
+
+- `match` — the default at the edge; fold all three channels into one value.
+- `unwrap` / `unwrapErr` — extract, throwing on the wrong variant (and
+  _panicking_ on a defect).
+- `unwrapOr` / `unwrapOrElse` / `getOrNull` / `getOrUndefined` — recover an `Err`
+  to a fallback, but **re-throw a defect** (it's a bug, not an absent value).
+
+→ Continue to [Recipes](./recipes).

--- a/docs/guide/recipes.md
+++ b/docs/guide/recipes.md
@@ -1,0 +1,115 @@
+# Recipes
+
+Practical, copy-pasteable patterns. They share one running example — a small
+**user profile service** — so each recipe builds on a domain you already know.
+
+The errors are [tagged](./tagged-errors):
+
+```ts
+import { TaggedError } from "unthrown";
+
+class NotFound extends TaggedError("NotFound")<{ id: string }> {}
+class Forbidden extends TaggedError("Forbidden") {}
+class InvalidProfile extends TaggedError("InvalidProfile")<{ field: string }> {}
+
+type ProfileError = NotFound | Forbidden | InvalidProfile;
+```
+
+## 1. An HTTP handler — one `match` at the edge
+
+Because every boundary is qualified and every in-pipeline throw becomes a defect,
+the edge of a request handler needs **no `try`/`catch`** — just one `match`
+mapping each channel to a status code.
+
+```ts
+import { fromPromise, defect } from "unthrown";
+
+const loadProfile = (id: string) =>
+  fromPromise(fetch(`/api/users/${id}`), (cause) =>
+    cause instanceof Response && cause.status === 404 ? new NotFound({ id }) : defect(cause),
+  ).flatMap((res) => fromPromise(res.json() as Promise<Profile>, defect));
+
+async function handler(id: string): Promise<HttpResponse> {
+  return (await loadProfile(id)).match({
+    ok: (profile) => ({ status: 200, body: profile }),
+    err: (e) => ({ status: e._tag === "NotFound" ? 404 : 403, body: e }),
+    defect: (cause) => {
+      logger.error(cause); // a real bug — log it, don't leak it
+      return { status: 500, body: "Internal Error" };
+    },
+  });
+}
+```
+
+A thrown `TypeError` from a bad `.json()` shape lands in `defect` → 500. A
+modeled `NotFound` lands in `err` → 404. The type told you which is which.
+
+## 2. Wrap a throwing parser
+
+Third-party code that throws is bridged once, at the boundary, with
+`fromThrowable` — the `qualify` function triages each throw into a modeled error
+or a defect.
+
+```ts
+import { fromThrowable, defect } from "unthrown";
+
+const parseProfile = fromThrowable(
+  (raw: string) => JSON.parse(raw) as Profile,
+  (cause) => (cause instanceof SyntaxError ? new InvalidProfile({ field: "json" }) : defect(cause)),
+);
+
+parseProfile('{"name":"Ada"}'); // Result<Profile, InvalidProfile>
+```
+
+## 3. Bridge a nullable lookup
+
+A cache or `Map` that returns `T | undefined` becomes a `Result` with
+`fromNullable` — the sanctioned alternative to an `Option` type.
+
+```ts
+import { fromNullable } from "unthrown";
+
+const fromCache = (id: string) => fromNullable(cache.get(id), () => new NotFound({ id }));
+
+fromCache("u_1").map((p) => p.name); // Result<string, NotFound>
+```
+
+## 4. Combine independent fetches
+
+`all` collects several `Result`s, short-circuiting on the first `Err` (and any
+`Defect` dominates):
+
+```ts
+import { all } from "unthrown";
+
+const page = all([loadProfile(id), loadPosts(id), loadFollowers(id)]);
+// Result<[Profile, Post[], User[]], ProfileError>
+
+page.map(([profile, posts, followers]) => renderPage(profile, posts, followers));
+```
+
+## 5. Fold a tagged-error union exhaustively
+
+When you want a branch per error tag (not just per channel), `matchTags` is an
+exhaustive fold — miss a tag and it won't compile, with no `.exhaustive()` to
+forget:
+
+```ts
+import { matchTags, type Result } from "unthrown";
+
+declare const result: Result<Profile, ProfileError>;
+
+const status = matchTags(result, {
+  Ok: () => 200,
+  Defect: (cause) => {
+    logger.error(cause);
+    return 500;
+  },
+  NotFound: (e) => (logger.info(`missing ${e.id}`), 404),
+  Forbidden: () => 403,
+  InvalidProfile: (e) => (logger.warn(`bad ${e.field}`), 422),
+});
+```
+
+→ Back to the [Guide](./why-unthrown), or browse the
+[API Reference](/api/core/).

--- a/docs/guide/recipes.md
+++ b/docs/guide/recipes.md
@@ -21,13 +21,22 @@ Because every boundary is qualified and every in-pipeline throw becomes a defect
 the edge of a request handler needs **no `try`/`catch`** — just one `match`
 mapping each channel to a status code.
 
+`fetch` only _rejects_ on a network error — a 404/403 resolves normally — so the
+modeled statuses are mapped in a `flatMap` (a `throw` there, like an unexpected
+status or malformed JSON, becomes a `Defect`):
+
 ```ts
-import { fromPromise, defect } from "unthrown";
+import { fromPromise, err, defect } from "unthrown";
 
 const loadProfile = (id: string) =>
-  fromPromise(fetch(`/api/users/${id}`), (cause) =>
-    cause instanceof Response && cause.status === 404 ? new NotFound({ id }) : defect(cause),
-  ).flatMap((res) => fromPromise(res.json() as Promise<Profile>, defect));
+  // A network error (a rejected fetch) is unexpected → defect.
+  fromPromise(fetch(`/api/users/${id}`), defect).flatMap((res) => {
+    if (res.status === 404) return err(new NotFound({ id }));
+    if (res.status === 403) return err(new Forbidden());
+    if (!res.ok) throw new Error(`unexpected status ${res.status}`); // → Defect
+    return fromPromise(res.json() as Promise<Profile>, defect); // malformed JSON → Defect
+  });
+// AsyncResult<Profile, NotFound | Forbidden>
 
 async function handler(id: string): Promise<HttpResponse> {
   return (await loadProfile(id)).match({
@@ -41,8 +50,9 @@ async function handler(id: string): Promise<HttpResponse> {
 }
 ```
 
-A thrown `TypeError` from a bad `.json()` shape lands in `defect` → 500. A
-modeled `NotFound` lands in `err` → 404. The type told you which is which.
+A network failure or malformed response lands in `defect` → 500. The modeled
+`NotFound` / `Forbidden` land in `err` → 404 / 403. The type told you which is
+which.
 
 ## 2. Wrap a throwing parser
 
@@ -76,17 +86,21 @@ fromCache("u_1").map((p) => p.name); // Result<string, NotFound>
 
 ## 4. Combine independent fetches
 
-`all` collects several `Result`s, short-circuiting on the first `Err` (and any
-`Defect` dominates):
+`loadProfile` and friends are `AsyncResult`s, so `allAsync` combines them —
+resolving concurrently, short-circuiting on the first `Err` (and any `Defect`
+dominates):
 
 ```ts
-import { all } from "unthrown";
+import { allAsync } from "unthrown";
 
-const page = all([loadProfile(id), loadPosts(id), loadFollowers(id)]);
-// Result<[Profile, Post[], User[]], ProfileError>
+const page = allAsync([loadProfile(id), loadPosts(id), loadFollowers(id)]);
+// AsyncResult<[Profile, Post[], User[]], ProfileError>
 
 page.map(([profile, posts, followers]) => renderPage(profile, posts, followers));
 ```
+
+(For synchronous `Result`s, use `all`; to key the results by name instead of
+position, `allFromDict` / `allFromDictAsync`.)
 
 ## 5. Fold a tagged-error union exhaustively
 


### PR DESCRIPTION
Two new guide pages — the exact prose gaps byethrow's docs leave open.

**`guide/choosing-a-combinator.md`** — the "which method do I reach for?" cheat sheet:
- An intent → method → channel table covering the whole surface.
- The easily-confused pairs spelled out: `map`/`flatMap`, `tap`/`flatTap`, `flatMap`/`flatTap`, `orElse`/`recover`, `recover`/`recoverDefect`.
- When to leave the pipeline (which eliminator).

**`guide/recipes.md`** — five copy-pasteable patterns sharing **one running narrative** (a "user profile service"), which is byethrow's best onboarding device and the "single running narrative" idea from the menu:
1. HTTP handler — one `match` at the edge, no `try`/`catch`.
2. Wrapping a throwing parser (`fromThrowable`).
3. Bridging a nullable lookup (`fromNullable`).
4. Combining independent fetches (`all`).
5. Exhaustive tagged-error fold (`matchTags`).

Both wired into the **Working with Results** sidebar. Docs build is clean (all links resolve).

### Notes / scope
- I delivered the "running narrative" as the cookbook rather than rewriting Getting Started / Core Concepts — those are already clean, and rewriting them would collide with the other open PRs touching `core-concepts.md`. Happy to thread the same narrative through the intro pages as a follow-up if you'd like.
- **Depends on #23** (`flatTap`): the combinator guide lists `flatTap`. Merge #23 first, or I can drop those rows if you'd rather land this independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)