### PR TITLE
chore(docs): bump @btravstack/theme to 1.3.0 (chrome refinements)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: 3.4.0
       version: 3.4.0
     '@btravstack/theme':
-      specifier: 1.2.1
-      version: 1.2.1
+      specifier: 1.3.0
+      version: 1.3.0
     '@changesets/cli':
       specifier: 2.31.0
       version: 2.31.0
@@ -134,7 +134,7 @@ importers:
     devDependencies:
       '@btravstack/theme':
         specifier: 'catalog:'
-        version: 1.2.1(vitepress@1.6.4(@algolia/client-search@5.55.1)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3))
+        version: 1.3.0(vitepress@1.6.4(@algolia/client-search@5.55.1)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3))
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
@@ -571,8 +571,8 @@ packages:
       typescript:
         optional: true
 
-  '@btravstack/theme@1.2.1':
-    resolution: {integrity: sha512-v9FGRapJxIOpiniwVNFcn3ht18VIowf4K0bPwl9z5V1nfRW7YpqFYe3/JGGimNh6/Ukof0qtHmeuqYB8Hfpagg==}
+  '@btravstack/theme@1.3.0':
+    resolution: {integrity: sha512-7lyrA0XjH8Fm1BDPOVWji3iIVYTYFYBpeAdITenaV0KXdvImZSMPDhUr/XQRV8LHCMfo8E9FVxRMDRhNCHEdKg==}
     peerDependencies:
       vitepress: ^1.6.0
 
@@ -3568,7 +3568,7 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@btravstack/theme@1.2.1(vitepress@1.6.4(@algolia/client-search@5.55.1)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3))':
+  '@btravstack/theme@1.3.0(vitepress@1.6.4(@algolia/client-search@5.55.1)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3))':
     dependencies:
       vitepress: 1.6.4(@algolia/client-search@5.55.1)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,7 @@ catalog:
   "@changesets/cli": 2.31.0
   "@commitlint/cli": 21.0.2
   "@bloodyowl/boxed": 3.4.0
-  "@btravstack/theme": 1.2.1
+  "@btravstack/theme": 1.3.0
   "@standard-schema/spec": 1.1.0
   "@commitlint/config-conventional": 21.0.2
   "@oxlint/plugins": 1.69.0


### PR DESCRIPTION
Bumps the shared theme to **1.3.0**, picking up the docs chrome refinements:

- **Navbar logo** sized up via `--vp-nav-logo-height` (30px / 26px mobile).
- **Home hero** type tightened.
- **Feature cards** get a hairline border + soft hover-lift + brand-tinted icon chip.

Catalog-only change (`1.2.1 → 1.3.0` + lockfile); docs keeps its `catalog:` reference. Merging redeploys the docs with the refinements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)