### PR TITLE
feat(core): chain the offending value through UnwrapError.cause

### DIFF
--- a/.changeset/unwrap-error-cause.md
+++ b/.changeset/unwrap-error-cause.md
@@ -1,0 +1,9 @@
+---
+"unthrown": minor
+---
+
+`UnwrapError` now exposes the offending value on the standard `Error.cause` in
+addition to its typed `.error` property. When `unwrap()`/`unwrapErr()` throw on a
+modeled `Result`, an `Error`-typed `E` (e.g. a `TaggedError`) chains its original
+stack under "caused by"; other payloads surface under `[cause]`. `.error` is
+unchanged, and the `Defect` panic path still rethrows the raw cause.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,9 @@ was planned).
   `recoverDefect()`.** Therefore `unwrapOr`, `unwrapOrElse`, `getOrNull`,
   `getOrUndefined` still **throw** on a `Defect` — they recover the modeled `Err`,
   never an unmodeled defect (a defect is a bug, not an absent value).
-- **`unwrap()` is asymmetric.** On `Err` it throws a `UnwrapError` carrying `E`.
+- **`unwrap()` is asymmetric.** On `Err` it throws a `UnwrapError` carrying `E`
+  (on both the typed `.error` property and the standard `Error.cause`, so an
+  `Error`-typed `E` chains its original stack under "caused by").
   On a `Defect` it **rethrows the original `cause`** (it _panics_) with its
   original stack, so an unhandled defect hits the global handler looking like the
   real failure.

--- a/packages/core/src/constructors.spec.ts
+++ b/packages/core/src/constructors.spec.ts
@@ -137,5 +137,13 @@ describe("UnwrapError", () => {
     expect(e).toBeInstanceOf(UnwrapError);
     expect(e.name).toBe("UnwrapError");
     expect(e.error).toBe("payload");
+    expect(e.cause).toBe("payload");
+  });
+
+  it("chains an Error payload through the standard cause", () => {
+    const boom = new Error("boom");
+    const e = new UnwrapError(boom);
+    expect(e.cause).toBe(boom);
+    expect((e.cause as Error).stack).toBe(boom.stack);
   });
 });

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -22,6 +22,11 @@ import type { AsyncResult, Bound, DefectView, ErrView, OkView, Result } from "./
  * `Ok`.
  *
  * @remarks
+ * The offending value is exposed two ways: the typed {@link UnwrapError.error}
+ * property for programmatic access, and the standard `Error.cause` for the
+ * runtime and devtools to chain — when `E` is an `Error` (e.g. a `TaggedError`)
+ * its original stack is printed under "caused by".
+ *
  * A `Defect` is never wrapped in an `UnwrapError`: its original cause is
  * re-thrown (with its original stack) instead.
  *
@@ -34,7 +39,7 @@ export class UnwrapError<E = unknown> extends Error {
    */
   readonly error: E;
   constructor(error: E) {
-    super("unthrown: called unwrap on a non-matching Result");
+    super("unthrown: called unwrap on a non-matching Result", { cause: error });
     this.name = "UnwrapError";
     this.error = error;
     Object.setPrototypeOf(this, new.target.prototype);

--- a/packages/core/src/invariants.spec.ts
+++ b/packages/core/src/invariants.spec.ts
@@ -79,6 +79,8 @@ describe("Invariant 3: unwrap() is asymmetric", () => {
     } catch (e) {
       expect(e).toBeInstanceOf(UnwrapError);
       expect((e as UnwrapError<string>).error).toBe("modeled");
+      // the offending value is also surfaced as the standard Error.cause
+      expect((e as UnwrapError<string>).cause).toBe("modeled");
     }
   });
 


### PR DESCRIPTION
## What

`UnwrapError` now exposes the offending value on the standard `Error.cause` in addition to its existing typed `.error` property.

When `unwrap()` / `unwrapErr()` throw on a modeled `Result`:
- an `Error`-typed `E` (notably a `TaggedError`) chains its **original stack** under "caused by" in V8 output;
- a non-`Error` payload (string, plain object) surfaces under `[cause]`.

`.error` is unchanged for programmatic access. The `Defect` panic path is untouched — it still rethrows the raw `cause` with its original stack.

## Why

`unwrap()` on a modeled `Err` previously threw an `UnwrapError` with a generic message and the error tucked only on `.error`, so the original stack never showed in console output. Setting the standard `cause` restores stack-trace chaining for free.

We deliberately **did not** add a non-wrapping / raw-throw option: `UnwrapError` still always wraps, preserving its "you asserted the wrong variant" assertion-violation semantics (distinct from `match`/`unwrapErr` and the `Defect` panic). `cause` resolves the stack-trace concern without growing the API surface.

## Changes

- `packages/core/src/core.ts` — `super(msg, { cause: error })`; expanded `UnwrapError` `@remarks`.
- `constructors.spec.ts` / `invariants.spec.ts` — assert `.cause === .error` and that an `Error` payload's stack is preserved through `cause`.
- `CLAUDE.md` — the "`unwrap()` is asymmetric" invariant records the `cause` behavior.
- Changeset: `minor` bump for `unthrown`.

## Verification

Full gate green: 169 tests pass, typecheck / lint / format / knip / build / typedoc all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)