### PR TITLE
chore(docs): adopt @btravstack/theme 1.5.0 (docs chrome)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: 3.4.0
       version: 3.4.0
     '@btravstack/theme':
-      specifier: 1.4.0
-      version: 1.4.0
+      specifier: 1.5.0
+      version: 1.5.0
     '@changesets/cli':
       specifier: 2.31.0
       version: 2.31.0
@@ -134,7 +134,7 @@ importers:
     devDependencies:
       '@btravstack/theme':
         specifier: 'catalog:'
-        version: 1.4.0(vitepress@1.6.4(@algolia/client-search@5.55.1)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3))
+        version: 1.5.0(vitepress@1.6.4(@algolia/client-search@5.55.1)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3))
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
@@ -562,8 +562,8 @@ packages:
       typescript:
         optional: true
 
-  '@btravstack/theme@1.4.0':
-    resolution: {integrity: sha512-K6s6gxBkRRQG51gf13CMS+lu6QX+mH4DFhR8v75+v0UYDmAL/hCBbkuc0ydRcPMQ1NcBvHpkbj34Tukl4LCtSQ==}
+  '@btravstack/theme@1.5.0':
+    resolution: {integrity: sha512-tTTWDNarS0GOSeHk3GZ+GtrNfAFacZNvYMzG+X/gpyUa8irPGB8MT4f+uCbloJ2UFG6JNLNXnMF7KuAVtMaoAA==}
     peerDependencies:
       vitepress: ^1.6.0
 
@@ -3541,7 +3541,7 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@btravstack/theme@1.4.0(vitepress@1.6.4(@algolia/client-search@5.55.1)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3))':
+  '@btravstack/theme@1.5.0(vitepress@1.6.4(@algolia/client-search@5.55.1)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3))':
     dependencies:
       vitepress: 1.6.4(@algolia/client-search@5.55.1)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,7 @@ catalog:
   "@changesets/cli": 2.31.0
   "@commitlint/cli": 21.1.0
   "@bloodyowl/boxed": 3.4.0
-  "@btravstack/theme": 1.4.0
+  "@btravstack/theme": 1.5.0
   "@standard-schema/spec": 1.1.0
   "@commitlint/config-conventional": 21.1.0
   "@oxlint/plugins": 1.71.0


### PR DESCRIPTION
Bumps `@btravstack/theme` 1.4.0 → **1.5.0** to pick up the shared docs chrome (the "Part of btravstack" strip, larger hero mark, broader accent glow). Docs build verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)