### PR TITLE
test(core): add a type-level test suite

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,5 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "ignorePatterns": ["**/*.test-d.ts"],
   "rules": {
     "@typescript-eslint/no-explicit-any": "error",
     "typescript/consistent-type-definitions": ["error", "type"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,6 +253,15 @@ changesets `release.yml` (plus enabling GitHub Pages for `deploy-docs.yml`).
 - Tests: Vitest. Every load-bearing invariant above gets an explicit test
   (`invariants.spec.ts` guards them 1:1); core holds 100% line/function coverage,
   enforced by thresholds in its `vitest.config.ts`.
+- **Type-level tests:** `packages/core/src/types.test-d.ts` asserts the
+  type-level behaviour the runtime can't (the conditional `all`/`allFromDict`
+  shapes, `Exclude<R, Defect>` boundary inference, `flatTap`/`recover` channel
+  widening, the `this is …` guard narrowing, `matchTags` exhaustiveness) with a
+  `Expect<Equal<…>>` helper plus `@ts-expect-error` for must-not-compile cases.
+  They are checked by `tsc` via `tsconfig.test-d.json` (which relaxes
+  `noUnusedLocals`), folded into the package's `typecheck` script — so a typing
+  regression fails the gate. The file is excluded from the build, coverage,
+  oxlint, and knip (it has no runtime).
 - Public API carries full **TSDoc**; `pnpm --filter <pkg> build:docs` must stay
   typedoc-warning-free.
 - One concept = one name. Resist convenience aliases.

--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "ignoreExportsUsedInFile": true,
+  "ignore": ["**/*.test-d.ts"],
   "workspaces": {
     "packages/*": {
       "project": ["src/**/*.ts"]

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -19,6 +19,12 @@ pre-commit:
       stage_fixed: true
     lint:
       glob: "*.{ts,tsx,js,jsx}"
+      # Mirror oxlint's `ignorePatterns` (type-only test files): handing oxlint
+      # ONLY ignored files makes it exit non-zero ("No files found to lint"),
+      # which would fail a commit touching only those. Exclude them here so the
+      # step is skipped instead.
+      exclude:
+        - "*.test-d.ts"
       run: pnpm oxlint {staged_files}
 
 commit-msg:

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,8 @@
     "build:docs": "typedoc",
     "dev": "tsdown src/index.ts --format cjs,esm --dts --watch",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit"
+    "test:types": "tsc --noEmit -p tsconfig.test-d.json",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test-d.json"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -1,0 +1,165 @@
+// Type-level test suite. These assertions have no runtime; they are checked by
+// `tsc` (the `typecheck` script runs this file through `tsconfig.test-d.json`,
+// which relaxes the unused-locals rules so throwaway assertion bindings are
+// allowed). A failing assertion is a compile error.
+//
+// `Expect<Equal<A, B>>` is a hard error when `A` and `B` differ; `@ts-expect-error`
+// guards the cases that must NOT compile.
+
+import {
+  all,
+  allAsync,
+  allFromDict,
+  allFromDictAsync,
+  type AsyncErrOf,
+  type AsyncOkOf,
+  type AsyncResult,
+  defect,
+  type ErrOf,
+  err,
+  fromPromise,
+  fromThrowable,
+  isErr,
+  isOk,
+  matchTags,
+  ok,
+  type OkOf,
+  type Result,
+  TaggedError,
+} from "./index.js";
+
+// --- assertion helpers -------------------------------------------------------
+
+type Equal<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+// --- constructors ------------------------------------------------------------
+
+const okV = ok(1);
+type _ok = Expect<Equal<typeof okV, Result<number, never>>>;
+
+const errV = err<string>("e");
+type _err = Expect<Equal<typeof errV, Result<never, string>>>;
+
+// --- aggregation: `all` keeps positional tuple types -------------------------
+
+const tuple = all([ok(1), ok("x"), ok(true)]);
+type _tuple = Expect<Equal<typeof tuple, Result<[number, string, boolean], never>>>;
+
+// the empty tuple stays `[]`, not `never[]` (regression guard)
+const empty = all([]);
+type _empty = Expect<Equal<typeof empty, Result<[], never>>>;
+
+// a dynamic array collapses to `T[]`
+declare const arr: Result<number, "e">[];
+const collapsed = all(arr);
+type _collapsed = Expect<Equal<typeof collapsed, Result<number[], "e">>>;
+
+// the error channel is the union of every element's error
+declare const r1: Result<number, "e1">;
+declare const r2: Result<string, "e2">;
+const mixedErr = all([r1, r2]);
+type _mixedErr = Expect<Equal<typeof mixedErr, Result<[number, string], "e1" | "e2">>>;
+
+// `allFromDict` produces a record of values, keyed by name
+const dict = allFromDict({ id: ok(1), name: ok("ada") });
+type _dict = Expect<Equal<typeof dict, Result<{ id: number; name: string }, never>>>;
+
+// async counterparts
+const tupleAsync = allAsync([r1.toAsync(), r2.toAsync()]);
+type _tupleAsync = Expect<Equal<typeof tupleAsync, AsyncResult<[number, string], "e1" | "e2">>>;
+
+const dictAsync = allFromDictAsync({ id: ok(1).toAsync(), name: ok("ada").toAsync() });
+type _dictAsync = Expect<Equal<typeof dictAsync, AsyncResult<{ id: number; name: string }, never>>>;
+
+// --- boundaries: `Defect` is subtracted from the error channel ---------------
+
+// a defect-only qualify yields `E = never`
+const defectOnly = fromPromise(Promise.resolve(1), (c) => defect(c));
+type _defectOnly = Expect<Equal<typeof defectOnly, AsyncResult<number, never>>>;
+
+// a mixed qualify keeps only the modeled arm
+const mixedQualify = fromPromise(Promise.resolve(1), (c) =>
+  c === 1 ? ("nf" as const) : defect(c),
+);
+type _mixedQualify = Expect<Equal<typeof mixedQualify, AsyncResult<number, "nf">>>;
+
+// the same subtraction on `fromThrowable`
+const throwable = fromThrowable(
+  (s: string) => s.length,
+  (c) => defect(c),
+);
+type _throwable = Expect<Equal<ReturnType<typeof throwable>, Result<number, never>>>;
+
+// qualify is mandatory — there is no one-arg boundary
+// @ts-expect-error - the qualify argument is required
+fromPromise(Promise.resolve(1));
+
+// --- combinators -------------------------------------------------------------
+
+// flatMap widens the error channel
+const flatMapped = r1.flatMap(() => err<"e2">("e2"));
+type _flatMapped = Expect<Equal<typeof flatMapped, Result<never, "e1" | "e2">>>;
+
+// flatTap KEEPS the value type and widens the error channel
+const flatTapped = r1.flatTap(() => err<"e2">("e2"));
+type _flatTapped = Expect<Equal<typeof flatTapped, Result<number, "e1" | "e2">>>;
+
+// recover empties the error channel (to `never`)
+const recovered = r1.recover(() => 0);
+type _recovered = Expect<Equal<typeof recovered, Result<number, never>>>;
+
+// map changes the value type; mapErr changes the error type
+const mapped = r1.map((n) => `${n}`);
+type _mapped = Expect<Equal<typeof mapped, Result<string, "e1">>>;
+const errMapped = r1.mapErr(() => 0 as const);
+type _errMapped = Expect<Equal<typeof errMapped, Result<number, 0>>>;
+
+// --- guards narrow (methods AND standalone) ----------------------------------
+
+declare const g: Result<number, string>;
+
+if (g.isOk()) {
+  type _gv = Expect<Equal<typeof g.value, number>>;
+}
+if (g.isErr()) {
+  type _ge = Expect<Equal<typeof g.error, string>>;
+}
+if (g.isDefect()) {
+  type _gc = Expect<Equal<typeof g.cause, unknown>>;
+}
+if (isOk(g)) {
+  type _sv = Expect<Equal<typeof g.value, number>>;
+}
+if (isErr(g)) {
+  type _se = Expect<Equal<typeof g.error, string>>;
+}
+
+// the payload is unreachable before narrowing
+// @ts-expect-error - `.value` only exists on the Ok variant
+const _noValue = g.value;
+// @ts-expect-error - `.error` only exists on the Err variant
+const _noError = g.error;
+
+// --- extractor types ---------------------------------------------------------
+
+type _okOf = Expect<Equal<OkOf<Result<number, "e">>, number>>;
+type _errOf = Expect<Equal<ErrOf<Result<number, "e">>, "e">>;
+type _asyncOkOf = Expect<Equal<AsyncOkOf<AsyncResult<number, "e">>, number>>;
+type _asyncErrOf = Expect<Equal<AsyncErrOf<AsyncResult<number, "e">>, "e">>;
+
+// --- tagged errors: matchTags is exhaustive ----------------------------------
+
+class TagA extends TaggedError("TagA") {}
+class TagB extends TaggedError("TagB") {}
+declare const tagged: Result<number, TagA | TagB>;
+
+matchTags(tagged, { Ok: () => 1, Defect: () => 2, TagA: () => 3, TagB: () => 4 });
+
+// @ts-expect-error - the TagB handler is missing
+matchTags(tagged, { Ok: () => 1, Defect: () => 2, TagA: () => 3 });
+
+// `_tag` is the literal; `options.name` is independent (still a literal `_tag`)
+class Named extends TaggedError("@scope/Named", { name: "Named" }) {}
+type _namedTag = Expect<Equal<(typeof Named)["prototype"]["_tag"], "@scope/Named">>;

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -19,6 +19,7 @@ import {
   err,
   fromPromise,
   fromThrowable,
+  isDefect,
   isErr,
   isOk,
   matchTags,
@@ -134,6 +135,9 @@ if (isOk(g)) {
 }
 if (isErr(g)) {
   type _se = Expect<Equal<typeof g.error, string>>;
+}
+if (isDefect(g)) {
+  type _sc = Expect<Equal<typeof g.cause, unknown>>;
 }
 
 // the payload is unreachable before narrowing

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test-d.ts"]
 }

--- a/packages/core/tsconfig.test-d.json
+++ b/packages/core/tsconfig.test-d.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/core/tsconfig.test-d.json
+++ b/packages/core/tsconfig.test-d.json
@@ -4,6 +4,6 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*.test-d.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -7,6 +7,8 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       include: ["src/**"],
+      // Type-only tests carry no runtime; they're checked by `tsc`, not coverage.
+      exclude: ["src/**/*.test-d.ts"],
       // Lock in the full-coverage suite. Branches sit below 100 only because of
       // the deliberately-unreachable defensive `then` rejection path.
       thresholds: {


### PR DESCRIPTION
Closes the one genuine gap in the quality story: the core has **load-bearing type-level machinery** (the conditional `all`/`allFromDict` shapes, `Exclude<R, Defect>` boundary inference, the `this is …` narrowing predicates, `matchTags` exhaustiveness) that nothing tested directly — a typing regression could ship silently.

Adds `packages/core/src/types.test-d.ts`: ~35 assertions using a `Expect<Equal<A, B>>` helper, plus `@ts-expect-error` for the must-**not**-compile cases. Coverage:

- **Aggregation:** `all` keeps positional tuple types; empty tuple stays `Result<[], never>` (the regression we fixed); dynamic array collapses to `T[]`; error channel unions; `allFromDict` / `allAsync` / `allFromDictAsync` shapes.
- **Boundaries:** a defect-only `qualify` → `E = never`; a mixed `qualify` keeps only the modeled arm; same on `fromThrowable`; `qualify` is mandatory (`@ts-expect-error` on the one-arg call).
- **Combinators:** `flatMap` widens `E`; `flatTap` **keeps `T`** and widens `E`; `recover` empties `E` to `never`; `map`/`mapErr`.
- **Guards:** method and standalone `isOk`/`isErr`/`isDefect` narrow; `.value`/`.error` are unreachable before narrowing (`@ts-expect-error`).
- **Extractors & tagged errors:** `OkOf`/`ErrOf`/`AsyncOkOf`/`AsyncErrOf`; `matchTags` fails to compile with a missing handler; `_tag` stays a literal independent of `options.name`.

## How it's wired
- Checked by `tsc` through a dedicated `tsconfig.test-d.json` (relaxes `noUnusedLocals` for throwaway assertion bindings), **folded into the package `typecheck` script** (`tsc --noEmit && tsc --noEmit -p tsconfig.test-d.json`) — so it runs in the existing CI gate, no new job. Also exposed as `pnpm --filter unthrown test:types`.
- The file has **no runtime**, so it's excluded from the build, coverage, oxlint, and knip.
- **Verified the harness isn't vacuous:** injecting `Expect<Equal<number, string>>` fails with `Type 'false' does not satisfy the constraint 'true'`.

Full gate green (format/lint/knip/typecheck/test/build); runtime coverage unchanged at 100% line/function.

No changeset — this is test infrastructure, no published behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)