### PR TITLE
fix: address whole-repo review findings

### DIFF
--- a/.changeset/fix-review-findings.md
+++ b/.changeset/fix-review-findings.md
@@ -1,0 +1,20 @@
+---
+"unthrown": patch
+---
+
+Fixes from a whole-repo review:
+
+- **`unthrown`** — `TaggedError` now reserves `name`: a payload field named `name`
+  can no longer shadow the display label (it was silently clobbered at runtime
+  while the instance type still promised it). `name` is excluded from the payload
+  type, consistent with how `_tag` is authoritative.
+- **`@unthrown/vitest`** — the matchers now reject a foreign `Result`-like object
+  (e.g. a neverthrow/Boxed result) via core's canonical `isResult` instead of a
+  loose `isOk`-duck-type, so such a value fails clearly as "not an unthrown
+  Result" rather than being mistaken for an `Err`.
+- **`@unthrown/oxlint`** — `no-ambiguous-error-type` resolves a bare `Error`
+  through scope analysis, so a locally-declared `type Error` or a generic
+  `<Error>` parameter is no longer a false positive.
+- **`@unthrown/standard-schema`** — async-schema detection uses a structural
+  thenable check instead of `instanceof Promise`, so a promise from another realm
+  (vm/worker) is correctly caught instead of silently producing `Ok(undefined)`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,7 +278,7 @@ channel?**
    — a forgotten one passes silently).
 4. ✅ **`packages/pattern`** — Done. Because `Result` is a discriminated union
    (Thesis #1 / Public surface), `ts-pattern` matches it natively — this package
-   is thin sugar: pattern constructors `P.ok`/`P.err`/`P.defect` (returning the
+   is thin sugar: pattern constructors `P.Ok`/`P.Err`/`P.Defect` (returning the
    `{ tag: … }` object patterns) plus `tag(t)` (the `{ _tag: t }` pattern,
    narrowing to the variant + payload). Kept small — the power is ts-pattern's;
    `matchTags` covers the everyday exhaustive case.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,10 @@ pnpm add unthrown
 ```ts
 import { fromPromise, TaggedError } from "unthrown";
 
+// Our modeled domain failure:
 class NotFound extends TaggedError("NotFound") {}
+// What the upstream `fetchUser` rejects with when the user is absent:
+class NotFoundError extends Error {}
 
 // Cross an async boundary — every rejection MUST be triaged into E or a defect.
 // `defect` is injected as qualify's second argument.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -6,7 +6,8 @@ This reference is generated from the source with
 ## Packages
 
 - [**unthrown**](./core/) — the core `Result` / `AsyncResult` types,
-  constructors (`Ok`, `Err`, `Defect`), guards, boundary interop
+  constructors (`Ok`, `Err` — a `Defect` has no constructor; it arises only at
+  boundaries), guards, boundary interop
   (`fromNullable`, `fromThrowable`, `fromPromise`, `fromSafePromise`),
   aggregation (`all`), and the tagged-error utilities (`TaggedError`,
   `matchTags`).

--- a/docs/guide/boundaries.md
+++ b/docs/guide/boundaries.md
@@ -45,7 +45,10 @@ A throw _inside_ `qualify` is itself treated as a defect.
 [`AsyncResult`](./async-results). Every rejection **must** be triaged:
 
 ```ts
-import { fromPromise } from "unthrown";
+import { fromPromise, TaggedError } from "unthrown";
+
+class NotFound extends TaggedError("NotFound") {} // our modeled domain failure
+class NotFoundError extends Error {} // what `fetchUser` rejects with on a 404
 
 const user = fromPromise(fetchUser(id), (cause, defect) =>
   cause instanceof NotFoundError ? new NotFound() : defect(cause),

--- a/docs/guide/interop.md
+++ b/docs/guide/interop.md
@@ -66,7 +66,9 @@ Every package mirrors its sync pair for the asynchronous types:
 Future<Result>`.
 
 On the way in, an _unexpected_ rejection inside the neighbour's async type
-becomes a `Defect` — never a silently-swallowed error.
+becomes a `Defect` — never a silently-swallowed error. (Boxed's `Future` has no
+failure channel and never rejects, so for `fromBoxedFuture` this is a defensive
+guarantee rather than a path you can actually hit.)
 
 ## Standard Schema — validators as `Result`s
 

--- a/packages/boxed/src/index.ts
+++ b/packages/boxed/src/index.ts
@@ -88,9 +88,12 @@ export function toBoxedFuture<T, E>(
  * Convert a Boxed `Future<Result>` into an `AsyncResult`.
  *
  * @remarks
- * The async counterpart of {@link fromBoxed}. A `Result.Error` stays an `Err`;
- * an *unexpected* rejection of the underlying promise becomes a `Defect`. The
- * returned `AsyncResult` never throws when awaited.
+ * The async counterpart of {@link fromBoxed}. A `Result.Error` inside the future
+ * stays an `Err`. Boxed's `Future` has no failure channel of its own —
+ * `Future.toPromise()` does not reject — so in practice no `Defect` arises here;
+ * the `fromSafePromise` boundary is a defensive net that would only capture one
+ * if a future somehow rejected. The returned `AsyncResult` never throws when
+ * awaited.
  *
  * @typeParam T - the success value type.
  * @typeParam E - the modeled error type.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -11,7 +11,10 @@ pnpm add unthrown
 ```
 
 ```ts
-import { Ok, Err, fromPromise, type Result } from "unthrown";
+import { fromPromise, TaggedError } from "unthrown";
+
+class NotFound extends TaggedError("NotFound") {} // our modeled domain failure
+class NotFoundError extends Error {} // what `fetchUser` rejects with on a 404
 
 const user = fromPromise(fetchUser(id), (cause, defect) =>
   cause instanceof NotFoundError ? new NotFound() : defect(cause),

--- a/packages/core/src/aggregate.spec.ts
+++ b/packages/core/src/aggregate.spec.ts
@@ -163,4 +163,13 @@ describe("allFromDictAsync", () => {
   it("returns Ok({}) for an empty record", async () => {
     expect((await allFromDictAsync({})).unwrap()).toEqual({});
   });
+
+  it("does not let a `__proto__` key pollute the prototype", async () => {
+    const r = await allFromDictAsync({
+      ["__proto__"]: fromSafePromise(Promise.resolve({ polluted: true })),
+      safe: fromSafePromise(Promise.resolve(1)),
+    });
+    expect(r.isOk()).toBe(true);
+    expect(({} as Record<string, unknown>)["polluted"]).toBeUndefined();
+  });
 });

--- a/packages/core/src/async-result.spec.ts
+++ b/packages/core/src/async-result.spec.ts
@@ -238,7 +238,10 @@ describe("AsyncResult eliminators", () => {
 
   it("a Defect rejects the eliminators with the original cause", async () => {
     await expect(asyncDefect().unwrap()).rejects.toBe(boom);
+    await expect(asyncDefect().unwrapErr()).rejects.toBe(boom);
     await expect(asyncDefect().unwrapOr(0)).rejects.toBe(boom);
+    await expect(asyncDefect().unwrapOrElse(() => 0)).rejects.toBe(boom);
     await expect(asyncDefect().getOrNull()).rejects.toBe(boom);
+    await expect(asyncDefect().getOrUndefined()).rejects.toBe(boom);
   });
 });

--- a/packages/core/src/facade.spec.ts
+++ b/packages/core/src/facade.spec.ts
@@ -3,12 +3,15 @@ import { describe, expect, it } from "vitest";
 import {
   all,
   allAsync,
+  allFromDict,
   allFromDictAsync,
   AsyncResult,
+  Do,
   Err,
   fromNullable,
   fromPromise,
   fromSafePromise,
+  fromThrowable,
   isDefect,
   isErr,
   isOk,
@@ -45,9 +48,13 @@ describe("Result facade mirrors the free functions", () => {
 
   it("exposes the sync interop and aggregate entry points", () => {
     expect(Result.fromNullable).toBe(fromNullable);
+    expect(Result.fromThrowable).toBe(fromThrowable);
+    expect(Result.Do).toBe(Do);
     expect(Result.all).toBe(all);
+    expect(Result.allFromDict).toBe(allFromDict);
     expect(Result.fromNullable(null, () => "absent").unwrapErr()).toBe("absent");
     expect(Result.all([Result.Ok(1), Result.Ok(2)]).unwrap()).toEqual([1, 2]);
+    expect(Result.allFromDict({ a: Result.Ok(1) }).unwrap()).toEqual({ a: 1 });
   });
 
   it("does NOT carry the async entry points (those live on AsyncResult)", () => {

--- a/packages/core/src/invariants.spec.ts
+++ b/packages/core/src/invariants.spec.ts
@@ -1,5 +1,7 @@
 // Explicit guards for the load-bearing runtime invariants documented in
-// CLAUDE.md. Each `describe` maps 1:1 to an invariant there.
+// CLAUDE.md. Most get a dedicated `describe` here; a couple are guarded where
+// their feature lives instead — prototype-pollution safety and `all` / `allAsync`
+// Defect-dominance are covered in `aggregate.spec.ts`.
 
 import { describe, expect, it, vi } from "vitest";
 

--- a/packages/core/src/tagged.spec.ts
+++ b/packages/core/src/tagged.spec.ts
@@ -44,6 +44,13 @@ describe("TaggedError", () => {
     expect(e._tag).toBe("Forbidden");
   });
 
+  it("keeps `name` reserved — a payload `name` cannot shadow the display name", () => {
+    class UserError extends TaggedError("UserError")<{ user: string }> {}
+    const e = new UserError({ user: "Alice", name: "Alice" } as { user: string });
+    expect(e.name).toBe("UserError"); // display label, not the payload's `name`
+    expect(e.user).toBe("Alice");
+  });
+
   it("distinct tags produce distinct, discriminable classes", () => {
     const errors: ApiError[] = [new NotFound(), new Forbidden({ user: "a" })];
     expect(errors.map((e) => e._tag)).toEqual(["NotFound", "Forbidden"]);

--- a/packages/core/src/tagged.ts
+++ b/packages/core/src/tagged.ts
@@ -23,14 +23,19 @@ export type TaggedErrorInstance<Tag extends string, A extends Props> = Error &
  *
  * @remarks
  * When the payload is empty, the constructor takes **no** arguments (the
- * `keyof A extends never ? void : A` trick); otherwise it takes the payload.
+ * `keyof A extends never ? void : A` trick); otherwise it takes the payload. A
+ * `name` key is **rejected** (`name?: never`) because it is reserved for the
+ * display label — mirroring how {@link TaggedErrorInstance} excludes it — so the
+ * reservation is enforced at the call site, not just ignored at runtime.
  *
  * @typeParam Tag - the string literal discriminant.
  *
  * @category Types
  */
 export type TaggedErrorConstructor<Tag extends string> = {
-  new <A extends Props = {}>(args: keyof A extends never ? void : A): TaggedErrorInstance<Tag, A>;
+  new <A extends Props = {}>(
+    args: keyof A extends never ? void : A & { readonly name?: never },
+  ): TaggedErrorInstance<Tag, A>;
 };
 
 /**
@@ -43,8 +48,8 @@ export type TaggedErrorConstructor<Tag extends string> = {
  * field in the payload is forwarded to `Error`. The `_tag` always reflects
  * `tag` and cannot be overridden by the payload. `name` is likewise reserved —
  * it is the display label (set it with `options.name`); a payload `name` is
- * ignored at runtime and excluded from the instance type, so it can't shadow
- * `Error.name`.
+ * rejected at compile time (and excluded from the instance type), so it can't
+ * shadow `Error.name`.
  *
  * `_tag` is the discriminant used by {@link matchTags}; `Error.name` is the
  * human-facing label in stack traces and logs. By default they coincide, but

--- a/packages/core/src/tagged.ts
+++ b/packages/core/src/tagged.ts
@@ -15,7 +15,7 @@ type Props = Record<string, unknown>;
  * @category Types
  */
 export type TaggedErrorInstance<Tag extends string, A extends Props> = Error &
-  Readonly<A> & { readonly _tag: Tag };
+  Readonly<Omit<A, "name">> & { readonly _tag: Tag };
 
 /**
  * The class constructor returned by {@link TaggedError}. Generic in its payload:
@@ -41,7 +41,10 @@ export type TaggedErrorConstructor<Tag extends string> = {
  * Extend the returned class to declare a concrete error. Supply the payload with
  * an instantiation expression; omit it for a payload-less error. A `message`
  * field in the payload is forwarded to `Error`. The `_tag` always reflects
- * `tag` and cannot be overridden by the payload.
+ * `tag` and cannot be overridden by the payload. `name` is likewise reserved —
+ * it is the display label (set it with `options.name`); a payload `name` is
+ * ignored at runtime and excluded from the instance type, so it can't shadow
+ * `Error.name`.
  *
  * `_tag` is the discriminant used by {@link matchTags}; `Error.name` is the
  * human-facing label in stack traces and logs. By default they coincide, but

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -17,6 +17,7 @@ import {
   Do,
   type ErrOf,
   Err,
+  type ErrView,
   fromPromise,
   fromThrowable,
   isDefect,
@@ -103,6 +104,20 @@ fromPromise(Promise.resolve(1));
 // flatMap widens the error channel
 const flatMapped = r1.flatMap(() => Err<"e2">("e2"));
 type _flatMapped = Expect<Equal<typeof flatMapped, Result<never, "e1" | "e2">>>;
+
+// A raw Promise may NEVER enter an AsyncResult combinator (Thesis #3): the
+// callback must return a Result or an AsyncResult, so its rejection can't
+// silently become a Defect. Pins that the param bound rejects a `Promise`.
+declare const ar: AsyncResult<number, "e">;
+// @ts-expect-error - a raw Promise callback return is not assignable
+ar.flatMap((n) => Promise.resolve(Ok(n)));
+
+// ErrView's parameter order is <E, T> (error first) — the reverse of OkView /
+// DefectView / Result — because `Result<T, E>` narrows to `ErrView<E, T>`.
+type _errViewErr = Expect<Equal<ErrView<"boom", number>["error"], "boom">>;
+type _errViewNarrow = Expect<
+  Equal<Extract<Result<number, "boom">, { readonly tag: "Err" }>, ErrView<"boom", number>>
+>;
 
 // flatTap KEEPS the value type and widens the error channel
 const flatTapped = r1.flatTap(() => Err<"e2">("e2"));

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -29,6 +29,7 @@ import {
   type OkOf,
   type Result,
   TaggedError,
+  type TaggedErrorInstance,
 } from "./index.js";
 
 // --- assertion helpers -------------------------------------------------------
@@ -230,3 +231,14 @@ matchTags(tagged, { Ok: () => 1, Defect: () => 2, TagA: () => 3 });
 // `_tag` is the literal; `options.name` is independent (still a literal `_tag`)
 class Named extends TaggedError("@scope/Named", { name: "Named" }) {}
 type _namedTag = Expect<Equal<(typeof Named)["prototype"]["_tag"], "@scope/Named">>;
+
+// `name` is reserved (the display label) — rejected as a payload key at the call
+// site, and never shadowed on the instance type.
+class WithCode extends TaggedError("WithCode")<{ code: number }> {}
+new WithCode({ code: 1 });
+// @ts-expect-error - a `name` payload key is reserved, not constructable
+new WithCode({ code: 1, name: "nope" });
+// Even a forced `name` payload does not narrow `Error.name`: it stays `string`.
+type _nameNotShadowed = Expect<
+  Equal<TaggedErrorInstance<"X", { code: number; name: "lit" }>["name"], string>
+>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -296,6 +296,14 @@ export type OkView<T, E = never> = ResultMethods<T, E> & {
  * The `Err` variant of a {@link Result}: a modeled failure carrying an `error`.
  * This is what a successful `isErr` guard narrows to, exposing `.error`.
  *
+ * @remarks
+ * **Note the parameter order: `ErrView<E, T>` puts the error type _first_** — the
+ * reverse of the `<T, E>` order used by {@link OkView}, {@link DefectView}, and
+ * {@link Result} — because `Result<T, E>` narrows to `ErrView<E, T>` (the error is
+ * the payload the guard makes reachable). You rarely write it by hand (a failed
+ * `isErr()` narrows to it for you); if you do, mind the flip — `ErrView<MyError,
+ * MyValue>`, not `ErrView<MyValue, MyError>`.
+ *
  * @example
  * ```ts
  * if (r.isErr()) r.error; // r: ErrView<E, T> here — .error is an E

--- a/packages/oxlint/src/helpers/is-locally-bound.ts
+++ b/packages/oxlint/src/helpers/is-locally-bound.ts
@@ -1,0 +1,15 @@
+import type { ESTree, Scope } from "@oxlint/plugins";
+
+/**
+ * Whether a type-name identifier resolves to a *local* binding — a type alias,
+ * interface, import, or type parameter — in `scope`, as opposed to an ambient
+ * global like the built-in `Error`.
+ *
+ * Used to keep the bare-`Error` check false-positive-free: a user-declared
+ * `type Error = { … }` or a generic `<Error>` parameter is not the global
+ * `Error`, so it must not be treated as the ambiguous built-in. Mirrors how
+ * {@link getImportSource} resolves `Result` / `AsyncResult` through scope rather
+ * than by name alone.
+ */
+export const isLocallyBound = (scope: Scope, target: ESTree.Node): boolean =>
+  scope.references.find((ref) => ref.identifier === target)?.resolved != null;

--- a/packages/oxlint/src/rules/no-ambiguous-error-type.test.ts
+++ b/packages/oxlint/src/rules/no-ambiguous-error-type.test.ts
@@ -15,6 +15,19 @@ ruleTester.run("no-ambiguous-error-type", noAmbiguousErrorType, {
     { code: `import type { Result } from "unthrown";\ntype T = Result<number, { code: number }>;` },
     // A `Result` from another library is none of our business.
     { code: `import type { Result } from "neverthrow";\ntype T = Result<number, unknown>;` },
+    // A user's own `type Error` is not the ambiguous global — resolve by scope,
+    // not by name. (Regression guard for the bare-`Error` false positive.)
+    {
+      code: `import type { Result } from "unthrown";\ntype Error = { code: number };\ntype T = Result<number, Error>;`,
+    },
+    // A generic parameter literally named `Error` is a concrete type variable.
+    {
+      code: `import type { Result } from "unthrown";\nfunction f<Error>(): Result<number, Error> { throw 0; }`,
+    },
+    // A generic error parameter `E` is concrete — never treat it as ambiguous.
+    {
+      code: `import type { Result } from "unthrown";\nfunction f<E>(): Result<number, E> { throw 0; }`,
+    },
   ],
   invalid: [
     {
@@ -31,6 +44,19 @@ ruleTester.run("no-ambiguous-error-type", noAmbiguousErrorType, {
     },
     {
       code: `import type { Result } from "unthrown";\ntype T = Result<number, {}>;`,
+      errors: [{ messageId: "noAmbiguousErrorType" }],
+    },
+    // The primitive / non-domain keywords are all ambiguous, not just any/unknown.
+    {
+      code: `import type { Result } from "unthrown";\ntype T = Result<number, string>;`,
+      errors: [{ messageId: "noAmbiguousErrorType" }],
+    },
+    {
+      code: `import type { Result } from "unthrown";\ntype T = Result<number, object>;`,
+      errors: [{ messageId: "noAmbiguousErrorType" }],
+    },
+    {
+      code: `import type { Result } from "unthrown";\ntype T = Result<number, null>;`,
       errors: [{ messageId: "noAmbiguousErrorType" }],
     },
     {

--- a/packages/oxlint/src/rules/no-ambiguous-error-type.ts
+++ b/packages/oxlint/src/rules/no-ambiguous-error-type.ts
@@ -3,8 +3,9 @@ import { defineRule } from "@oxlint/plugins";
 import { getImportSource } from "../helpers/get-import-source.js";
 import { hasTypeArguments } from "../helpers/has-type-arguments.js";
 import { isIdentifierTypeName } from "../helpers/is-identifier-type-name.js";
+import { isLocallyBound } from "../helpers/is-locally-bound.js";
 
-import type { ESTree } from "@oxlint/plugins";
+import type { ESTree, Scope } from "@oxlint/plugins";
 
 const MODULE = "unthrown";
 const RESULT_TYPES = ["Result", "AsyncResult"] as const;
@@ -50,11 +51,11 @@ export const noAmbiguousErrorType = defineRule({
         if (!isIdentifierTypeName(node, RESULT_TYPES)) return;
         if (!hasTypeArguments(node, 2)) return;
 
-        const importSource = getImportSource(context.sourceCode.getScope(node), node.typeName);
-        if (importSource !== MODULE) return;
+        const scope = context.sourceCode.getScope(node);
+        if (getImportSource(scope, node.typeName) !== MODULE) return;
 
         const errorNode: ESTree.TSType = node.typeArguments.params[1];
-        if (!isAmbiguousType(errorNode)) return;
+        if (!isAmbiguousType(errorNode, scope)) return;
 
         context.report({
           node: errorNode,
@@ -72,17 +73,24 @@ export const noAmbiguousErrorType = defineRule({
 /**
  * Whether an error-position type is non-specific. Recurses into unions and
  * intersections, so `MyError | unknown` and `Error | MyError` are flagged too —
- * one ambiguous member taints the whole type.
+ * one ambiguous member taints the whole type. `scope` is threaded through so the
+ * bare-`Error` check can resolve the identifier: only the ambient global `Error`
+ * is flagged, never a locally-declared `type Error` or a generic `<Error>`.
  */
-function isAmbiguousType(node: ESTree.TSType): boolean {
+function isAmbiguousType(node: ESTree.TSType, scope: Scope): boolean {
   if (node.type === "TSUnionType" || node.type === "TSIntersectionType") {
-    return node.types.some(isAmbiguousType);
+    return node.types.some((member) => isAmbiguousType(member, scope));
   }
   // The *empty* object literal `{}` is ambiguous; `{ code: number }` is fine.
   if (node.type === "TSTypeLiteral") return node.members.length === 0;
-  // The bare `Error` class is too generic; a `MyError` is fine.
+  // The bare global `Error` class is too generic; a `MyError` — or a user's own
+  // `type Error` / generic `<Error>` — is fine, so resolve it through scope.
   if (node.type === "TSTypeReference") {
-    return node.typeName.type === "Identifier" && node.typeName.name === "Error";
+    return (
+      node.typeName.type === "Identifier" &&
+      node.typeName.name === "Error" &&
+      !isLocallyBound(scope, node.typeName)
+    );
   }
   return AMBIGUOUS_KEYWORDS.has(node.type);
 }

--- a/packages/pattern/src/index.spec.ts
+++ b/packages/pattern/src/index.spec.ts
@@ -42,6 +42,7 @@ describe("pattern constructors", () => {
     expect(fold(Ok(5))).toBe("ok:5");
     expect(fold(Err(new NotFound()))).toBe("not-found");
     expect(fold(Err(new Forbidden({ user: "bob" })))).toBe("forbidden:bob");
+    expect(fold(aDefect)).toBe("defect");
   });
 
   it("P.Ok(pattern) constrains and selects the value", () => {

--- a/packages/standard-schema/src/index.spec.ts
+++ b/packages/standard-schema/src/index.spec.ts
@@ -45,9 +45,11 @@ describe("fromSchema (sync)", () => {
         version: 1,
         vendor: "test",
         // A genuine thenable typed (falsely) as a Promise — mimics a promise
-        // from another realm, which fails `instanceof Promise`.
+        // from another realm, which fails `instanceof Promise`. The `then` is the
+        // whole point of the test.
         validate: () =>
           ({
+            // oxlint-disable-next-line no-thenable
             then: (onfulfilled: (r: StandardSchemaV1.Result<string>) => void) =>
               onfulfilled({ value: "hi" }),
           }) as unknown as Promise<StandardSchemaV1.Result<string>>,

--- a/packages/standard-schema/src/index.spec.ts
+++ b/packages/standard-schema/src/index.spec.ts
@@ -37,6 +37,25 @@ describe("fromSchema (sync)", () => {
     expect(() => fromSchema(stringSchema({ async: true }))("hi")).toThrow(TypeError);
   });
 
+  it("detects an async schema even when its promise is a cross-realm thenable", () => {
+    // A promise from another realm (vm/worker) — a genuine thenable that fails
+    // `instanceof Promise`. It must still be caught, not silently produce Ok().
+    const foreign: StandardSchemaV1<unknown, string> = {
+      "~standard": {
+        version: 1,
+        vendor: "test",
+        // A genuine thenable typed (falsely) as a Promise — mimics a promise
+        // from another realm, which fails `instanceof Promise`.
+        validate: () =>
+          ({
+            then: (onfulfilled: (r: StandardSchemaV1.Result<string>) => void) =>
+              onfulfilled({ value: "hi" }),
+          }) as unknown as Promise<StandardSchemaV1.Result<string>>,
+      },
+    };
+    expect(() => fromSchema(foreign)("hi")).toThrow(TypeError);
+  });
+
   it("turns a throwing validator into a Defect (it never escapes)", () => {
     const r = fromSchema(stringSchema({ throws: true }))("hi");
     expect(r.isDefect()).toBe(true);

--- a/packages/standard-schema/src/index.ts
+++ b/packages/standard-schema/src/index.ts
@@ -20,6 +20,18 @@ import type { AsyncResult, Result } from "unthrown";
 /** The error channel both entry points produce: a schema's validation issues. */
 export type SchemaIssues = readonly StandardSchemaV1.Issue[];
 
+// A Standard Schema signals async validation by returning a thenable. Detect it
+// structurally rather than with `instanceof Promise`, which misses a promise
+// created in another realm (a `vm` context, a worker) even though it is a
+// genuine `PromiseLike`.
+function isThenable(value: unknown): value is PromiseLike<unknown> {
+  return (
+    (typeof value === "object" || typeof value === "function") &&
+    value !== null &&
+    typeof (value as { then?: unknown }).then === "function"
+  );
+}
+
 /**
  * Turn a **synchronous** Standard Schema into a validator returning a
  * `Result`.
@@ -61,7 +73,7 @@ export function fromSchema<S extends StandardSchemaV1>(
   return (input) => {
     const settled = validate(input);
     // An async schema can't be represented synchronously — fail loud and early.
-    if (settled.isOk() && settled.value instanceof Promise) {
+    if (settled.isOk() && isThenable(settled.value)) {
       throw new TypeError(
         "@unthrown/standard-schema: this schema validates asynchronously — use fromSchemaAsync instead.",
       );

--- a/packages/vitest/src/index.spec.ts
+++ b/packages/vitest/src/index.spec.ts
@@ -86,6 +86,17 @@ describe("non-Result input", () => {
     expect(42).not.toBeOk();
     expect({}).not.toBeErr();
   });
+
+  it("rejects a foreign Result-like object (e.g. neverthrow/Boxed) as not-a-Result", () => {
+    // A neverthrow/Boxed result carries `isOk`/`isErr` methods — the exact
+    // interop mistake these matchers exist to catch. It must fail as "not an
+    // unthrown Result", not be mistaken for an Err.
+    const foreign = { isOk: () => true, isErr: () => false, value: 1 };
+    expect(foreign).not.toBeOk();
+    expect(() => expect(foreign).toBeOk()).toThrowError(
+      /expected an unthrown Result, but received/,
+    );
+  });
 });
 
 describe("failure messages", () => {

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -10,7 +10,7 @@
 // IMPORTANT: for an AsyncResult the matcher is asynchronous, so you MUST `await`
 // the assertion. A forgotten `await` makes the assertion pass silently.
 
-import { isDefect, isErr, isOk, type Result } from "unthrown";
+import { isDefect, isErr, isOk, isResult, type Result } from "unthrown";
 import { expect } from "vitest";
 import type { MatcherResult, MatcherState } from "vitest";
 
@@ -26,14 +26,12 @@ function isThenable(x: unknown): x is PromiseLike<unknown> {
   );
 }
 
-function isResult(x: unknown): x is SomeResult {
-  return typeof (x as { isOk?: unknown } | null | undefined)?.isOk === "function";
-}
-
 function render(result: SomeResult, stringify: Stringify): string {
   if (isOk(result)) return `Ok(${stringify(result.value)})`;
   if (isErr(result)) return `Err(${stringify(result.error)})`;
   if (isDefect(result)) return `Defect(${stringify(result.cause)})`;
+  /* v8 ignore next -- unreachable: `settle` only calls `render` on a canonical
+     Result, which is always Ok/Err/Defect; kept for return-exhaustiveness. */
   return stringify(result);
 }
 

--- a/packages/vitest/vitest.config.ts
+++ b/packages/vitest/vitest.config.ts
@@ -7,15 +7,15 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       include: ["src/**"],
-      // Lock in the matcher suite (incl. every failure-message branch). Lines
-      // sit just below 100 only because of the defensive `render` fallback for a
-      // value that is Result-like but not Ok/Err/Defect — unreachable for a real
-      // Result, kept for return-exhaustiveness.
+      // Lock in the matcher suite at full statement/line/function coverage. The
+      // one uncovered branch is the defensive `typeof x === "function"` arm of
+      // `isThenable` (a value that is callable *and* thenable never reaches the
+      // matchers), so `branches` sits just below 100.
       thresholds: {
-        statements: 95,
-        branches: 90,
+        statements: 100,
+        branches: 95,
         functions: 100,
-        lines: 95,
+        lines: 100,
       },
     },
   },


### PR DESCRIPTION
Fixes the findings from the whole-repo review (correctness, API design, docs drift, tests). Split from PR #68: two findings that belong to that PR's own change (the changeset bump and the `AsyncResultMethods` eliminator docs) were fixed there; everything pre-existing is here.

## Correctness (with tests)

- **`unthrown` — `TaggedError` reserves `name`.** A payload field named `name` was silently clobbered by the display label at runtime, while the instance type still promised it (`Error.name: string` is wide, so a payload `name` leaked through). `name` is now excluded from the payload type — consistent with how `_tag` is authoritative — and a regression test mirrors the existing `_tag`-spoof test.
- **`@unthrown/vitest` — reject foreign `Result`-likes.** The matchers duck-typed `isResult` on an `isOk` method, so a neverthrow/Boxed result reached `check` and failed with a misleading "expected Ok" instead of "not an unthrown Result". Now uses core's canonical `isResult`; the `render` fallback is `v8 ignore`d and coverage thresholds tightened to 100/95.
- **`@unthrown/oxlint` — scope-resolve bare `Error`.** `no-ambiguous-error-type` flagged `Error` by name only, false-positiving on a local `type Error` or a generic `<Error>`. It now resolves the identifier through scope (new `isLocallyBound` helper), matching how `Result`/`AsyncResult` are resolved. Added valid cases (local `type Error`, `<Error>`, generic `<E>`) and invalid cases for the previously-untested keywords (`string`/`object`/`null`).
- **`@unthrown/standard-schema` — structural async detection.** `instanceof Promise` missed a cross-realm promise (vm/worker), silently producing `Ok(undefined)`. Now a structural thenable check, with a cross-realm test.

## API design & docs

- **`ErrView`'s reversed `<E, T>` param order** documented with a `@remarks` note and pinned in `types.test-d.ts`.
- **Quick-start snippets** (root README, core README, boundaries guide) declared `NotFound` but checked `instanceof NotFoundError` (undefined → `TS2304`); each now declares the upstream `NotFoundError` it maps from.
- **CLAUDE.md** pattern constructors corrected to `P.Ok`/`P.Err`/`P.Defect`.
- **`docs/api/index.md`** no longer lists a non-existent `Defect` constructor.
- **`fromBoxedFuture`** JSDoc + interop guide reworded: Boxed's `Future` never rejects, so the Defect path is a defensive no-op, not a live path.

## Tests

Closed coverage gaps surfaced by the review: facade aliasing for `Do`/`fromThrowable`/`allFromDict`, async Defect-rethrow for `unwrapErr`/`unwrapOrElse`/`getOrUndefined`, `allFromDictAsync` `__proto__`-safety, the `P.Defect()` match arm, and a `@ts-expect-error` pinning that a raw `Promise` can't enter an `AsyncResult` combinator. The `invariants.spec.ts` header no longer overstates 1:1 coverage.

> One review finding — the `@unthrown/effect` `fromExit` "Defect dominance" claim — was **adversarially refuted** during the review and is not a real issue, so it is intentionally not changed here.

## Verification

Full gate green: `format`, `lint` (pristine), `typecheck` (incl. `test-d`), `knip`, `test` (all 8 packages), `build`, `build:docs` (typedoc clean). One `patch` changeset covers the four behavior fixes (the packages version together as a fixed group).

🤖 Generated with [Claude Code](https://claude.com/claude-code)