### PR TITLE
chore(docs): link up to the btravstack hub

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -29,6 +29,8 @@ export default defineConfig({
         text: "Changelog",
         link: "https://github.com/btravstack/unthrown/releases",
       },
+      // Back to the btravstack hub (links the docs up to the landing page).
+      { text: "btravstack", link: "https://btravstack.github.io/" },
     ],
 
     sidebar: {


### PR DESCRIPTION
Adds a **btravstack** navbar item linking to `https://btravstack.github.io/`. The landing already links *down* to each docs site; this links the docs *up* to the hub — better for users and for crawl discovery / link equity across the one-domain site. (VitePress renders it with its external-link arrow.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)