### PR TITLE
fix(docs): hero polish — span the glyph + enlarge the logo on tablet/mobile

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -24,16 +24,15 @@
 .VPHome::after {
   content: "";
   position: absolute;
-  top: 30px;
+  top: 8px;
+  left: var(--btv-gutter);
   right: var(--btv-gutter);
-  width: 560px;
-  max-width: 46vw;
   aspect-ratio: 500 / 300;
   background-color: var(--accent);
   -webkit-mask: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MDAgMzAwIiBmaWxsPSJub25lIj48cGF0aCBkPSJNMCwxMjAgSDUwMCIgc3Ryb2tlPSIjZmZmIiBzdHJva2Utd2lkdGg9IjIiLz48cGF0aCBkPSJNMCwxOTAgSDIxMCBDMjUwLDE5MCAyNTAsMjUwIDI5MCwyNTAgSDUwMCIgc3Ryb2tlPSIjZmZmIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1kYXNoYXJyYXk9IjcgNyIvPjxjaXJjbGUgY3g9IjIxMCIgY3k9IjE5MCIgcj0iNiIgZmlsbD0iI2ZmZiIvPjx0ZXh0IHg9IjQyNSIgeT0iMTA4IiBmb250LWZhbWlseT0ibW9ub3NwYWNlIiBmb250LXNpemU9IjE1IiBmaWxsPSIjZmZmIj5vazwvdGV4dD48dGV4dCB4PSI0MjUiIHk9IjIzOCIgZm9udC1mYW1pbHk9Im1vbm9zcGFjZSIgZm9udC1zaXplPSIxNSIgZmlsbD0iI2ZmZiI+ZXJyPC90ZXh0Pjwvc3ZnPg==")
-    no-repeat top right / contain;
+    no-repeat top center / contain;
   mask: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MDAgMzAwIiBmaWxsPSJub25lIj48cGF0aCBkPSJNMCwxMjAgSDUwMCIgc3Ryb2tlPSIjZmZmIiBzdHJva2Utd2lkdGg9IjIiLz48cGF0aCBkPSJNMCwxOTAgSDIxMCBDMjUwLDE5MCAyNTAsMjUwIDI5MCwyNTAgSDUwMCIgc3Ryb2tlPSIjZmZmIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1kYXNoYXJyYXk9IjcgNyIvPjxjaXJjbGUgY3g9IjIxMCIgY3k9IjE5MCIgcj0iNiIgZmlsbD0iI2ZmZiIvPjx0ZXh0IHg9IjQyNSIgeT0iMTA4IiBmb250LWZhbWlseT0ibW9ub3NwYWNlIiBmb250LXNpemU9IjE1IiBmaWxsPSIjZmZmIj5vazwvdGV4dD48dGV4dCB4PSI0MjUiIHk9IjIzOCIgZm9udC1mYW1pbHk9Im1vbm9zcGFjZSIgZm9udC1zaXplPSIxNSIgZmlsbD0iI2ZmZiI+ZXJyPC90ZXh0Pjwvc3ZnPg==")
-    no-repeat top right / contain;
+    no-repeat top center / contain;
   opacity: 0.14;
   pointer-events: none;
   z-index: 0;


### PR DESCRIPTION
Follow-up to the anchoring fix: widen the hero glyph from the content-right column to the **full content column**, so its motif reads across the whole hero head rather than only behind the logo. Verified locally at 1440/1920.

🤖 Generated with [Claude Code](https://claude.com/claude-code)