### PR TITLE
docs: remove redundant google-site-verification meta

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -154,13 +154,6 @@ export default defineConfig({
     [
       "meta",
       {
-        name: "google-site-verification",
-        content: "u6ZPW5bWbP9G1yF5Sv7B4fSOJm5rLbZWeH858tmisTc",
-      },
-    ],
-    [
-      "meta",
-      {
         name: "keywords",
         content:
           "typescript, result, error handling, errors as values, neverthrow, effect, railway oriented programming, tagged error, defect, panic, type-safe",


### PR DESCRIPTION
Removes the `google-site-verification` `<meta>` from the docs.

Search Console verification tokens are **account-level**, and the `https://btravstack.github.io/` root URL-prefix property (verified via the landing page) already covers every sub-path — including these docs. So the per-docs tag was redundant; verification stays on the landing.

No effect on crawling/indexing — the docs remain in the sitemaps and are linked from the hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)