### PR TITLE
chore: address Fable audit — tree-shaking, invariant guards, OSS hygiene

### DIFF
--- a/.changeset/fable-audit-fixes.md
+++ b/.changeset/fable-audit-fixes.md
@@ -1,0 +1,10 @@
+---
+"unthrown": patch
+---
+
+Mark shipped packages as `"sideEffects": false` so bundlers can prune between
+modules (all except `@unthrown/vitest`, whose `expect.extend` registration is a
+genuine import-time effect). Also: `AsyncResult.unwrapOrElse` now delegates to the
+sync eliminator (guarding the "unwrapOr\* throws on a Defect" invariant), `all`
+short-circuits once a Defect is found, and `tapDefect`'s throw-to-Defect behaviour
+is documented.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: Bug report
+description: Report incorrect behaviour in unthrown or an @unthrown/* package
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a report. Please search existing issues first.
+  - type: dropdown
+    id: package
+    attributes:
+      label: Package
+      description: Which package is affected?
+      options:
+        - unthrown (core)
+        - "@unthrown/pattern"
+        - "@unthrown/vitest"
+        - "@unthrown/effect"
+        - "@unthrown/neverthrow"
+        - "@unthrown/boxed"
+        - "@unthrown/standard-schema"
+        - "@unthrown/oxlint"
+        - not sure
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Which version of the package are you using?
+      placeholder: e.g. 3.0.0
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, including what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: A minimal code snippet or link that reproduces the issue.
+      render: ts
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: TypeScript version, Node version, bundler/runtime if relevant.
+      placeholder: |
+        - TypeScript: 5.x
+        - Node: 22.x
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/btravstack/unthrown/security/advisories/new
+    about: Please report security issues privately, not as a public issue. See SECURITY.md.
+  - name: Question or discussion
+    url: https://github.com/btravstack/unthrown/discussions
+    about: For usage questions and open-ended design discussion.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: Feature request
+description: Suggest a change or addition to unthrown
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        `unthrown` is deliberately small — "one concept = one name", and the surface
+        is meant to stay small enough that the library can be "done". Additions that
+        sharpen the existing design are more likely to land than ones that grow it.
+        Please read the design rationale in `CLAUDE.md` first.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem are you trying to solve? What can't you express today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What API or behaviour would you like? Include type signatures if relevant.
+      render: ts
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Existing combinators or patterns you tried, and why they fall short.
+    validations:
+      required: false
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope check
+      options:
+        - label: I've read `CLAUDE.md` and this doesn't duplicate an existing concept or a deliberately-excluded one (generator do-notation, error accumulation, aliases, an `Option` type).
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+<!--
+Thanks for contributing! Keep PRs focused on one concern.
+See CONTRIBUTING.md for the full workflow.
+-->
+
+## What & why
+
+<!-- What does this change and why? Link any related issue (Closes #123). -->
+
+## Checklist
+
+- [ ] The full gate passes locally: `pnpm format --check && pnpm lint && pnpm typecheck && pnpm knip && pnpm test && pnpm build`
+- [ ] Added/updated tests (and invariant guards / type-level tests if behaviour changed)
+- [ ] Added a changeset (`pnpm changeset`) for any user-facing change
+- [ ] Updated TSDoc and `CLAUDE.md` if the public surface or a design rule changed
+- [ ] Commits follow Conventional Commits

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,11 @@ library can be "done".
   `Result` union (wraps a `Promise<Result>`, branches on `r.tag`), never on `Res`
   internals.
 - **Builders are free functions** (`Ok`, `Err`, …) because they tree-shake — and
-  there is a `bundle-size` CI gate that protects this. The `Result` companion
+  every shipped package sets `"sideEffects": false` so bundlers can prune between
+  modules (the sole exception is `@unthrown/vitest`, whose top-level
+  `expect.extend` registration is a genuine import-time effect). A `bundle-size`
+  CI job reports the per-package `dist` sizes to the run summary — it is
+  informational (no threshold), not a hard gate. The `Result` companion
   object is additive sugar (value + type share the name via a re-alias in
   `facade.ts`); it must stay a separate export so `import { Ok }` never pulls it
   in.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,93 @@
+# Contributing to unthrown
+
+Thanks for your interest in improving `unthrown`. This is a small, focused
+library — the guiding principle is **one concept = one name**, and the surface is
+meant to stay small enough that the library can be "done". Contributions that
+sharpen the existing design are more welcome than ones that grow it.
+
+## Prerequisites
+
+- **Node** `>=22.19`
+- **pnpm** `11.7.0` (pinned via `packageManager`; run `corepack enable` to get it)
+
+## Getting started
+
+```sh
+git clone https://github.com/btravstack/unthrown.git
+cd unthrown
+pnpm install
+```
+
+## The gate
+
+Every change must keep all of these green (CI runs the same set):
+
+```sh
+pnpm format --check   # oxfmt
+pnpm lint             # oxlint
+pnpm typecheck        # tsc (incl. type-level tests)
+pnpm knip             # dead code / unused deps
+pnpm test             # vitest (+ v8 coverage)
+pnpm build            # tsdown dual CJS/ESM + d.ts
+```
+
+Run `pnpm format` (no `--check`) to auto-fix formatting.
+
+### Coverage and invariants
+
+The core package holds **100% line/function coverage**, enforced by thresholds in
+its `vitest.config.ts`. Every load-bearing runtime invariant (see `CLAUDE.md`) is
+guarded 1:1 in `packages/core/src/invariants.spec.ts`, and type-level behaviour is
+asserted in `packages/core/src/types.test-d.ts`. If you change behaviour, update
+or add the matching guard.
+
+## Design rules (binding)
+
+`CLAUDE.md` is the authoritative spec — the rules **and** the reasoning. Read it
+before proposing a change. In particular:
+
+- **oxlint rules are binding:** no `interface` (use `type`), no `any` (use
+  `unknown`). Genuine exceptions carry a targeted `oxlint-disable` with a reason.
+- **Core has no runtime dependencies.** This is a feature — protect it. Never pull
+  `ts-pattern`, `vitest`, or any interop peer into core.
+- **One name per concept.** Resist convenience aliases.
+- Public API carries full **TSDoc**; `pnpm --filter <pkg> build:docs` must stay
+  warning-free.
+
+If your change contradicts something in `CLAUDE.md`, either the change or the spec
+is wrong — resolve that in the PR discussion, and keep `CLAUDE.md` in sync (it
+describes what _is_, not what was planned).
+
+## Commit convention
+
+Commits follow [Conventional Commits](https://www.conventionalcommits.org/) and are
+checked by **commitlint** via a **lefthook** `commit-msg` hook. Examples:
+
+```
+feat(core): add flatTapErr combinator
+fix(interop): let a Defect dominate in allFromDictAsync
+docs: clarify the qualify boundary
+chore(deps): bump vitest
+```
+
+## Changesets
+
+User-facing changes need a changeset so the release notes and version bumps are
+generated correctly:
+
+```sh
+pnpm changeset
+```
+
+Pick the affected packages and a semver bump, and describe the change in one line.
+Purely internal changes (tests, CI, refactors with no API/behaviour impact) don't
+need one.
+
+## Pull requests
+
+- Keep PRs focused — one concern each.
+- Make sure the full gate passes locally before pushing.
+- Reference the issue you're addressing, if any.
+
+By contributing, you agree that your contributions are licensed under the
+project's [MIT License](./LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported versions
+
+`unthrown` and the `@unthrown/*` packages are released together from this
+monorepo. Security fixes land on the **latest** published version; please upgrade
+to the latest release before reporting.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security vulnerabilities.**
+
+Report privately through one of:
+
+- **GitHub Security Advisories** — [open a private report](https://github.com/btravstack/unthrown/security/advisories/new)
+  (preferred; keeps the discussion and fix coordination in one place).
+- **Email** — `btravers.pro@gmail.com`.
+
+Please include:
+
+- the affected package and version,
+- a description of the issue and its impact,
+- and a minimal reproduction if possible.
+
+## What to expect
+
+- Acknowledgement of your report as soon as it is triaged.
+- An assessment of the impact and affected versions.
+- A coordinated fix and release, with credit to you in the advisory unless you
+  prefer to remain anonymous.
+
+Thank you for helping keep `unthrown` and its users safe.

--- a/packages/boxed/package.json
+++ b/packages/boxed/package.json
@@ -27,6 +27,7 @@
     "docs"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,6 +29,7 @@
     "docs"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -613,11 +613,7 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
     return this.promise.then((r) => r.unwrapOr(fallback));
   }
   unwrapOrElse(f: (error: E) => T): Promise<T> {
-    return this.promise.then((r) => {
-      if (r.tag === "Ok") return r.value;
-      if (r.tag === "Defect") throw r.cause;
-      return f(r.error);
-    });
+    return this.promise.then((r) => r.unwrapOrElse(f));
   }
   getOrNull(): Promise<T | null> {
     return this.promise.then((r) => r.getOrNull());

--- a/packages/core/src/interop.ts
+++ b/packages/core/src/interop.ts
@@ -198,8 +198,10 @@ function foldArray(results: readonly Result<unknown, unknown>[]): Result<unknown
   let firstDefect: Result<unknown, unknown> | undefined;
   const values: unknown[] = [];
   for (const r of results) {
-    if (r.tag === "Defect") firstDefect ??= r;
-    else if (r.tag === "Err") firstErr ??= r;
+    if (r.tag === "Defect") {
+      firstDefect ??= r;
+      break; // any Defect dominates — nothing later can change the outcome
+    } else if (r.tag === "Err") firstErr ??= r;
     else values.push(r.value);
   }
   return firstDefect ?? firstErr ?? Ok(values);
@@ -335,7 +337,7 @@ export function allFromDictAsync<R extends AsyncResultRecord>(
     // Null-proto accumulator: pairing resolved values back to keys can't pollute.
     const byKey: ResultRecord = Object.create(null) as ResultRecord;
     entries.forEach(([key], i) => {
-      byKey[key] = resolved[i] as Result<unknown, unknown>;
+      byKey[key] = resolved[i]!;
     });
     return foldRecord(byKey);
   });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -199,7 +199,7 @@ export type ResultMethods<T, E> = {
   recoverDefect<U, E2>(f: (cause: unknown) => Result<U, E2>): Result<T | U, E | E2>;
   /**
    * Run a side effect on a present `Defect`'s cause (e.g. logging) and pass the
-   * `Defect` through unchanged.
+   * `Defect` through unchanged. If `f` throws, the throw becomes a new `Defect`.
    *
    * @param f - the side effect over the unknown cause.
    */

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -27,6 +27,7 @@
     "docs"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",

