### PR TITLE
docs: import TaggedError in the landing snippet

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ features:
 ## At a glance
 
 ```ts
-import { Ok, Err, fromPromise, type Result } from "unthrown";
+import { Ok, Err, fromPromise, TaggedError, type Result } from "unthrown";
 
 class NotFound extends TaggedError("NotFound") {}
 


### PR DESCRIPTION
Site review turned up one copy-paste bug: the homepage "At a glance" example calls `TaggedError("NotFound")` but the import line only had `Ok, Err, fromPromise, type Result`. Added `TaggedError`.

(`User`/`users` are left as illustrative domain placeholders, per the usual hero-snippet convention.)

Docs-only. Format clean, docs site builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)