### PR TITLE
docs: beginner-friendly overhaul + categorized, exampled API reference

### DIFF
--- a/.changeset/docs-beginner-friendly.md
+++ b/.changeset/docs-beginner-friendly.md
@@ -1,0 +1,9 @@
+---
+"unthrown": patch
+---
+
+Improve the generated API reference: add `@category` grouping (Constructors,
+Guards, Interop, Aggregate, Tagged errors, Facade, Types, …) to every exported
+symbol, and give the standalone functions richer, convention-following `@example`
+blocks (both Ok and Err branches, `// =>` output comments). Comment-only — no
+runtime or type changes.

--- a/docs/guide/async-results.md
+++ b/docs/guide/async-results.md
@@ -10,7 +10,7 @@ You get one from a qualified boundary ([`fromPromise`](./boundaries),
 import { fromSafePromise } from "unthrown";
 
 const result = await fromSafePromise(Promise.resolve(1)).map((n) => n + 1);
-result.unwrap(); // 2
+result.unwrap(); // => 2
 ```
 
 ## Awaitable, not a Promise

--- a/docs/guide/choosing-a-combinator.md
+++ b/docs/guide/choosing-a-combinator.md
@@ -6,52 +6,72 @@ channel** and turns a thrown callback into a `Defect`.
 
 ## By intent
 
-| I want to…                                     | use                | channel |
-| ---------------------------------------------- | ------------------ | ------- |
-| transform the success value                    | `map`              | Ok      |
-| run a dependent, `Result`-returning step       | `flatMap`          | Ok      |
-| run a side effect, keep the value              | `tap`              | Ok      |
-| run a **failable** side effect, keep the value | `flatTap`          | Ok      |
-| sequence dependent steps into a named scope    | `Do`/`bind`/`let`  | Ok      |
-| replace the value with a constant              | `as`               | Ok      |
-| transform the error                            | `mapErr`           | Err     |
-| try a fallback that returns a `Result`         | `orElse`           | Err     |
-| turn an error into a success value             | `recover`          | Err     |
-| run a side effect on the error                 | `tapErr`           | Err     |
-| run a **failable** side effect on the error    | `flatTapErr`       | Err     |
-| recover from a defect (rare)                   | `recoverDefect`    | Defect  |
-| observe a defect, e.g. log it                  | `tapDefect`        | Defect  |
-| handle all three channels at the edge          | `match`            | all     |
-| combine many `Result`s                         | `all` / `allAsync` | —       |
+The `→ Result<…>` half of each signature is the tell — it shows how the combinator
+moves the channels: `flatMap` widens `E` to `E | E2`, `recover` empties it to
+`never`, `orElse` widens the value to `T | U`.
+
+| I want to…                                     | use               | signature                                                    | channel |
+| ---------------------------------------------- | ----------------- | ------------------------------------------------------------ | ------- |
+| transform the success value                    | `map`             | `(v: T) => U` → `Result<U, E>`                               | Ok      |
+| chain a `Result`-returning step                | `flatMap`         | `(v: T) => Result<U, E2>` → `Result<U, E \| E2>`             | Ok      |
+| run a side effect, keep the value              | `tap`             | `(v: T) => void` → `Result<T, E>`                            | Ok      |
+| run a **failable** side effect, keep the value | `flatTap`         | `(v: T) => Result<unknown, E2>` → `Result<T, E \| E2>`       | Ok      |
+| sequence steps into a named scope              | `Do`/`bind`/`let` | `bind(k, (scope) => Result<U, E2>)` → `Result<{…}, E \| E2>` | Ok      |
+| replace the value with a constant              | `as`              | `(value: U)` → `Result<U, E>`                                | Ok      |
+| transform the error                            | `mapErr`          | `(e: E) => E2` → `Result<T, E2>`                             | Err     |
+| try a fallback that returns a `Result`         | `orElse`          | `(e: E) => Result<U, E2>` → `Result<T \| U, E2>`             | Err     |
+| turn an error into a success value             | `recover`         | `(e: E) => U` → `Result<T \| U, never>`                      | Err     |
+| run a side effect on the error                 | `tapErr`          | `(e: E) => void` → `Result<T, E>`                            | Err     |
+| run a **failable** side effect on the error    | `flatTapErr`      | `(e: E) => Result<unknown, E2>` → `Result<T, E \| E2>`       | Err     |
+| recover from a defect (rare)                   | `recoverDefect`   | `(cause) => Result<U, E2>` → `Result<T \| U, E \| E2>`       | Defect  |
+| observe a defect, e.g. log it                  | `tapDefect`       | `(cause) => void` → `Result<T, E>`                           | Defect  |
+| handle all three channels at the edge          | `match`           | `{ ok, err, defect }` → `R`                                  | all     |
+| combine many `Result`s                         | `all`             | `Result<T, E>[]` → `Result<T[], E>`                          | —       |
+
+## Behavior at a glance
+
+A combinator touches **only its own channel**; the other two flow through
+untouched. This grid is the whole story — notice the `Defect` column is
+"passes ▸" everywhere except `recoverDefect` and `match`, which is the one
+invariant to remember:
+
+| method                  | on `Ok`  | on `Err`        | on `Defect` | resulting `E`   |
+| ----------------------- | -------- | --------------- | ----------- | --------------- |
+| `map`                   | runs `f` | passes ▸        | passes ▸    | `E`             |
+| `flatMap`               | runs `f` | passes ▸        | passes ▸    | `E \| E2`       |
+| `tap` / `flatTap`       | runs `f` | passes ▸        | passes ▸    | `E` / `E \| E2` |
+| `mapErr`                | passes ▸ | runs `f`        | passes ▸    | `E2`            |
+| `orElse`                | passes ▸ | runs `f`        | passes ▸    | `E2`            |
+| `recover`               | passes ▸ | runs `f` → `Ok` | passes ▸    | `never`         |
+| `tapErr` / `flatTapErr` | passes ▸ | runs `f`        | passes ▸    | `E` / `E \| E2` |
+| `recoverDefect`         | passes ▸ | passes ▸        | runs `f`    | `E \| E2`       |
+| `tapDefect`             | passes ▸ | passes ▸        | runs `f`    | `E`             |
+| `match`                 | `ok()`   | `err()`         | `defect()`  | —               |
+
+::: tip `recover`'s `never` under-describes the runtime
+`recover` empties only the **error** channel to `never` — a `Defect` can still be
+present at runtime and flows past it untouched. See
+[The Defect Channel](./the-defect-channel).
+:::
 
 ## The pairs that are easy to confuse
 
 **`map` vs `flatMap`** — does your callback return a plain value or a `Result`?
 A `(value) => U` is `map`; a `(value) => Result<U, E2>` is `flatMap` (otherwise
-you get a nested `Result<Result<…>>`).
-
-**`tap` vs `flatTap`** — both keep the original value. `tap` takes a `void`
-callback that can't fail; `flatTap` takes a `Result`-returning one and threads
-its error (a validation or write whose _outcome_ matters but whose _value_ you
-don't need).
+you nest a `Result<Result<…>>`).
 
 **`flatMap` vs `flatTap`** — both take a `Result`-returning callback. `flatMap`
-**replaces** the value with the callback's; `flatTap` **discards** the callback's
-value and keeps the original.
-
-**`tapErr` vs `flatTapErr`** — the error-channel mirror of `tap` vs `flatTap`.
-Both run only on `Err` and keep the original error on success. `tapErr` takes a
-`void` callback that can't fail; `flatTapErr` takes a `Result`-returning one and
-threads its error (a failable effect _during_ error handling — e.g. writing the
-error to an audit log that may itself fail).
+**replaces** the value with the callback's; `flatTap` **discards** it and keeps
+the original (a validation or write whose _outcome_ matters but whose _value_
+you don't need). `tapErr`/`flatTapErr` are the same pair on the error channel.
 
 **`orElse` vs `recover`** — both run on `Err`. `recover` produces a plain success
-value (emptying the error channel to `never`); `orElse` produces another
-`Result` (which may still be an `Err`).
+value (emptying the error channel to `never`); `orElse` produces another `Result`
+(which may still be an `Err`).
 
 **`recover` vs `recoverDefect`** — `recover` handles a modeled `Err`;
 `recoverDefect` is the **only** combinator that can touch a `Defect`. Neither is
-the other's fallback: a defect flows past `recover` untouched.
+the other's fallback — a defect flows past `recover` untouched.
 
 ## When to leave the pipeline
 

--- a/docs/guide/core-concepts.md
+++ b/docs/guide/core-concepts.md
@@ -35,9 +35,9 @@ A combinator only runs its callback on its own channel — the other states flow
 through untouched:
 
 ```ts
-Ok(2).map((n) => n + 1); // Ok(3)
-Err("e").map((n) => n + 1); // Err("e") — callback skipped
-Ok(2).mapErr((e) => `${e}!`); // Ok(2) — callback skipped
+Ok(2).map((n) => n + 1); // => Ok(3)
+Err("e").map((n) => n + 1); // => Err("e") — callback skipped
+Ok(2).mapErr((e) => `${e}!`); // => Ok(2) — callback skipped
 ```
 
 `tap` and `flatTap` both run a side effect and keep the original value — the
@@ -118,10 +118,10 @@ matched.
 Once you are ready to leave the `Result` world, pick the right exit:
 
 ```ts
-Ok(1).unwrap(); // 1            — throws on Err/Defect
-Err("e").unwrapErr(); // "e"    — throws on Ok/Defect
-Err("e").unwrapOr(0); // 0      — recovers an Err; rethrows a Defect
-Err("e").getOrNull(); // null   — recovers an Err; rethrows a Defect
+Ok(1).unwrap(); // => 1         — throws on Err/Defect
+Err("e").unwrapErr(); // => "e" — throws on Ok/Defect
+Err("e").unwrapOr(0); // => 0   — recovers an Err; rethrows a Defect
+Err("e").getOrNull(); // => null — recovers an Err; rethrows a Defect
 Ok(1).match({ ok, err, defect }); // fold all three channels
 ```
 
@@ -139,8 +139,8 @@ earlier `Err`). A fixed tuple keeps its positional types; a dynamic
 ```ts
 import { all, Ok, type Result } from "unthrown";
 
-all([Ok(1), Ok("two"), Ok(true)]).unwrap(); // [1, "two", true] (typed [number, string, boolean])
-all([Ok(1), Ok(2)] as Result<number, never>[]).unwrap(); // number[]
+all([Ok(1), Ok("two"), Ok(true)]).unwrap(); // => [1, "two", true] (typed [number, string, boolean])
+all([Ok(1), Ok(2)] as Result<number, never>[]).unwrap(); // => number[]
 ```
 
 For **named** parallel work, `allFromDict` takes a record instead — same rules,
@@ -149,7 +149,7 @@ no tupling:
 ```ts
 import { allFromDict, Ok } from "unthrown";
 
-allFromDict({ id: Ok(1), name: Ok("ada") }).unwrap(); // { id: 1, name: "ada" }
+allFromDict({ id: Ok(1), name: Ok("ada") }).unwrap(); // => { id: 1, name: "ada" }
 ```
 
 Both short-circuit on the first `Err` — this is **not** error accumulation. If

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -56,8 +56,9 @@ can chain without checking at every step:
 ```ts
 parseAge("42")
   .map((n) => n + 1) // => Ok(43)   — map: callback returns a plain value
-  .flatMap((n) => (n >= 18 ? Ok(n) : Err("negative"))) // => Ok(43) — flatMap: callback returns a Result
+  .flatMap((n) => (n >= 18 ? Ok(n) : Err("underage"))) // => Ok(43) — flatMap: callback returns a Result
   .unwrap(); // => 43
+// the error type widens to AgeError | "underage" — flatMap unions the channels
 ```
 
 ```ts
@@ -77,14 +78,15 @@ You handle all three runtime channels — `ok`, `err`, and the `defect` channel 
 the _unexpected_ (covered next):
 
 ```ts
-const message = parseAge(input).match({
+const message = parseAge("-3").match({
   ok: (age) => `age is ${age}`,
   err: (e) => (e === "negative" ? "must be positive" : "not a number"),
   defect: (cause) => {
-    logger.error(cause); // a bug slipped through — log it, don't leak it
+    console.error(cause); // a bug slipped through — log it, don't leak it
     return "something went wrong";
   },
 });
+// => "must be positive"
 ```
 
 Because a thrown bug inside any combinator becomes a `defect` (never an `Err`),

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -24,49 +24,70 @@ and has **zero runtime dependencies**. It targets TypeScript with `strict` mode.
 ## Your first Result
 
 A `Result<T, E>` is either an **Ok** carrying a value `T`, or an **Err** carrying
-a _modeled_ error `E`. Build them with `Ok` and `Err`:
+a _modeled_ error `E`. `E` lists only the failures you _anticipate_.
+
+Say you're parsing a user-supplied age. Two things can go wrong, and you want to
+model both instead of throwing:
 
 ```ts
 import { Ok, Err, type Result } from "unthrown";
 
-function half(n: number): Result<number, "odd"> {
-  return n % 2 === 0 ? Ok(n / 2) : Err("odd");
+type AgeError = "not_a_number" | "negative";
+
+function parseAge(input: string): Result<number, AgeError> {
+  const n = Number(input);
+  if (Number.isNaN(n)) return Err("not_a_number");
+  if (n < 0) return Err("negative");
+  return Ok(n);
 }
+
+parseAge("42"); // => Ok(42)
+parseAge("-3"); // => Err("negative")
+parseAge("x"); // => Err("not_a_number")
 ```
 
-`E` lists only the failures you _anticipate_. Here, the only modeled failure is
-the literal `"odd"`.
+Nothing is thrown — both outcomes come back as values you can inspect.
 
 ## Transform and chain
 
-The success combinators run only on `Ok`; an `Err` passes straight through:
+Success combinators run only on `Ok`; an `Err` passes straight through, so you
+can chain without checking at every step:
 
 ```ts
-half(10)
-  .map((n) => n + 1) // Ok(6)
-  .flatMap((n) => half(n)) // Ok(3)
-  .unwrap(); // 3
+parseAge("42")
+  .map((n) => n + 1) // => Ok(43)   — map: callback returns a plain value
+  .flatMap((n) => (n >= 18 ? Ok(n) : Err("negative"))) // => Ok(43) — flatMap: callback returns a Result
+  .unwrap(); // => 43
 ```
 
 ```ts
-half(7) // Err("odd")
-  .map((n) => n + 1) // still Err("odd") — callback never runs
-  .unwrapErr(); // "odd"
+parseAge("x") // => Err("not_a_number")
+  .map((n) => n + 1) // callback never runs — still Err("not_a_number")
+  .unwrapErr(); // => "not_a_number"
 ```
+
+Reach for `map` when your callback returns a plain value, `flatMap` when it
+returns another `Result`. The [Choosing a Combinator](./choosing-a-combinator)
+cheat sheet has the full picture.
 
 ## Handle every outcome
 
 At the edge of your program, fold a `Result` into a single value with `match`.
-You must handle all three runtime channels — `ok`, `err`, and `defect`:
+You handle all three runtime channels — `ok`, `err`, and the `defect` channel for
+the _unexpected_ (covered next):
 
 ```ts
-const message = half(7).match({
-  ok: (n) => `got ${n}`,
-  err: (e) => `failed: ${e}`,
-  defect: (cause) => `bug: ${String(cause)}`,
+const message = parseAge(input).match({
+  ok: (age) => `age is ${age}`,
+  err: (e) => (e === "negative" ? "must be positive" : "not a number"),
+  defect: (cause) => {
+    logger.error(cause); // a bug slipped through — log it, don't leak it
+    return "something went wrong";
+  },
 });
 ```
 
-The third channel, `defect`, is for the _unexpected_ — covered next.
+Because a thrown bug inside any combinator becomes a `defect` (never an `Err`),
+this single `match` at the edge needs no surrounding `try`/`catch`.
 
 → Continue to [Core Concepts](./core-concepts).

--- a/docs/guide/the-defect-channel.md
+++ b/docs/guide/the-defect-channel.md
@@ -18,7 +18,7 @@ const r = Ok(1).map(() => {
   throw new Error("boom");
 });
 
-r.isDefect(); // true
+r.isDefect(); // => true
 ```
 
 This is what makes "no `try`/`catch` at the edge" real: a bug in a `.map`
@@ -50,7 +50,7 @@ runtime:
 ```ts
 const recovered = d.recover(() => 99);
 // type: Result<number, never>
-recovered.isDefect(); // true — `never` does NOT mean "total"
+recovered.isDefect(); // => true — `never` does NOT mean "total"
 ```
 
 A defect is a bug; you should not be able to accidentally "recover" it into a
@@ -63,6 +63,13 @@ d.unwrapOrElse(() => 0); // throws the original cause
 ```
 
 They recover a modeled `Err`, never an unmodeled defect.
+
+::: warning `unwrapOr` / `getOrNull` still throw on a defect
+It's tempting to read `unwrapOr(0)` as "always give me a value." It doesn't — it
+supplies the fallback for a modeled `Err` but **rethrows a defect** (a bug is not
+an absent value). If you must not throw, handle the defect explicitly first with
+`match` or `recoverDefect`.
+:::
 
 ## `unwrap` is asymmetric
 

--- a/packages/core/src/constructors.ts
+++ b/packages/core/src/constructors.ts
@@ -12,8 +12,12 @@ import type { DefectView, ErrView, OkView, Result } from "./types.js";
  * @example
  * ```ts
  * import { Ok } from "unthrown";
- * Ok(42).unwrap(); // 42
+ *
+ * Ok(2).map((n) => n + 1); // => Ok(3)
+ * Ok(42).unwrap(); // => 42
  * ```
+ *
+ * @category Constructors
  */
 export function Ok<T>(value: T): Result<T, never> {
   return okRes(value);
@@ -28,8 +32,12 @@ export function Ok<T>(value: T): Result<T, never> {
  * @example
  * ```ts
  * import { Err } from "unthrown";
- * Err("not_found").unwrapErr(); // "not_found"
+ *
+ * Err("not_found").map((n) => n + 1); // => Err("not_found") (map skipped)
+ * Err("not_found").unwrapErr(); // => "not_found"
  * ```
+ *
+ * @category Constructors
  */
 export function Err<E>(error: E): Result<never, E> {
   return errRes(error);
@@ -42,10 +50,16 @@ export function Err<E>(error: E): Result<never, E> {
  *
  * @example
  * ```ts
- * import { isOk, type Result } from "unthrown";
+ * import { isOk, Ok, Err, type Result } from "unthrown";
+ *
+ * isOk(Ok(1)); // => true
+ * isOk(Err("boom")); // => false
+ *
  * declare const r: Result<number, string>;
  * if (isOk(r)) r.value; // number, narrowed
  * ```
+ *
+ * @category Guards
  */
 export function isOk<T, E>(r: Result<T, E>): r is OkView<T, E> {
   return r.tag === "Ok";
@@ -54,6 +68,19 @@ export function isOk<T, E>(r: Result<T, E>): r is OkView<T, E> {
  * Type guard: narrow a {@link Result} to its `Err` variant, exposing `.error`.
  *
  * @returns `true` when `r` is `Err`.
+ *
+ * @example
+ * ```ts
+ * import { isErr, Ok, Err, type Result } from "unthrown";
+ *
+ * isErr(Err("boom")); // => true
+ * isErr(Ok(1)); // => false
+ *
+ * declare const r: Result<number, string>;
+ * if (isErr(r)) r.error; // string, narrowed
+ * ```
+ *
+ * @category Guards
  */
 export function isErr<T, E>(r: Result<T, E>): r is ErrView<E, T> {
   return r.tag === "Err";
@@ -61,7 +88,27 @@ export function isErr<T, E>(r: Result<T, E>): r is ErrView<E, T> {
 /**
  * Type guard: narrow a {@link Result} to its `Defect` variant, exposing `.cause`.
  *
+ * @remarks
+ * A `Defect` has no public constructor — it only arises at a boundary (e.g. a
+ * callback throwing inside a combinator). This guard is how you detect one.
+ *
  * @returns `true` when `r` is a `Defect`.
+ *
+ * @example
+ * ```ts
+ * import { isDefect, Ok } from "unthrown";
+ *
+ * // A throw inside a combinator is captured as a Defect:
+ * const r = Ok(1).map(() => {
+ *   throw new Error("boom");
+ * });
+ * isDefect(r); // => true
+ * isDefect(Ok(1)); // => false
+ *
+ * if (isDefect(r)) r.cause; // unknown, narrowed
+ * ```
+ *
+ * @category Guards
  */
 export function isDefect<T, E>(r: Result<T, E>): r is DefectView<T, E> {
   return r.tag === "Defect";

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -31,6 +31,8 @@ import type { AsyncResult, Bound, DefectView, ErrView, OkView, Result } from "./
  * re-thrown (with its original stack) instead.
  *
  * @typeParam E - the type of the {@link UnwrapError.error} it carries.
+ *
+ * @category Errors
  */
 export class UnwrapError<E = unknown> extends Error {
   /**
@@ -334,6 +336,20 @@ export function defectRes<T, E>(cause: unknown): Result<T, E> {
  * is not a `Result` and returns `false`.
  *
  * @returns `true` when `x` is a `Result` produced by this library.
+ *
+ * @example
+ * ```ts
+ * import { isResult, Ok } from "unthrown";
+ *
+ * isResult(Ok(1)); // => true
+ * isResult({ tag: "Ok" }); // => false (look-alike, wrong prototype)
+ * isResult(Ok(1).toAsync()); // => false (an AsyncResult is not a Result)
+ *
+ * const x: unknown = Ok(1);
+ * if (isResult(x)) x.match({ ok: () => 1, err: () => 0, defect: () => -1 });
+ * ```
+ *
+ * @category Guards
  */
 export function isResult(x: unknown): x is Result<unknown, unknown> {
   return x instanceof Res;

--- a/packages/core/src/do.ts
+++ b/packages/core/src/do.ts
@@ -26,6 +26,24 @@ import type { Result } from "./types.js";
  *   .map(({ user, org, label }) => render(user, org, label));
  * // Result<View, NotFound>
  * ```
+ *
+ * @example
+ * ```ts
+ * import { Do, Ok, Err } from "unthrown";
+ *
+ * // Ok path — the scope accumulates:
+ * Do()
+ *   .bind("a", () => Ok(2))
+ *   .let("b", ({ a }) => a * 10)
+ *   .map(({ a, b }) => a + b); // => Ok(22)
+ *
+ * // Err path — the first Err short-circuits the rest:
+ * Do()
+ *   .bind("a", () => Err("boom"))
+ *   .let("b", ({ a }) => a); // => Err("boom")
+ * ```
+ *
+ * @category Do-notation
  */
 export function Do(): Result<{}, never> {
   return Ok({});

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -36,10 +36,12 @@ import type { AsyncResult as AsyncResultType, Result as ResultType } from "./typ
  * (`AsyncResult.fromPromise`, `AsyncResult.all`, …), grouped by what they
  * return — a static lives in exactly one namespace.
  *
+ * @category Facade
+ *
  * @example
  * ```ts
  * import { Result } from "unthrown";
- * Result.Ok(1).flatMap((n) => Result.Ok(n + 1)).unwrap(); // 2
+ * Result.Ok(1).flatMap((n) => Result.Ok(n + 1)).unwrap(); // => 2
  * ```
  */
 export const Result = {
@@ -76,10 +78,13 @@ export type Result<T, E> = ResultType<T, E>;
  * {@link Result}, the free functions remain the primary, tree-shakeable API; the
  * value `AsyncResult` and the type {@link AsyncResult} share one name.
  *
+ * @category Facade
+ *
  * @example
  * ```ts
  * import { AsyncResult } from "unthrown";
  * const user = await AsyncResult.fromPromise(fetchUser(id), (c, defect) => defect(c));
+ * user.unwrap(); // => the fetched user (on success)
  * ```
  */
 export const AsyncResult = {

--- a/packages/core/src/interop.ts
+++ b/packages/core/src/interop.ts
@@ -20,10 +20,16 @@ import type { AsyncErrOf, AsyncOkOf, AsyncResult, ErrOf, OkOf, Result } from "./
  * @param value - the possibly-absent value.
  * @param onAbsent - lazily produces the error for the absent case.
  *
+ * @category Interop
+ *
  * @example
  * ```ts
  * import { fromNullable } from "unthrown";
- * fromNullable(map.get(key), () => "missing").unwrap();
+ *
+ * const map = new Map([["a", 1]]);
+ * fromNullable(map.get("a"), () => "absent").unwrap(); // => 1
+ * fromNullable(map.get("z"), () => "absent"); // => Err("absent")
+ * fromNullable(0, () => "absent").unwrap(); // => 0 (falsy but present)
  * ```
  */
 export function fromNullable<T, E>(
@@ -58,11 +64,21 @@ export function fromNullable<T, E>(
  * unmodeled by returning `defect(cause)` (the helper passed as its second arg).
  * @returns a function with the same arguments returning `Result<T, E>`.
  *
+ * @category Interop
+ *
  * @example
  * ```ts
  * import { fromThrowable } from "unthrown";
- * const parse = fromThrowable(JSON.parse, (cause, defect) => defect(cause));
- * parse("{}").unwrap();
+ *
+ * // Model the parse failure as an `Err`, everything unexpected as a `Defect`.
+ * const parse = fromThrowable(
+ *   (text: string) => JSON.parse(text) as unknown,
+ *   (cause, defect) =>
+ *     cause instanceof SyntaxError ? ("invalid_json" as const) : defect(cause),
+ * );
+ *
+ * parse('{"ok":true}').unwrap(); // => { ok: true }
+ * parse("nope"); // => Err("invalid_json")
  * ```
  */
 export function fromThrowable<A extends unknown[], T, R>(
@@ -102,12 +118,19 @@ export function fromThrowable<A extends unknown[], T, R>(
  * @param qualify - triages a rejection `cause` into a modeled `E`, or marks it
  * unmodeled by returning `defect(cause)` (the helper passed as its second arg).
  *
+ * @category Interop
+ *
  * @example
  * ```ts
  * import { fromPromise } from "unthrown";
+ *
+ * // A rejection with a NotFoundError becomes a modeled `Err`; anything else a Defect.
  * const user = await fromPromise(fetchUser(id), (cause, defect) =>
  *   cause instanceof NotFoundError ? ("not_found" as const) : defect(cause),
  * );
+ *
+ * user.unwrap(); // => the fetched user (on success)
+ * // when fetchUser rejects with NotFoundError: => Err("not_found")
  * ```
  */
 export function fromPromise<T, R>(
@@ -135,6 +158,17 @@ export function fromPromise<T, R>(
  *
  * @typeParam T - the resolved value type.
  * @param promise - the promise, or a thunk returning one.
+ *
+ * @category Interop
+ *
+ * @example
+ * ```ts
+ * import { fromSafePromise } from "unthrown";
+ *
+ * (await fromSafePromise(Promise.resolve(3))).unwrap(); // => 3
+ * // a rejection becomes a Defect (never a modeled Err):
+ * await fromSafePromise(Promise.reject(new Error("boom"))); // => Defect(Error("boom"))
+ * ```
  */
 export function fromSafePromise<T>(
   promise: Promise<T> | (() => Promise<T>),
@@ -244,11 +278,14 @@ function foldRecord(results: ResultRecord): Result<unknown, unknown> {
  * collapses to `Result<T[], E>` with no cast. For a **record** keyed by name,
  * use {@link allFromDict}.
  *
+ * @category Aggregate
+ *
  * @example
  * ```ts
- * import { all, Ok } from "unthrown";
- * all([Ok(1), Ok("a"), Ok(true)]).unwrap(); // [1, "a", true] (typed [number, string, boolean])
- * all([Ok(1), Ok(2)] as Result<number, never>[]).unwrap(); // number[]
+ * import { all, Ok, Err } from "unthrown";
+ *
+ * all([Ok(1), Ok("a"), Ok(true)]).unwrap(); // => [1, "a", true] (typed [number, string, boolean])
+ * all([Ok(1), Err("e"), Ok(3)]); // => Err("e") (short-circuits on the first Err)
  * ```
  */
 export function all<Rs extends readonly Result<unknown, unknown>[]>(
@@ -270,10 +307,14 @@ export function all<Rs extends readonly Result<unknown, unknown>[]>(
  * Same folding rules as {@link all}: first `Err` short-circuits, any `Defect`
  * dominates. This is **not** error accumulation.
  *
+ * @category Aggregate
+ *
  * @example
  * ```ts
- * import { allFromDict, Ok } from "unthrown";
- * allFromDict({ id: Ok(1), name: Ok("ada") }).unwrap(); // { id: 1, name: "ada" }
+ * import { allFromDict, Ok, Err } from "unthrown";
+ *
+ * allFromDict({ id: Ok(1), name: Ok("ada") }).unwrap(); // => { id: 1, name: "ada" }
+ * allFromDict({ id: Ok(1), name: Err("missing") }); // => Err("missing")
  * ```
  */
 export function allFromDict<R extends ResultRecord>(
@@ -295,10 +336,14 @@ export function allFromDict<R extends ResultRecord>(
  * short-circuits, any `Defect` dominates. As ever, the returned `AsyncResult`'s
  * internal promise never rejects. For a **record**, use {@link allFromDictAsync}.
  *
+ * @category Aggregate
+ *
  * @example
  * ```ts
  * import { allAsync, fromSafePromise } from "unthrown";
- * await allAsync([fromSafePromise(a()), fromSafePromise(b())]);
+ *
+ * const both = allAsync([fromSafePromise(Promise.resolve(1)), fromSafePromise(Promise.resolve(2))]);
+ * (await both).unwrap(); // => [1, 2]
  * ```
  */
 export function allAsync<Rs extends readonly AsyncResult<unknown, unknown>[]>(
@@ -323,10 +368,17 @@ export function allAsync<Rs extends readonly AsyncResult<unknown, unknown>[]>(
  * Resolved concurrently (order preserved), folded with the {@link all} rules,
  * and the internal promise never rejects.
  *
+ * @category Aggregate
+ *
  * @example
  * ```ts
  * import { allFromDictAsync, fromSafePromise } from "unthrown";
- * await allFromDictAsync({ a: fromSafePromise(a()), b: fromSafePromise(b()) });
+ *
+ * const both = allFromDictAsync({
+ *   a: fromSafePromise(Promise.resolve(1)),
+ *   b: fromSafePromise(Promise.resolve("x")),
+ * });
+ * (await both).unwrap(); // => { a: 1, b: "x" }
  * ```
  */
 export function allFromDictAsync<R extends AsyncResultRecord>(

--- a/packages/core/src/tagged.ts
+++ b/packages/core/src/tagged.ts
@@ -133,7 +133,7 @@ export type TagHandlers<T, E extends { _tag: string }, R> = {
  *
  * @example
  * ```ts
- * import { Ok, Err, matchTags, TaggedError } from "unthrown";
+ * import { Ok, Err, matchTags, TaggedError, type Result } from "unthrown";
  *
  * class NotFound extends TaggedError("NotFound") {}
  * class Forbidden extends TaggedError("Forbidden")<{ user: string }> {}

--- a/packages/core/src/tagged.ts
+++ b/packages/core/src/tagged.ts
@@ -11,6 +11,8 @@ type Props = Record<string, unknown>;
  *
  * @typeParam Tag - the string literal discriminant.
  * @typeParam A - the payload object type.
+ *
+ * @category Types
  */
 export type TaggedErrorInstance<Tag extends string, A extends Props> = Error &
   Readonly<A> & { readonly _tag: Tag };
@@ -24,6 +26,8 @@ export type TaggedErrorInstance<Tag extends string, A extends Props> = Error &
  * `keyof A extends never ? void : A` trick); otherwise it takes the payload.
  *
  * @typeParam Tag - the string literal discriminant.
+ *
+ * @category Types
  */
 export type TaggedErrorConstructor<Tag extends string> = {
   new <A extends Props = {}>(args: keyof A extends never ? void : A): TaggedErrorInstance<Tag, A>;
@@ -60,13 +64,15 @@ export type TaggedErrorConstructor<Tag extends string> = {
  * @param options - optional overrides. `options.name` sets `Error.name`
  * independently of `tag` (defaults to `tag`).
  *
+ * @category Tagged errors
+ *
  * @example
  * ```ts
  * class NotFound extends TaggedError("NotFound") {}
  * class HttpError extends TaggedError("HttpError")<{ status: number }> {}
  *
- * new NotFound()._tag; // "NotFound"
- * new HttpError({ status: 500 }).status; // 500
+ * new NotFound()._tag; // => "NotFound"
+ * new HttpError({ status: 500 }).status; // => 500
  * ```
  */
 export function TaggedError<Tag extends string>(
@@ -99,6 +105,8 @@ export function TaggedError<Tag extends string>(
  * @typeParam T - the success value type.
  * @typeParam E - the tagged error union.
  * @typeParam R - the folded result type.
+ *
+ * @category Types
  */
 export type TagHandlers<T, E extends { _tag: string }, R> = {
   Ok: (value: T) => R;
@@ -121,18 +129,25 @@ export type TagHandlers<T, E extends { _tag: string }, R> = {
  * @param result - the result to fold.
  * @param handlers - one branch per channel/tag.
  *
+ * @category Tagged errors
+ *
  * @example
  * ```ts
+ * import { Ok, Err, matchTags, TaggedError } from "unthrown";
+ *
  * class NotFound extends TaggedError("NotFound") {}
  * class Forbidden extends TaggedError("Forbidden")<{ user: string }> {}
  *
- * declare const r: Result<number, NotFound | Forbidden>;
- * matchTags(r, {
- *   Ok: (n) => `got ${n}`,
- *   Defect: (cause) => `bug: ${String(cause)}`,
- *   NotFound: () => "404",
- *   Forbidden: (e) => `403 for ${e.user}`,
- * });
+ * const fold = (r: Result<number, NotFound | Forbidden>) =>
+ *   matchTags(r, {
+ *     Ok: (n) => `got ${n}`,
+ *     Defect: (cause) => `bug: ${String(cause)}`,
+ *     NotFound: () => "404",
+ *     Forbidden: (e) => `403 for ${e.user}`,
+ *   });
+ *
+ * fold(Ok(1)); // => "got 1"
+ * fold(Err(new Forbidden({ user: "ada" }))); // => "403 for ada"
  * ```
  */
 export function matchTags<T, E extends { _tag: string }, R>(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -275,17 +275,29 @@ export type ResultMethods<T, E> = {
   toAsync(): AsyncResult<T, E>;
 };
 
-/** The `Ok` variant of a {@link Result}: a success carrying a `value`. */
+/**
+ * The `Ok` variant of a {@link Result}: a success carrying a `value`.
+ *
+ * @category Types
+ */
 export type OkView<T, E = never> = ResultMethods<T, E> & {
   readonly tag: "Ok";
   readonly value: T;
 };
-/** The `Err` variant of a {@link Result}: a modeled failure carrying an `error`. */
+/**
+ * The `Err` variant of a {@link Result}: a modeled failure carrying an `error`.
+ *
+ * @category Types
+ */
 export type ErrView<E, T = never> = ResultMethods<T, E> & {
   readonly tag: "Err";
   readonly error: E;
 };
-/** The `Defect` variant of a {@link Result}: an unmodeled failure carrying a `cause`. */
+/**
+ * The `Defect` variant of a {@link Result}: an unmodeled failure carrying a `cause`.
+ *
+ * @category Types
+ */
 export type DefectView<T = never, E = never> = ResultMethods<T, E> & {
   readonly tag: "Defect";
   readonly cause: unknown;
@@ -342,6 +354,8 @@ export type Result<T, E> = OkView<T, E> | ErrView<E, T> | DefectView<T, E>;
  * being treated as a raw promise (e.g. dropped into `Promise.all`).
  *
  * @typeParam T - the value `await` resolves to.
+ *
+ * @category Types
  */
 export type Awaitable<T> = {
   then<R = T>(onfulfilled?: ((value: T) => R | PromiseLike<R>) | null): PromiseLike<R>;
@@ -446,23 +460,31 @@ export type AsyncResult<T, E> = Awaitable<Result<T, E>> & {
  * Extract the success type `T` from a `Result`.
  *
  * @typeParam R - the `Result` type to inspect.
+ *
+ * @category Types
  */
 export type OkOf<R> = R extends { readonly tag: "Ok"; readonly value: infer T } ? T : never;
 /**
  * Extract the error type `E` from a `Result`.
  *
  * @typeParam R - the `Result` type to inspect.
+ *
+ * @category Types
  */
 export type ErrOf<R> = R extends { readonly tag: "Err"; readonly error: infer E } ? E : never;
 /**
  * Extract the success type `T` from an {@link AsyncResult}.
  *
  * @typeParam R - the `AsyncResult` type to inspect.
+ *
+ * @category Types
  */
 export type AsyncOkOf<R> = R extends AsyncResult<infer T, unknown> ? T : never;
 /**
  * Extract the error type `E` from an {@link AsyncResult}.
  *
  * @typeParam R - the `AsyncResult` type to inspect.
+ *
+ * @category Types
  */
 export type AsyncErrOf<R> = R extends AsyncResult<unknown, infer E> ? E : never;


### PR DESCRIPTION
Acts on the docs review (unthrown vs byethrow vs boxed). Focus: beginner-friendliness, illustrated examples, a more readable API reference, and a "Choosing a combinator" page driven by **intent + operator signature**.

## Guide
- **Getting Started** — rewritten around a realistic thread (`parseAge` → chain → `match`) instead of the abstract `half(n)`; every line carries a `// =>` output. (byethrow/boxed both onboard with realistic snippets.)
- **Choosing a Combinator** — the intent table gains an **operator signature column**; the `→ Result<…>` half shows how each combinator moves the channels (`flatMap` widens `E`, `recover` empties it to `never`, `orElse` widens the value). Added a **"Behavior at a glance" grid** (`method × Ok/Err/Defect × resulting E`) that makes the defect-passthrough invariant visual — the `Defect` column is "passes ▸" everywhere except `recoverDefect`/`match`. (boxed's per-type cheatsheet grid.)
- **Callouts** — `:::tip`/`:::warning` for the load-bearing footguns: `recover`'s `never` isn't "total", and `unwrapOr`/`getOrNull` rethrow on a defect.
- Standardized example outputs to `// =>` across the surface pages.

## API reference (TSDoc — comment-only, no code/type changes)
- **`@category` on every exported symbol** → the TypeDoc-generated page becomes grouped tables (Constructors / Guards / Interop / Aggregate / Tagged errors / Facade / Types) instead of a flat alphabetical list. (byethrow uses the same `@category` trick on the same pipeline.)
- **Richer `@example` blocks** on the standalone functions: both an Ok and an Err branch, `// =>` output comments, and the current injected-`defect` `qualify` form (`(cause, defect) => … defect(cause)`).

## Scope notes
- The fluent **methods** (`map`/`flatMap`/…) aren't in the API reference at all — `ResultMethods` is `intentionallyNotExported`, so they live only in the guide; that's why the combinator work targets the guide, and the `@example` work targets the standalone functions.
- **Deliberately not done** (larger, separate bets): a hand-authored 4-part per-method API page set (redundant now that the generated page is grouped+exampled), a full graded "tutorial" section, and a live playground link. Happy to follow up on any of these.

Gate: format · lint · knip · typecheck 15/15 · test 168 · **build:docs warning-free** · docs site builds (no dead links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)