--- a/packages/neverthrow/package.json
+++ b/packages/neverthrow/package.json
@@ -26,6 +26,7 @@
     "docs"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",

--- a/packages/oxlint/src/rules/no-ambiguous-error-type.test.ts
+++ b/packages/oxlint/src/rules/no-ambiguous-error-type.test.ts
@@ -46,5 +46,21 @@ ruleTester.run("no-ambiguous-error-type", noAmbiguousErrorType, {
       code: `import type { Result } from "unthrown";\ntype T = Result<number, Error | MyError>;`,
       errors: [{ messageId: "noAmbiguousErrorType" }],
     },
+    // Inner scope — a function return-type annotation. Locks that the import
+    // source resolves from a nested scope (regression guard for scope analysis).
+    {
+      code: `import type { Result } from "unthrown";\nfunction f(): Result<number, unknown> { throw 0; }`,
+      errors: [{ messageId: "noAmbiguousErrorType" }],
+    },
+    // Inner scope — a type alias declared inside a function body.
+    {
+      code: `import type { Result } from "unthrown";\nfunction f() { type T = Result<number, any>; return null as unknown as T; }`,
+      errors: [{ messageId: "noAmbiguousErrorType" }],
+    },
+    // Inner scope — a nested block.
+    {
+      code: `import type { Result } from "unthrown";\n{ type T = Result<number, Error>; }`,
+      errors: [{ messageId: "noAmbiguousErrorType" }],
+    },
   ],
 });

