### PR TITLE
feat(core): add AsyncResult facade, split statics by return type

### DIFF
--- a/.changeset/async-result-facade.md
+++ b/.changeset/async-result-facade.md
@@ -1,0 +1,22 @@
+---
+"unthrown": major
+---
+
+**BREAKING:** add an `AsyncResult` companion object and split the static entry
+points across the two facades **by what they return**, so each static lives in
+exactly one namespace.
+
+- New `AsyncResult.*` companion (value + type sharing one name, like `Result`):
+  `AsyncResult.fromPromise`, `AsyncResult.fromSafePromise`, `AsyncResult.all`,
+  `AsyncResult.allFromDict`. The aggregates **drop the `Async` suffix** the free
+  functions carry — the namespace already says async (`AsyncResult.all` _is_ the
+  free function `allAsync`).
+- The async entry points are **removed from the `Result` facade**:
+  `Result.fromPromise`, `Result.fromSafePromise`, `Result.allAsync`, and
+  `Result.allFromDictAsync` are gone — use `AsyncResult.fromPromise` etc. (They
+  returned an `AsyncResult`, not a `Result`, so they were misplaced.)
+
+Unaffected: the **free functions** (`fromPromise`, `allAsync`, …) are unchanged
+and remain the primary, tree-shakeable API; the companions are opt-in sugar. The
+`Result` facade keeps every `Result`-producing static
+(`Ok`/`Err`/`Defect`/`Do`/`fromNullable`/`fromThrowable`/`all`/`allFromDict`/`is*`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,11 +118,20 @@ async work re-enters via `fromPromise` / `fromSafePromise` and composes with
   `allAsync` / `allFromDictAsync` resolve concurrently (order preserved) and never
   reject. The record fold writes keys via `Object.defineProperty`, so a
   caller-supplied `"__proto__"` key can't pollute the prototype.
-- facade: a `Result` companion object aliases the standalone entry points
-  (`Result.Ok`/`Err`/`Defect`/`Do`/`from*`/`all`/`allAsync`/`allFromDict`/`allFromDictAsync`/`is*`)
-  for discoverability;
-  the free functions remain the primary, tree-shakeable API. One concept, two
-  import styles — not a second concept.
+- facade: two companion objects alias the standalone entry points, **grouped by
+  what they return** so a static lives in exactly one namespace. `Result.*` holds
+  the `Result`-producing ones
+  (`Result.Ok`/`Err`/`Defect`/`Do`/`fromNullable`/`fromThrowable`/`all`/`allFromDict`/`is*`);
+  `AsyncResult.*` holds the `AsyncResult`-producing ones
+  (`AsyncResult.fromPromise`/`fromSafePromise`/`all`/`allFromDict` — the
+  aggregates drop the `Async` suffix the free functions carry, since the
+  namespace already says async). Both are value+type companions (the value and
+  the `Result<T,E>` / `AsyncResult<T,E>` type share one name). The free functions
+  remain the primary, tree-shakeable API; the companions are opt-in sugar (only
+  code importing a companion value forgoes tree-shaking). One concept, two import
+  styles — not a second concept. (Each companion re-aliases its type in
+  `facade.ts`, so the `types.ts` `Result`/`AsyncResult` declarations both sit in
+  `typedoc.json`'s `intentionallyNotExported`.)
 - tagged errors: `TaggedError(tag, options?)` (the error-class factory; optional
   `options.name` sets `Error.name` independently of the `_tag` discriminant, so a
   tag can be namespaced for collision-safety without leaking into the display

--- a/docs/guide/core-concepts.md
+++ b/docs/guide/core-concepts.md
@@ -65,7 +65,7 @@ If you prefer a namespace, two companion objects alias the same entry points —
 **grouped by what they return**, so each static lives in exactly one place:
 
 ```ts
-import { Result, AsyncResult } from "unthrown";
+import { Result, AsyncResult, Defect } from "unthrown";
 
 // Result.* — everything that yields a Result (sync)
 Result.Ok(1);
@@ -77,10 +77,13 @@ await AsyncResult.fromPromise(fetchUser(id), (c) => Defect(c));
 await AsyncResult.all([AsyncResult.fromSafePromise(loadA()), AsyncResult.fromSafePromise(loadB())]);
 ```
 
-The free functions remain the primary, tree-shakeable API; the companions are a
-zero-cost, opt-in alias (a separate export — `import { Ok }` never pulls one in).
-Inside `AsyncResult` the aggregates drop the `Async` suffix (`AsyncResult.all`
-**is** the free function `allAsync`) — the namespace already says async.
+The free functions remain the primary, tree-shakeable API; the companions are an
+opt-in alias (a separate export — `import { Ok }` never pulls one in). Importing a
+companion _value_ trades that tree-shaking for the namespace, since it references
+every entry point; the library is small, so the cost is minor — but if you care
+about it, prefer the free functions. Inside `AsyncResult` the aggregates drop the
+`Async` suffix (`AsyncResult.all` **is** the free function `allAsync`) — the
+namespace already says async.
 
 ## Guards that narrow
 

--- a/docs/guide/core-concepts.md
+++ b/docs/guide/core-concepts.md
@@ -53,7 +53,7 @@ Ok(user)
 // → still the original user on success; short-circuits to WriteError on failure
 ```
 
-## Constructors and the `Result` facade
+## Constructors and the `Result` / `AsyncResult` facades
 
 The constructors and helpers are tree-shakeable free functions:
 
@@ -61,19 +61,26 @@ The constructors and helpers are tree-shakeable free functions:
 import { Ok, Err, fromNullable, all } from "unthrown";
 ```
 
-If you prefer a namespace, a `Result` companion object aliases the same entry
-points — handy for discoverability:
+If you prefer a namespace, two companion objects alias the same entry points —
+**grouped by what they return**, so each static lives in exactly one place:
 
 ```ts
-import { Result } from "unthrown";
+import { Result, AsyncResult } from "unthrown";
 
+// Result.* — everything that yields a Result (sync)
 Result.Ok(1);
 Result.fromNullable(map.get(key), () => "absent");
 Result.all([Result.Ok(1), Result.Ok(2)]);
+
+// AsyncResult.* — everything that yields an AsyncResult
+await AsyncResult.fromPromise(fetchUser(id), (c) => Defect(c));
+await AsyncResult.all([AsyncResult.fromSafePromise(loadA()), AsyncResult.fromSafePromise(loadB())]);
 ```
 
-The free functions remain the primary, tree-shakeable API; `Result.*` is a
-zero-cost alias (a separate export — `import { Ok }` never pulls it in).
+The free functions remain the primary, tree-shakeable API; the companions are a
+zero-cost, opt-in alias (a separate export — `import { Ok }` never pulls one in).
+Inside `AsyncResult` the aggregates drop the `Async` suffix (`AsyncResult.all`
+**is** the free function `allAsync`) — the namespace already says async.
 
 ## Guards that narrow
 

--- a/packages/core/src/facade.spec.ts
+++ b/packages/core/src/facade.spec.ts
@@ -1,6 +1,21 @@
 import { describe, expect, it } from "vitest";
 
-import { all, Err, fromNullable, isDefect, isErr, isOk, isResult, Ok, Result } from "./index.js";
+import {
+  all,
+  allAsync,
+  allFromDictAsync,
+  AsyncResult,
+  Err,
+  fromNullable,
+  fromPromise,
+  fromSafePromise,
+  isDefect,
+  isErr,
+  isOk,
+  isResult,
+  Ok,
+  Result,
+} from "./index.js";
 
 const boom = new Error("boom");
 
@@ -28,10 +43,39 @@ describe("Result facade mirrors the free functions", () => {
     expect(Result.isResult(42)).toBe(false);
   });
 
-  it("exposes the same interop and aggregate entry points", () => {
+  it("exposes the sync interop and aggregate entry points", () => {
     expect(Result.fromNullable).toBe(fromNullable);
     expect(Result.all).toBe(all);
     expect(Result.fromNullable(null, () => "absent").unwrapErr()).toBe("absent");
     expect(Result.all([Result.Ok(1), Result.Ok(2)]).unwrap()).toEqual([1, 2]);
+  });
+
+  it("does NOT carry the async entry points (those live on AsyncResult)", () => {
+    expect("fromPromise" in Result).toBe(false);
+    expect("fromSafePromise" in Result).toBe(false);
+    expect("allAsync" in Result).toBe(false);
+    expect("allFromDictAsync" in Result).toBe(false);
+  });
+});
+
+describe("AsyncResult facade groups the async-producing entry points", () => {
+  it("aliases the free functions, dropping the Async suffix on the aggregates", () => {
+    expect(AsyncResult.fromPromise).toBe(fromPromise);
+    expect(AsyncResult.fromSafePromise).toBe(fromSafePromise);
+    expect(AsyncResult.all).toBe(allAsync);
+    expect(AsyncResult.allFromDict).toBe(allFromDictAsync);
+  });
+
+  it("constructs and aggregates async results", async () => {
+    expect((await AsyncResult.fromSafePromise(Promise.resolve(3))).unwrap()).toBe(3);
+    const both = await AsyncResult.all([
+      AsyncResult.fromSafePromise(Promise.resolve(1)),
+      AsyncResult.fromSafePromise(Promise.resolve(2)),
+    ]);
+    expect(both.unwrap()).toEqual([1, 2]);
+    const dict = await AsyncResult.allFromDict({
+      a: AsyncResult.fromSafePromise(Promise.resolve("x")),
+    });
+    expect(dict.unwrap()).toEqual({ a: "x" });
   });
 });

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -81,7 +81,7 @@ export type Result<T, E> = ResultType<T, E>;
  *
  * @example
  * ```ts
- * import { AsyncResult } from "unthrown";
+ * import { AsyncResult, Defect } from "unthrown";
  * const user = await AsyncResult.fromPromise(fetchUser(id), (c) => Defect(c));
  * ```
  */

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -18,22 +18,25 @@ import {
   fromSafePromise,
   fromThrowable,
 } from "./interop.js";
-import type { Result as ResultType } from "./types.js";
+import type { AsyncResult as AsyncResultType, Result as ResultType } from "./types.js";
 
 /**
- * Companion object grouping the standalone entry points under a single,
- * discoverable namespace: {@link Result.Ok}, {@link Result.Err},
- * {@link Result.Defect}, {@link Result.fromNullable}, {@link Result.fromThrowable},
- * {@link Result.fromPromise}, {@link Result.fromSafePromise}, {@link Result.all},
- * {@link Result.allAsync}, {@link Result.allFromDict},
- * {@link Result.allFromDictAsync}, {@link Result.isOk}, {@link Result.isErr},
- * {@link Result.isDefect}, {@link Result.isResult}.
+ * Companion object grouping the **`Result`-producing** entry points under a
+ * single, discoverable namespace: {@link Result.Ok}, {@link Result.Err},
+ * {@link Result.Defect}, {@link Result.Do}, {@link Result.fromNullable},
+ * {@link Result.fromThrowable}, {@link Result.all}, {@link Result.allFromDict},
+ * {@link Result.isOk}, {@link Result.isErr}, {@link Result.isDefect},
+ * {@link Result.isResult}.
  *
  * @remarks
  * Purely additive sugar — each member **is** the corresponding free function.
  * The free functions remain the primary, tree-shakeable API; importing only
  * `{ Ok }` never pulls this object in. The value `Result` and the type
  * {@link Result} share one name (the companion-object pattern).
+ *
+ * The **async** entry points live on the sibling {@link AsyncResult} companion
+ * (`AsyncResult.fromPromise`, `AsyncResult.all`, …), grouped by what they
+ * return — a static lives in exactly one namespace.
  *
  * @example
  * ```ts
@@ -48,12 +51,8 @@ export const Result = {
   Do,
   fromNullable,
   fromThrowable,
-  fromPromise,
-  fromSafePromise,
   all,
-  allAsync,
   allFromDict,
-  allFromDictAsync,
   isOk,
   isErr,
   isDefect,
@@ -64,3 +63,35 @@ export const Result = {
 // (from index.ts) carries BOTH the companion object above and the type — value
 // and type sharing one name, declaration-merged in one place.
 export type Result<T, E> = ResultType<T, E>;
+
+/**
+ * Companion object grouping the **`AsyncResult`-producing** entry points under
+ * the matching namespace: {@link AsyncResult.fromPromise},
+ * {@link AsyncResult.fromSafePromise}, {@link AsyncResult.all},
+ * {@link AsyncResult.allFromDict}.
+ *
+ * @remarks
+ * The async sibling of {@link Result}. Statics are grouped by what they
+ * **return**, so `fromPromise`/`fromSafePromise` and the async aggregates sit
+ * here rather than on {@link Result}; the namespace already conveys "async", so
+ * the aggregates drop the `Async` suffix (`AsyncResult.all` is the free function
+ * `allAsync`; `AsyncResult.allFromDict` is `allFromDictAsync`). Like
+ * {@link Result}, the free functions remain the primary, tree-shakeable API; the
+ * value `AsyncResult` and the type {@link AsyncResult} share one name.
+ *
+ * @example
+ * ```ts
+ * import { AsyncResult } from "unthrown";
+ * const user = await AsyncResult.fromPromise(fetchUser(id), (c) => Defect(c));
+ * ```
+ */
+export const AsyncResult = {
+  fromPromise,
+  fromSafePromise,
+  all: allAsync,
+  allFromDict: allFromDictAsync,
+} as const;
+
+// Re-alias the AsyncResult type into this module (same companion-object pattern
+// as Result above) so one `export { AsyncResult }` carries value + type.
+export type AsyncResult<T, E> = AsyncResultType<T, E>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,7 +2,7 @@ export { Err, isDefect, isErr, isOk, Ok } from "./constructors.js";
 export { isResult, UnwrapError } from "./core.js";
 export { Defect } from "./defect.js";
 export { Do } from "./do.js";
-export { Result } from "./facade.js";
+export { AsyncResult, Result } from "./facade.js";
 export {
   all,
   allAsync,
@@ -19,7 +19,6 @@ export type { TaggedErrorConstructor, TaggedErrorInstance, TagHandlers } from ".
 export type {
   AsyncErrOf,
   AsyncOkOf,
-  AsyncResult,
   Awaitable,
   DefectView,
   ErrOf,

--- a/packages/core/typedoc.json
+++ b/packages/core/typedoc.json
@@ -4,6 +4,7 @@
   "out": "docs",
   "intentionallyNotExported": [
     "Result",
+    "AsyncResult",
     "Props",
     "ResultMethods",
     "AllOk",


### PR DESCRIPTION
Follow-up to the API-surface work. Adds an **`AsyncResult` companion object** and groups the two facades by **what they return**, so each static lives in exactly one namespace — readable `AsyncResult.fromPromise(...)` instead of importing free factories.

### New `AsyncResult.*` companion
Value + type sharing one name (same companion-object pattern as `Result`):
- `AsyncResult.fromPromise`, `AsyncResult.fromSafePromise`
- `AsyncResult.all`, `AsyncResult.allFromDict` — the aggregates **drop the `Async` suffix** the free functions carry; the namespace already says async (`AsyncResult.all` _is_ `allAsync`).

```ts
import { AsyncResult, Defect } from "unthrown";
const user = await AsyncResult.fromPromise(fetchUser(id), (c) => Defect(c));
```

### Result facade trimmed (breaking)
`Result.fromPromise` / `Result.fromSafePromise` / `Result.allAsync` / `Result.allFromDictAsync` are **removed** — they returned an `AsyncResult`, not a `Result`, so they were misplaced. Use `AsyncResult.*`. The `Result` facade keeps every `Result`-producing static (`Ok`/`Err`/`Defect`/`Do`/`fromNullable`/`fromThrowable`/`all`/`allFromDict`/`is*`).

### Not affected
The **free functions** (`fromPromise`, `allAsync`, …) are unchanged and remain the primary, tree-shakeable API; the companions are opt-in sugar (only code importing a companion *value* forgoes tree-shaking — which, per the design discussion, is an acceptable, local cost).

### Notes
- Mirrors neverthrow's `Result.*` vs `ResultAsync.*` split.
- The `AsyncResult` **type** is re-aliased in `facade.ts` (companion pattern), so the `types.ts` declaration joins `Result` in `typedoc.json`'s `intentionallyNotExported` — `build:docs` stays warning-free.
- Gate green: format · lint · typecheck 15/15 · knip · test 15/15 (168, incl. a new `AsyncResult` facade block + a `Result`-has-no-async-entries guard) · build · docs warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)