### PR TITLE
fix(docs): enlarge the hero logo on tablet/mobile

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -48,9 +48,8 @@
  * too. */
 @media (max-width: 959px) {
   .VPHero .image-src {
-    width: 208px;
-    height: 208px;
-    max-width: 62vw;
+    width: min(208px, 62vw);
+    height: min(208px, 62vw);
     object-fit: contain;
   }
 }

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -42,3 +42,15 @@
     display: none;
   }
 }
+
+/* The shared theme only enlarges the hero mark at >=960px; below that the
+ * mark's small intrinsic size leaves it tiny, so size it up for tablet/mobile
+ * too. */
+@media (max-width: 959px) {
+  .VPHero .image-src {
+    width: 208px;
+    height: 208px;
+    max-width: 62vw;
+    object-fit: contain;
+  }
+}


### PR DESCRIPTION
The shared theme only enlarges the hero mark at >=960px, so on tablet and mobile it rendered at its small intrinsic size (~64px). This sizes it to ~208px there too. Verified locally at 768 and 390.

🤖 Generated with [Claude Code](https://claude.com/claude-code)