--- a/packages/oxlint/src/rules/prefer-async-result.test.ts
+++ b/packages/oxlint/src/rules/prefer-async-result.test.ts
@@ -28,5 +28,18 @@ ruleTester.run("prefer-async-result", preferAsyncResult, {
       errors: [{ messageId: "preferAsyncResult" }],
       output: null,
     },
+    // Inner scope — a function return-type annotation, with AsyncResult imported
+    // so the autofix applies. Locks import-source resolution from a nested scope.
+    {
+      code: `import type { Result, AsyncResult } from "unthrown";\nfunction f(): Promise<Result<number, MyError>> { throw 0; }`,
+      errors: [{ messageId: "preferAsyncResult" }],
+      output: `import type { Result, AsyncResult } from "unthrown";\nfunction f(): AsyncResult<number, MyError> { throw 0; }`,
+    },
+    // Inner scope — a type alias inside a function body.
+    {
+      code: `import type { Result } from "unthrown";\nfunction f() { type T = Promise<Result<number, MyError>>; return null as unknown as T; }`,
+      errors: [{ messageId: "preferAsyncResult" }],
+      output: null,
+    },
   ],
 });

--- a/packages/pattern/package.json
+++ b/packages/pattern/package.json
@@ -26,6 +26,7 @@
     "docs"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",

