### PR TITLE
docs: enrich API Types section + group Facade type aliases

### DIFF
--- a/.changeset/api-types-facade-docs.md
+++ b/.changeset/api-types-facade-docs.md
@@ -1,0 +1,10 @@
+---
+"unthrown": patch
+---
+
+Polish the generated API reference (comment-only): give the `Types`-section
+aliases practical framing and examples (`OkView`/`ErrView`/`DefectView` note what
+each guard narrows to; `OkOf`/`ErrOf`/`AsyncOkOf`/`AsyncErrOf` show a type-extraction
+example), and group the `Result`/`AsyncResult` **type** aliases under the `Facade`
+category alongside their companion objects, cross-linked so the value+type pairing
+is clear.

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -58,6 +58,13 @@ export const Result = {
   isResult,
 } as const;
 
+/**
+ * `Result<T, E>` — the core discriminated union. Shares its name with the
+ * {@link Result | companion object} above (the value and type are one name); this
+ * is the type half.
+ *
+ * @category Facade
+ */
 // Re-alias the Result type into this module so a single `export { Result }`
 // (from index.ts) carries BOTH the companion object above and the type — value
 // and type sharing one name, declaration-merged in one place.
@@ -94,6 +101,13 @@ export const AsyncResult = {
   allFromDict: allFromDictAsync,
 } as const;
 
+/**
+ * `AsyncResult<T, E>` — the async counterpart of {@link Result}. Shares its name
+ * with the {@link AsyncResult | companion object} above (value and type are one
+ * name); this is the type half.
+ *
+ * @category Facade
+ */
 // Re-alias the AsyncResult type into this module (same companion-object pattern
 // as Result above) so one `export { AsyncResult }` carries value + type.
 export type AsyncResult<T, E> = AsyncResultType<T, E>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -276,7 +276,13 @@ export type ResultMethods<T, E> = {
 };
 
 /**
- * The `Ok` variant of a {@link Result}: a success carrying a `value`.
+ * The `Ok` variant of a {@link Result}: a success carrying a `value`. This is
+ * what a successful `isOk` guard narrows to, making `.value` reachable.
+ *
+ * @example
+ * ```ts
+ * if (r.isOk()) r.value; // r: OkView<T, E> here — .value is a T
+ * ```
  *
  * @category Types
  */
@@ -286,6 +292,12 @@ export type OkView<T, E = never> = ResultMethods<T, E> & {
 };
 /**
  * The `Err` variant of a {@link Result}: a modeled failure carrying an `error`.
+ * What a successful `isErr` guard narrows to, exposing `.error`.
+ *
+ * @example
+ * ```ts
+ * if (r.isErr()) r.error; // r: ErrView<E, T> here — .error is an E
+ * ```
  *
  * @category Types
  */
@@ -294,7 +306,13 @@ export type ErrView<E, T = never> = ResultMethods<T, E> & {
   readonly error: E;
 };
 /**
- * The `Defect` variant of a {@link Result}: an unmodeled failure carrying a `cause`.
+ * The `Defect` variant of a {@link Result}: an unmodeled failure carrying a
+ * `cause`. What a successful `isDefect` guard narrows to, exposing `.cause`.
+ *
+ * @example
+ * ```ts
+ * if (r.isDefect()) r.cause; // r: DefectView<T, E> here — .cause is `unknown`
+ * ```
  *
  * @category Types
  */
@@ -457,33 +475,59 @@ export type AsyncResult<T, E> = Awaitable<Result<T, E>> & {
 };
 
 /**
- * Extract the success type `T` from a `Result`.
+ * Extract the success type `T` from a `Result` type — derive one type from
+ * another instead of restating it (e.g. the payload a function returns).
  *
  * @typeParam R - the `Result` type to inspect.
+ *
+ * @example
+ * ```ts
+ * type R = Result<User, NotFound>;
+ * type U = OkOf<R>; // User
+ * type E = ErrOf<R>; // NotFound
+ * ```
  *
  * @category Types
  */
 export type OkOf<R> = R extends { readonly tag: "Ok"; readonly value: infer T } ? T : never;
 /**
- * Extract the error type `E` from a `Result`.
+ * Extract the error type `E` from a `Result` type — the counterpart of
+ * {@link OkOf}.
  *
  * @typeParam R - the `Result` type to inspect.
+ *
+ * @example
+ * ```ts
+ * type E = ErrOf<Result<User, NotFound>>; // NotFound
+ * ```
  *
  * @category Types
  */
 export type ErrOf<R> = R extends { readonly tag: "Err"; readonly error: infer E } ? E : never;
 /**
- * Extract the success type `T` from an {@link AsyncResult}.
+ * Extract the success type `T` from an {@link AsyncResult} type — the async
+ * counterpart of {@link OkOf}.
  *
  * @typeParam R - the `AsyncResult` type to inspect.
+ *
+ * @example
+ * ```ts
+ * type T = AsyncOkOf<AsyncResult<User, NotFound>>; // User
+ * ```
  *
  * @category Types
  */
 export type AsyncOkOf<R> = R extends AsyncResult<infer T, unknown> ? T : never;
 /**
- * Extract the error type `E` from an {@link AsyncResult}.
+ * Extract the error type `E` from an {@link AsyncResult} type — the async
+ * counterpart of {@link ErrOf}.
  *
  * @typeParam R - the `AsyncResult` type to inspect.
+ *
+ * @example
+ * ```ts
+ * type E = AsyncErrOf<AsyncResult<User, NotFound>>; // NotFound
+ * ```
  *
  * @category Types
  */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -292,7 +292,7 @@ export type OkView<T, E = never> = ResultMethods<T, E> & {
 };
 /**
  * The `Err` variant of a {@link Result}: a modeled failure carrying an `error`.
- * What a successful `isErr` guard narrows to, exposing `.error`.
+ * This is what a successful `isErr` guard narrows to, exposing `.error`.
  *
  * @example
  * ```ts
@@ -307,7 +307,8 @@ export type ErrView<E, T = never> = ResultMethods<T, E> & {
 };
 /**
  * The `Defect` variant of a {@link Result}: an unmodeled failure carrying a
- * `cause`. What a successful `isDefect` guard narrows to, exposing `.cause`.
+ * `cause`. This is what a successful `isDefect` guard narrows to, exposing
+ * `.cause`.
  *
  * @example
  * ```ts


### PR DESCRIPTION
Follow-up to the live-site review — the two minor API-reference nits.

## Types section was terse
The utility aliases rendered with a signature but almost no practical framing. Now:
- **`OkView` / `ErrView` / `DefectView`** say what each is *for* (what a successful `isOk`/`isErr`/`isDefect` guard narrows to) with a one-line narrowing example.
- **`OkOf` / `ErrOf` / `AsyncOkOf` / `AsyncErrOf`** get a type-extraction `@example` (`type U = OkOf<Result<User, NotFound>> // User`).

## Facade looked duplicated
`Result`/`AsyncResult` each appeared as both a const and a type. Gave the two **type** aliases `@category Facade` so they now sit next to their companion objects, each cross-linked to the value half ("value + type, one name") — so the pairing reads as intentional rather than accidental duplication.

Comment-only — no runtime/type changes. Verified against the generated output: the Types examples render and the Facade section now contains both halves, cross-linked. Gate green: format · typecheck · **build:docs warning-free** (incl. the `{@link X | text}` links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)