--- a/packages/standard-schema/package.json
+++ b/packages/standard-schema/package.json
@@ -29,6 +29,7 @@
     "docs"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",


### PR DESCRIPTION
Addresses the Claude Fable audit (2026-07-02). Each verified finding, one commit group.

## Code fixes
- **1.1** `AsyncResult.unwrapOrElse` now delegates to the sync `Res.unwrapOrElse` instead of duplicating the three-branch logic — protects the load-bearing "unwrapOr* throws on a `Defect`" invariant from silent divergence.
- **1.3** Replaced a `noUncheckedIndexedAccess`-defeating `as` cast in `allFromDictAsync` with an explicit `!`.
- **1.4** `foldArray` breaks out once a `Defect` is found (a `Defect` dominates — nothing later can change the outcome).
- **1.5** Added inner-scope invalid cases (function signature, function body, nested block) to both oxlint rule tests, locking that import-source resolution works from a nested scope.

## Packaging & docs
- **2.1** Added `"sideEffects": false` to the **6** genuinely-pure shipped packages. **Deviation from the review:** `@unthrown/vitest` is excluded — its top-level `expect.extend` registration is a real import-time side effect, and marking it side-effect-free would let a bundler drop the matchers.
- **2.2** Resolved the spec drift by correcting `CLAUDE.md`: the `bundle-size` CI job is an informational size report, not a hard gate. Also documents the new `sideEffects` policy.
- **1.2** Added the throw-to-`Defect` note to `tapDefect`'s TSDoc (parity with `tap`/`tapErr`).

## OSS hygiene (finding 3)
- `CONTRIBUTING.md`, `SECURITY.md`, and GitHub issue/PR templates.

## Not included
- **4 (deps)** — left to the already-configured Dependabot.

A changeset (`patch`) is included; the `fixed` group bumps all packages together.

Gate: `test` (168 core + 24 oxlint), `typecheck`, `lint`, `format --check`, `knip`, `build` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)