### PR TITLE
feat(core)!: gate unwrap/unwrapErr on an empty opposite channel

### DIFF
--- a/.changeset/gate-unwrap.md
+++ b/.changeset/gate-unwrap.md
@@ -1,0 +1,14 @@
+---
+"unthrown": major
+---
+
+**Breaking:** `unwrap()` and `unwrapErr()` are now type-gated. `unwrap()` compiles
+only on a `Result` / `AsyncResult` whose error channel is empty (`E = never`), and
+`unwrapErr()` only when the success channel is empty (`T = never`). Calling `.unwrap()`
+on a fallible `Result<T, E>` is now a **compile error** instead of a runtime
+`UnwrapError` — eliminate the error channel first with `match` / `recover` / `orElse`,
+or use the `unwrapOr` / `unwrapOrElse` / `getOrNull` / `getOrUndefined` family (which
+recover an `Err`). `Ok(x).unwrap()` and error-free results are unaffected. The runtime
+is unchanged and `UnwrapError` is retained as a defensive guard.
+
+Also adds `toBeErrWith` to `@unthrown/vitest` for asserting a plain error value.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,12 +83,16 @@ was planned).
   (widened cast, JS caller) an unknown or reserved (`"Ok"`/`"Defect"`) `_tag`
   routes to the `Defect` handler; reserved tags in `E` are additionally a
   compile error.
-- **`unwrap()` is asymmetric.** On `Err` it throws a `UnwrapError` carrying `E`
-  (on both the typed `.error` property and the standard `Error.cause`, so an
-  `Error`-typed `E` chains its original stack under "caused by").
-  On a `Defect` it **rethrows the original `cause`** (it _panics_) with its
-  original stack, so an unhandled defect hits the global handler looking like the
-  real failure.
+- **`unwrap()` / `unwrapErr()` are type-gated.** `unwrap()` compiles only when the
+  error channel is empty (`this: Result<T, never>`); `unwrapErr()` only when the
+  success channel is empty (`this: Result<never, E>`). Eliminate the opposite
+  channel first (`match` / `recover` / `orElse`), or use the `unwrapOr` /
+  `unwrapOrElse` / `getOrNull` / `getOrUndefined` family (which recover an `Err`).
+  On a `Defect` they still **rethrow the original `cause`** (they _panic_) with its
+  original stack — so `Result<T, never>` means the modeled error channel is empty,
+  **not** that `unwrap()` cannot throw. The `UnwrapError`-on-wrong-variant branch
+  remains at runtime as a defensive guard but is **unreachable through well-typed
+  code** (only a cast or a raw-JS caller can reach it).
 - **`recover` returns `Result<T | U, never>`, and `never` means only the _error_
   channel is empty — a `Defect` can still be present at runtime.** This is the one
   place the type intentionally under-describes the runtime. Do not read `never`
@@ -127,9 +131,13 @@ async work re-enters via `fromPromise` / `fromSafePromise` and composes with
   mirror of `flatTap` — runs a `Result`-returning effect on the error, keeps the
   original error, threads the effect's error)
 - defect: `recoverDefect`, `tapDefect`
-- eliminate: `match`, `unwrap`, `unwrapErr`, `unwrapOr` (signature
-  `unwrapOr<U>(fallback: U): T | U` — widening, not narrowed to `T`),
-  `unwrapOrElse` (same `T | U` widening), `getOrNull`, `getOrUndefined`
+- eliminate: `match`, `unwrap`/`unwrapErr` (type-gated — `unwrap` only compiles on
+  `Result<T, never>`, `unwrapErr` only on `Result<never, E>`; use `match` /
+  `recover` / `orElse` to empty the opposite channel first), `unwrapOr` (signature
+  `unwrapOr<U>(fallback: U): T | U` — widening, not narrowed to `T`), `unwrapOrElse`
+  (same `T | U` widening), `getOrNull`, `getOrUndefined` — the `unwrapOr…`/`getOr…`
+  family extracts from a still-fallible `Result` with a fallback, since
+  `unwrap`/`unwrapErr` won't compile on it
 - guards: methods `isOk`/`isErr`/`isDefect` **and** standalone
   `isOk`/`isErr`/`isDefect` both narrow (to `OkView`/`ErrView`/`DefectView`) — the
   methods are `this is …` type predicates, so `if (r.isErr()) r.error` compiles.

--- a/docs/guide/async-results.md
+++ b/docs/guide/async-results.md
@@ -28,10 +28,13 @@ not interchangeable with a raw promise.
 > isn't known until it settles. `await` it first — the guards live on the
 > `Result` you get back.
 
-::: warning Eliminators still reject
-The async eliminators do throw when you ask them to: `await result.unwrap()`
-rejects on an `Err` or `Defect`, just like the synchronous `unwrap()`. It is the
-_internal_ promise — the one `await result` resolves — that never rejects.
+::: warning Eliminators still reject on a Defect
+The async eliminators reject when they hit a `Defect`: `await result.unwrap()`
+rethrows the defect's cause, just like the synchronous `unwrap()`. (Like its sync
+form, `unwrap()` is type-gated — it compiles only when the error channel is
+`never` — so in well-typed code an `Err` can't reach it; a `Defect` is the only
+rejection you'll see.) It is the _internal_ promise — the one `await result`
+resolves — that never rejects.
 :::
 
 ## Combinator callbacks are synchronous

--- a/docs/guide/choosing-a-combinator.md
+++ b/docs/guide/choosing-a-combinator.md
@@ -136,8 +136,9 @@ the other's fallback — a defect flows past `recover` untouched.
 Reach for an eliminator once you're done chaining:
 
 - `match` — the default at the edge; fold all three channels into one value.
-- `unwrap` / `unwrapErr` — extract, throwing on the wrong variant (and
-  _panicking_ on a defect).
+- `unwrap` / `unwrapErr` — extract; type-gated to compile only when the
+  opposite channel is `never` (`unwrap` needs `Result<T, never>`, `unwrapErr`
+  needs `Result<never, E>`), and _panicking_ (rethrowing the cause) on a defect.
 - `unwrapOr` / `unwrapOrElse` / `getOrNull` / `getOrUndefined` — recover an `Err`
   to a fallback, but **re-throw a defect** (it's a bug, not an absent value).
 

--- a/docs/guide/core-concepts.md
+++ b/docs/guide/core-concepts.md
@@ -118,8 +118,8 @@ matched.
 Once you are ready to leave the `Result` world, pick the right exit:
 
 ```ts
-Ok(1).unwrap(); // => 1         — throws on Err/Defect
-Err("e").unwrapErr(); // => "e" — throws on Ok/Defect
+Ok(1).unwrap(); // => 1         — panics on a Defect (Err doesn't compile here)
+Err("e").unwrapErr(); // => "e" — panics on a Defect (Ok doesn't compile here)
 Err("e").unwrapOr(0); // => 0   — recovers an Err; rethrows a Defect
 Err("e").getOrNull(); // => null — recovers an Err; rethrows a Defect
 Ok(1).match({ ok, err, defect }); // fold all three channels

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -57,14 +57,17 @@ can chain without checking at every step:
 parseAge("42")
   .map((n) => n + 1) // => Ok(43)   — map: callback returns a plain value
   .flatMap((n) => (n >= 18 ? Ok(n) : Err("underage"))) // => Ok(43) — flatMap: callback returns a Result
-  .unwrap(); // => 43
+  .unwrapOrElse((e) => {
+    throw new Error(e); // eliminate the error channel first — unwrap() needs E = never
+  }); // => 43
 // the error type widens to AgeError | "underage" — flatMap unions the channels
 ```
 
 ```ts
-parseAge("x") // => Err("not_a_number")
-  .map((n) => n + 1) // callback never runs — still Err("not_a_number")
-  .unwrapErr(); // => "not_a_number"
+const tooYoung = parseAge("x") // => Err("not_a_number")
+  .map((n) => n + 1); // callback never runs — still Err("not_a_number")
+
+if (tooYoung.isErr()) tooYoung.error; // => "not_a_number"
 ```
 
 Reach for `map` when your callback returns a plain value, `flatMap` when it

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -64,10 +64,10 @@ parseAge("42")
 ```
 
 ```ts
-const tooYoung = parseAge("x") // => Err("not_a_number")
+const parsed = parseAge("x") // => Err("not_a_number")
   .map((n) => n + 1); // callback never runs — still Err("not_a_number")
 
-if (tooYoung.isErr()) tooYoung.error; // => "not_a_number"
+if (parsed.isErr()) parsed.error; // => "not_a_number"
 ```
 
 Reach for `map` when your callback returns a plain value, `flatMap` when it

--- a/docs/guide/interop.md
+++ b/docs/guide/interop.md
@@ -89,8 +89,11 @@ import { z } from "zod";
 
 const parseUser = fromSchema(z.object({ id: z.string() }));
 
-parseUser({ id: "u_1" }).unwrap(); // { id: "u_1" }
-parseUser({ id: 1 }).unwrapErr(); // readonly StandardSchemaV1.Issue[]
+const ok = parseUser({ id: "u_1" });
+if (ok.isOk()) ok.value; // { id: "u_1" }
+
+const bad = parseUser({ id: 1 });
+if (bad.isErr()) bad.error; // readonly StandardSchemaV1.Issue[]
 ```
 
 - `fromSchema(schema)` → `(input) => Result<Output, Issues>` for a synchronous

--- a/docs/guide/the-defect-channel.md
+++ b/docs/guide/the-defect-channel.md
@@ -73,10 +73,19 @@ an absent value). If you must not throw, handle the defect explicitly first with
 
 ## `unwrap` is asymmetric
 
-- On an `Err`, `unwrap()` throws an `UnwrapError` carrying your `E`.
-- On a `Defect`, `unwrap()` **rethrows the original cause** with its original
-  stack — so an unhandled defect reaches the global handler looking like the real
-  failure, not wrapped in library noise.
+`unwrap()` / `unwrapErr()` are **type-gated**: `unwrap()` only compiles when the
+error channel is `never` (`Result<T, never>`), `unwrapErr()` only when the success
+channel is `never` (`Result<never, E>`). Calling `.unwrap()` on a still-fallible
+`Result<T, E>` is a compile error, not a runtime throw — so the `Err` case can't
+reach either eliminator in well-typed code. The remaining wrong-variant throw
+(`UnwrapError`) is a defensive runtime guard for unsound edges (e.g. a cast), not
+something you should hit normally.
+
+A `Defect`, though, is invisible to the type system — `never` on the error
+channel says nothing about it (see above). So on a `Defect`, `unwrap()` /
+`unwrapErr()` **rethrow the original cause** with its original stack — so an
+unhandled defect reaches the global handler looking like the real failure, not
+wrapped in library noise.
 
 ```ts
 try {

--- a/packages/core/src/aggregate.spec.ts
+++ b/packages/core/src/aggregate.spec.ts
@@ -35,13 +35,16 @@ describe("all", () => {
 
   it("short-circuits on the first Err", () => {
     const r = all([Ok(1), Err("first"), Err("second")]);
-    expect(r.unwrapErr()).toBe("first");
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error).toBe("first");
   });
 
   it("lets any Defect dominate, even over an earlier Err", () => {
     const r = all([Ok(1), Err("e"), defectOf(boom)]);
     expect(r.isDefect()).toBe(true);
-    expect(r.recoverDefect((c) => Ok(c === boom)).unwrap()).toBe(true);
+    const recovered = r.recoverDefect((c) => Ok(c === boom));
+    expect(recovered.isOk()).toBe(true);
+    if (recovered.isOk()) expect(recovered.value).toBe(true);
   });
 
   it("keeps the first Defect when several are present", () => {
@@ -54,10 +57,12 @@ describe("all", () => {
     // The array overload: no `as` needed, even in a generic-feeling shape.
     const combine = <T, E>(rs: Result<T, E>[]): Result<T[], E> => all(rs);
     const r = combine([Ok(1), Ok(2), Ok(3)] as Result<number, string>[]);
-    expect(r.unwrap()).toEqual([1, 2, 3]);
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) expect(r.value).toEqual([1, 2, 3]);
 
     const e = combine([Ok(1), Err("bad")] as Result<number, string>[]);
-    expect(e.unwrapErr()).toBe("bad");
+    expect(e.isErr()).toBe(true);
+    if (e.isErr()) expect(e.error).toBe("bad");
   });
 });
 
@@ -70,10 +75,14 @@ describe("allFromDict", () => {
   });
 
   it("short-circuits a record on the first Err and lets a Defect dominate", () => {
-    expect(allFromDict({ a: Ok(1), b: Err("bad") }).unwrapErr()).toBe("bad");
+    const r = allFromDict({ a: Ok(1), b: Err("bad") });
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error).toBe("bad");
     const d = allFromDict({ a: Ok(1), b: Err("e"), c: defectOf(boom) });
     expect(d.isDefect()).toBe(true);
-    expect(d.recoverDefect((c) => Ok(c === boom)).unwrap()).toBe(true);
+    const recovered = d.recoverDefect((c) => Ok(c === boom));
+    expect(recovered.isOk()).toBe(true);
+    if (recovered.isOk()) expect(recovered.value).toBe(true);
   });
 
   it("returns Ok({}) for an empty record", () => {
@@ -107,7 +116,8 @@ describe("allAsync", () => {
       fromPromise(Promise.reject("first"), (c) => c as string),
       fromPromise(Promise.reject("second"), (c) => c as string),
     ]);
-    expect(r.unwrapErr()).toBe("first");
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error).toBe("first");
   });
 
   it("lets any Defect dominate, even over an earlier Err", async () => {
@@ -116,7 +126,9 @@ describe("allAsync", () => {
       fromSafePromise(Promise.reject(boom)),
     ]);
     expect(r.isDefect()).toBe(true);
-    expect((await r.toAsync().recoverDefect((c) => Ok(c === boom))).unwrap()).toBe(true);
+    const recovered = await r.toAsync().recoverDefect((c) => Ok(c === boom));
+    expect(recovered.isOk()).toBe(true);
+    if (recovered.isOk()) expect(recovered.value).toBe(true);
   });
 
   it("never rejects — await always yields a Result", async () => {
@@ -149,7 +161,8 @@ describe("allFromDictAsync", () => {
       a: fromSafePromise(Promise.resolve(1)),
       b: fromPromise(Promise.reject("bad"), (c) => c as string),
     });
-    expect(r.unwrapErr()).toBe("bad");
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error).toBe("bad");
   });
 
   it("lets any Defect dominate over an earlier Err", async () => {

--- a/packages/core/src/async-result.spec.ts
+++ b/packages/core/src/async-result.spec.ts
@@ -45,15 +45,16 @@ describe("AsyncResult is awaitable and never rejects", () => {
   });
 
   it("fromPromise: a resolved value becomes Ok (promise and thunk forms)", async () => {
-    expect((await fromPromise(Promise.resolve(5), (c) => c as string)).unwrap()).toBe(5);
-    expect(
-      (
-        await fromPromise(
-          () => Promise.resolve(6),
-          (c) => c as string,
-        )
-      ).unwrap(),
-    ).toBe(6);
+    const r1 = await fromPromise(Promise.resolve(5), (c) => c as string);
+    expect(r1.isOk()).toBe(true);
+    if (r1.isOk()) expect(r1.value).toBe(5);
+
+    const r2 = await fromPromise(
+      () => Promise.resolve(6),
+      (c) => c as string,
+    );
+    expect(r2.isOk()).toBe(true);
+    if (r2.isOk()) expect(r2.value).toBe(6);
   });
 });
 
@@ -111,7 +112,9 @@ describe("AsyncResult success channel", () => {
   });
 
   it("flatTap short-circuits to the effect's Err", async () => {
-    expect((await asyncOk(5).flatTap(() => Err("denied"))).unwrapErr()).toBe("denied");
+    const r = await asyncOk(5).flatTap(() => Err("denied"));
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error).toBe("denied");
   });
 
   it("flatTap composes an async effect via a qualified boundary, keeping the value", async () => {
@@ -128,7 +131,9 @@ describe("AsyncResult success channel", () => {
 
   it("as replaces the Ok value, and passes Err/Defect through", async () => {
     expect((await asyncOk(1).as("x")).unwrap()).toBe("x");
-    expect((await asyncErr("e").as("x")).unwrapErr()).toBe("e");
+    const r = await asyncErr("e").as("x");
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error).toBe("e");
     expect((await asyncDefect().as("x")).isDefect()).toBe(true);
   });
 });
@@ -252,7 +257,11 @@ describe("AsyncResult eliminators", () => {
 
   it("unwrap resolves the value and rejects (via UnwrapError) on Err", async () => {
     await expect(asyncOk(1).unwrap()).resolves.toBe(1);
-    await expect(asyncErr("e").unwrap()).rejects.toMatchObject({ name: "UnwrapError", error: "e" });
+    // The Err branch is unreachable in typed code (unwrap needs E = never);
+    // force it via a cast to exercise the defensive runtime guard.
+    await expect(
+      (asyncErr("e") as unknown as AsyncResult<number, never>).unwrap(),
+    ).rejects.toMatchObject({ name: "UnwrapError", error: "e" });
   });
 
   it("unwrapErr resolves the error", async () => {
@@ -273,7 +282,11 @@ describe("AsyncResult eliminators", () => {
 
   it("a Defect rejects the eliminators with the original cause", async () => {
     await expect(asyncDefect().unwrap()).rejects.toBe(boom);
-    await expect(asyncDefect().unwrapErr()).rejects.toBe(boom);
+    // Also type-unreachable (unwrapErr needs T = never; asyncDefect's declared
+    // T is number) — cast to exercise the Defect-rethrow guard.
+    await expect((asyncDefect() as unknown as AsyncResult<never, never>).unwrapErr()).rejects.toBe(
+      boom,
+    );
     await expect(asyncDefect().unwrapOr(0)).rejects.toBe(boom);
     await expect(asyncDefect().unwrapOrElse(() => 0)).rejects.toBe(boom);
     await expect(asyncDefect().getOrNull()).rejects.toBe(boom);

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -38,6 +38,11 @@ import type {
  * A `Defect` is never wrapped in an `UnwrapError`: its original cause is
  * re-thrown (with its original stack) instead.
  *
+ * `unwrap()` and `unwrapErr()` are type-gated (`this: Result<T, never>` /
+ * `Result<never, E>`), so the wrong-variant branch that throws this is
+ * unreachable through well-typed code — it remains only as a defensive guard
+ * against unsound runtime misuse (e.g. an `as` cast past the gate).
+ *
  * @typeParam E - the type of the {@link UnwrapError.error} it carries.
  *
  * @category Errors

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -657,10 +657,10 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
   }
 
   unwrap(): Promise<T> {
-    return this.promise.then((r) => r.unwrap());
+    return this.promise.then((r) => (r as Result<T, never>).unwrap());
   }
   unwrapErr(): Promise<E> {
-    return this.promise.then((r) => r.unwrapErr());
+    return this.promise.then((r) => (r as Result<never, E>).unwrapErr());
   }
   unwrapOr<U>(fallback: U): Promise<T | U> {
     return this.promise.then((r) => r.unwrapOr(fallback));

--- a/packages/core/src/do.spec.ts
+++ b/packages/core/src/do.spec.ts
@@ -26,7 +26,8 @@ describe("Do / bind / let", () => {
     const r = Do()
       .bind("a", () => Err("denied"))
       .bind("b", later);
-    expect(r.unwrapErr()).toBe("denied");
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error).toBe("denied");
     expect(later).not.toHaveBeenCalled();
   });
 
@@ -34,7 +35,8 @@ describe("Do / bind / let", () => {
     const a: Result<{ x: number }, "e1"> = Do().bind("x", () => Err<"e1">("e1"));
     const b = a.bind("y", () => Err<"e2">("e2"));
     // `b` is Result<{ x; y }, "e1" | "e2"> — exercised at runtime here:
-    expect(b.unwrapErr()).toBe("e1");
+    expect(b.isErr()).toBe(true);
+    if (b.isErr()) expect(b.error).toBe("e1");
   });
 
   it("propagates a Defect and does not run later steps", () => {
@@ -114,7 +116,8 @@ describe("Do / bind / let — async", () => {
       .toAsync()
       .bind("a", () => Err("denied"))
       .bind("b", () => Ok(1));
-    expect(r.unwrapErr()).toBe("denied");
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error).toBe("denied");
   });
 
   it("turns a throw in an async bind or let into a Defect and never rejects", async () => {

--- a/packages/core/src/interop.spec.ts
+++ b/packages/core/src/interop.spec.ts
@@ -19,10 +19,21 @@ describe("fromNullable", () => {
   });
 
   it("keeps a present value as Ok (and treats falsy non-null as present)", () => {
-    expect(fromNullable(5, () => "absent").unwrap()).toBe(5);
-    expect(fromNullable(0, () => "absent").unwrap()).toBe(0);
-    expect(fromNullable("", () => "absent").unwrap()).toBe("");
-    expect(fromNullable(false, () => "absent").unwrap()).toBe(false);
+    const r1 = fromNullable(5, () => "absent");
+    expect(r1.isOk()).toBe(true);
+    if (r1.isOk()) expect(r1.value).toBe(5);
+
+    const r2 = fromNullable(0, () => "absent");
+    expect(r2.isOk()).toBe(true);
+    if (r2.isOk()) expect(r2.value).toBe(0);
+
+    const r3 = fromNullable("", () => "absent");
+    expect(r3.isOk()).toBe(true);
+    if (r3.isOk()) expect(r3.value).toBe("");
+
+    const r4 = fromNullable(false, () => "absent");
+    expect(r4.isOk()).toBe(true);
+    if (r4.isOk()) expect(r4.value).toBe(false);
   });
 });
 
@@ -32,7 +43,9 @@ describe("fromThrowable", () => {
       (a: number, b: number) => a + b,
       () => "qualified",
     );
-    expect(add(2, 3).unwrap()).toBe(5);
+    const r = add(2, 3);
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) expect(r.value).toBe(5);
   });
 
   it("triages a thrown cause into Err when qualify returns E", () => {
@@ -40,8 +53,13 @@ describe("fromThrowable", () => {
       (s: string) => JSON.parse(s) as unknown,
       () => "invalid-json",
     );
-    expect(parse("{not json}").unwrapErr()).toBe("invalid-json");
-    expect(parse('{"a":1}').unwrap()).toEqual({ a: 1 });
+    const err = parse("{not json}");
+    expect(err.isErr()).toBe(true);
+    if (err.isErr()) expect(err.error).toBe("invalid-json");
+
+    const ok = parse('{"a":1}');
+    expect(ok.isOk()).toBe(true);
+    if (ok.isOk()) expect(ok.value).toEqual({ a: 1 });
   });
 
   it("triages a thrown cause into a Defect when qualify returns the injected defect marker", () => {
@@ -93,7 +111,8 @@ describe("fromThrowable", () => {
       (c, defect) => (c === boom ? ("known" as const) : defect(c)),
     );
     const r: Result<number, "known"> = fn();
-    expect(r.unwrap()).toBe(1);
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) expect(r.value).toBe(1);
   });
 });
 

--- a/packages/core/src/interop.ts
+++ b/packages/core/src/interop.ts
@@ -27,9 +27,9 @@ import type { AsyncErrOf, AsyncOkOf, AsyncResult, ErrOf, OkOf, Result } from "./
  * import { fromNullable } from "unthrown";
  *
  * const map = new Map([["a", 1]]);
- * fromNullable(map.get("a"), () => "absent").unwrap(); // => 1
+ * fromNullable(map.get("a"), () => "absent").unwrapOr(0); // => 1
  * fromNullable(map.get("z"), () => "absent"); // => Err("absent")
- * fromNullable(0, () => "absent").unwrap(); // => 0 (falsy but present)
+ * fromNullable(0, () => "absent").unwrapOr(-1); // => 0 (falsy but present)
  * ```
  */
 export function fromNullable<T, E>(
@@ -77,7 +77,7 @@ export function fromNullable<T, E>(
  *     cause instanceof SyntaxError ? ("invalid_json" as const) : defect(cause),
  * );
  *
- * parse('{"ok":true}').unwrap(); // => { ok: true }
+ * parse('{"ok":true}').unwrapOr(null); // => { ok: true }
  * parse("nope"); // => Err("invalid_json")
  * ```
  */
@@ -129,8 +129,8 @@ export function fromThrowable<A extends unknown[], T, R>(
  *   cause instanceof NotFoundError ? ("not_found" as const) : defect(cause),
  * );
  *
- * user.unwrap(); // => the fetched user (on success)
- * // when fetchUser rejects with NotFoundError: => Err("not_found")
+ * if (user.isOk()) user.value; // => the fetched user
+ * // when fetchUser rejects with NotFoundError: user is Err("not_found")
  * ```
  */
 export function fromPromise<T, R>(

--- a/packages/core/src/invariants.spec.ts
+++ b/packages/core/src/invariants.spec.ts
@@ -76,7 +76,9 @@ describe("Invariant 2: a Defect flows through every method except match() and re
 describe("Invariant 3: unwrap() is asymmetric", () => {
   it("on Err throws an UnwrapError carrying E", () => {
     try {
-      Err("modeled").unwrap();
+      // The Err branch is unreachable in typed code (unwrap needs E = never);
+      // force it via a cast to exercise the defensive runtime guard.
+      (Err("modeled") as unknown as Result<number, never>).unwrap();
       expect.unreachable();
     } catch (e) {
       expect(e).toBeInstanceOf(UnwrapError);

--- a/packages/core/src/result.spec.ts
+++ b/packages/core/src/result.spec.ts
@@ -21,7 +21,8 @@ describe("Result.map", () => {
     const f = vi.fn();
     const r = Err<string>("e").map(f);
     expect(f).not.toHaveBeenCalled();
-    expect(r.unwrapErr()).toBe("e");
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error).toBe("e");
   });
 
   it("passes a Defect through untouched without calling the callback", () => {
@@ -59,7 +60,9 @@ describe("Result.flatMap", () => {
 
   it("passes Err through and does not call the callback", () => {
     const f = vi.fn();
-    expect(Err<string>("e").flatMap(f).unwrapErr()).toBe("e");
+    const r = Err<string>("e").flatMap(f);
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error).toBe("e");
     expect(f).not.toHaveBeenCalled();
   });
 
@@ -119,7 +122,8 @@ describe("Result.flatTap", () => {
 
   it("short-circuits to the effect's Err", () => {
     const r = Ok(5).flatTap(() => Err("denied"));
-    expect(r.unwrapErr()).toBe("denied");
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error).toBe("denied");
   });
 
   it("propagates a Defect from the effect", () => {
@@ -151,7 +155,9 @@ describe("Result.as", () => {
   });
 
   it("passes Err and Defect through", () => {
-    expect(Err("e").as("x").unwrapErr()).toBe("e");
+    const r = Err("e").as("x");
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error).toBe("e");
     expect(defectOf(boom).as("x").isDefect()).toBe(true);
   });
 });
@@ -167,7 +173,9 @@ describe("Result.mapErr", () => {
 
   it("passes Ok through and does not call the callback", () => {
     const f = vi.fn();
-    expect(Ok(1).mapErr(f).unwrap()).toBe(1);
+    const r = Ok(1).mapErr(f);
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) expect(r.value).toBe(1);
     expect(f).not.toHaveBeenCalled();
   });
 
@@ -207,7 +215,9 @@ describe("Result.orElse", () => {
 
   it("passes Ok through and does not call the callback", () => {
     const f = vi.fn();
-    expect(Ok(1).orElse(f).unwrap()).toBe(1);
+    const r = Ok(1).orElse(f);
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) expect(r.value).toBe(1);
     expect(f).not.toHaveBeenCalled();
   });
 
@@ -326,17 +336,19 @@ describe("Result.recoverDefect (the only door to a Defect)", () => {
   });
 
   it("replaces a Defect with an Err", () => {
-    expect(
-      defectOf(boom)
-        .recoverDefect(() => Err("modeled now"))
-        .unwrapErr(),
-    ).toBe("modeled now");
+    const r = defectOf(boom).recoverDefect(() => Err("modeled now"));
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error).toBe("modeled now");
   });
 
   it("passes Ok and Err through and does not call the callback", () => {
     const f = vi.fn();
-    expect(Ok(1).recoverDefect(f).unwrap()).toBe(1);
-    expect(Err("e").recoverDefect(f).unwrapErr()).toBe("e");
+    const okR = Ok(1).recoverDefect(f);
+    expect(okR.isOk()).toBe(true);
+    if (okR.isOk()) expect(okR.value).toBe(1);
+    const errR = Err("e").recoverDefect(f);
+    expect(errR.isErr()).toBe(true);
+    if (errR.isErr()) expect(errR.error).toBe("e");
     expect(f).not.toHaveBeenCalled();
   });
 
@@ -432,7 +444,9 @@ describe("Result eliminators on Ok / Err", () => {
   it("unwrap returns the Ok value; throws UnwrapError on Err", () => {
     expect(Ok(1).unwrap()).toBe(1);
     try {
-      Err("e").unwrap();
+      // The Err branch is unreachable in typed code (unwrap needs E = never);
+      // force it via a cast to exercise the defensive runtime guard.
+      (Err("e") as unknown as Result<number, never>).unwrap();
       expect.unreachable();
     } catch (e) {
       expect(e).toBeInstanceOf(Error);
@@ -444,14 +458,18 @@ describe("Result eliminators on Ok / Err", () => {
   it("unwrapErr returns the Err; throws UnwrapError on Ok; rethrows the cause on a Defect", () => {
     expect(Err("e").unwrapErr()).toBe("e");
     try {
-      Ok(1).unwrapErr();
+      // The Ok branch is unreachable in typed code (unwrapErr needs T = never);
+      // force it via a cast to exercise the defensive runtime guard.
+      (Ok(1) as unknown as Result<never, number>).unwrapErr();
       expect.unreachable();
     } catch (e) {
       expect((e as { name: string }).name).toBe("UnwrapError");
       expect((e as { error: unknown }).error).toBe(1);
     }
     try {
-      defectOf(boom).unwrapErr();
+      // Also type-unreachable (unwrapErr needs T = never; defectOf's declared
+      // T is number) — cast to exercise the Defect-rethrow guard.
+      (defectOf(boom) as unknown as Result<never, never>).unwrapErr();
       expect.unreachable();
     } catch (e) {
       expect(e).toBe(boom);

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -210,6 +210,26 @@ const _noValue = g.value;
 // @ts-expect-error - `.error` only exists on the Err variant
 const _noError = g.error;
 
+// --- unwrap / unwrapErr are gated on an empty opposite channel ---------------
+
+declare const rNever: Result<number, never>;
+declare const rFallible: Result<number, "e">;
+declare const rErrOnly: Result<never, "e">;
+rNever.unwrap(); // ok: E = never
+rErrOnly.unwrapErr(); // ok: T = never
+// @ts-expect-error - unwrap requires E = never
+rFallible.unwrap();
+// @ts-expect-error - unwrapErr requires T = never
+rFallible.unwrapErr();
+
+declare const arNever: AsyncResult<number, never>;
+declare const arFallible: AsyncResult<number, "e">;
+arNever.unwrap();
+// @ts-expect-error - async unwrap requires E = never
+arFallible.unwrap();
+// @ts-expect-error - async unwrapErr requires T = never
+arFallible.unwrapErr();
+
 // --- extractor types ---------------------------------------------------------
 
 type _okOf = Expect<Equal<OkOf<Result<number, "e">>, number>>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -570,8 +570,9 @@ export type AsyncResultMethods<T, E> = {
     defect: (cause: unknown) => R;
   }): Promise<R>;
   /**
-   * Asynchronous {@link ResultMethods.unwrap | unwrap}. The returned promise
-   * rejects on `Err`/`Defect`.
+   * Asynchronous {@link ResultMethods.unwrap | unwrap}. Compiles only when the
+   * error channel is empty (`this: AsyncResult<T, never>`); the returned promise
+   * rejects on a `Defect` (rethrowing its cause).
    */
   unwrap(this: AsyncResult<T, never>): Promise<T>;
   /** Asynchronous {@link ResultMethods.unwrapErr | unwrapErr}. */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -264,8 +264,14 @@ export type ResultMethods<T, E> = {
    *
    * @remarks
    * Compiles only when the error channel is empty (`E = never`) — eliminate
-   * modeled errors first (`match` / `recover` / `orElse`). A `Defect` still
-   * **rethrows its original cause** (a defect is a bug, not an absent value).
+   * modeled errors first (`match` / `recover` / `orElse`), or reach for the
+   * `unwrapOr` / `unwrapOrElse` / `getOrNull` / `getOrUndefined` family (which
+   * recover an `Err`). If you get a `'this' context` type error here, that is
+   * the gate: the receiver still has a non-`never` error channel.
+   *
+   * `E = never` empties only the **modeled** error channel — a `Defect` can
+   * still be present, and `unwrap()` **rethrows its original cause** (it
+   * _panics_); `Result<T, never>` does not mean `unwrap()` cannot throw.
    *
    * @returns the `Ok` value.
    */
@@ -275,8 +281,11 @@ export type ResultMethods<T, E> = {
    *
    * @remarks
    * Compiles only when the success channel is empty (`T = never`) — eliminate
-   * the success case first. A `Defect` still **rethrows its original cause**
-   * (a defect is a bug, not an absent value).
+   * the success case first. `T = never` is rarely the case in practice (a
+   * `Result` you hold usually still has a success type), so to inspect an
+   * error prefer an `isErr()` guard or, in tests, `@unthrown/vitest`'s
+   * `toBeErrWith`. A `Defect` still **rethrows its original cause** (a defect is
+   * a bug, not an absent value), so this does not mean `unwrapErr()` can't throw.
    *
    * @returns the `Err` value.
    */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -575,7 +575,11 @@ export type AsyncResultMethods<T, E> = {
    * rejects on a `Defect` (rethrowing its cause).
    */
   unwrap(this: AsyncResult<T, never>): Promise<T>;
-  /** Asynchronous {@link ResultMethods.unwrapErr | unwrapErr}. */
+  /**
+   * Asynchronous {@link ResultMethods.unwrapErr | unwrapErr}. Compiles only when
+   * the success channel is empty (`this: AsyncResult<never, E>`); the returned
+   * promise rejects on a `Defect` (rethrowing its cause).
+   */
   unwrapErr(this: AsyncResult<never, E>): Promise<E>;
   /** Asynchronous {@link ResultMethods.unwrapOr | unwrapOr}. */
   unwrapOr<U>(fallback: U): Promise<T | U>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -267,7 +267,7 @@ export type ResultMethods<T, E> = {
    * re-throws the **original cause** with its original stack, so an unhandled
    * Defect surfaces at the global handler as the real failure.
    */
-  unwrap(): T;
+  unwrap(this: Result<T, never>): T;
   /**
    * Extract the modeled error.
    *
@@ -275,7 +275,7 @@ export type ResultMethods<T, E> = {
    * @throws On `Ok`, an {@link UnwrapError} carrying the value. On a `Defect`,
    * re-throws the original cause.
    */
-  unwrapErr(): E;
+  unwrapErr(this: Result<never, E>): E;
   /**
    * The success value, or `fallback` on `Err`.
    *
@@ -568,9 +568,9 @@ export type AsyncResultMethods<T, E> = {
    * Asynchronous {@link ResultMethods.unwrap | unwrap}. The returned promise
    * rejects on `Err`/`Defect`.
    */
-  unwrap(): Promise<T>;
+  unwrap(this: AsyncResult<T, never>): Promise<T>;
   /** Asynchronous {@link ResultMethods.unwrapErr | unwrapErr}. */
-  unwrapErr(): Promise<E>;
+  unwrapErr(this: AsyncResult<never, E>): Promise<E>;
   /** Asynchronous {@link ResultMethods.unwrapOr | unwrapOr}. */
   unwrapOr<U>(fallback: U): Promise<T | U>;
   /** Asynchronous {@link ResultMethods.unwrapOrElse | unwrapOrElse}. */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -262,18 +262,23 @@ export type ResultMethods<T, E> = {
   /**
    * Extract the success value.
    *
+   * @remarks
+   * Compiles only when the error channel is empty (`E = never`) — eliminate
+   * modeled errors first (`match` / `recover` / `orElse`). A `Defect` still
+   * **rethrows its original cause** (a defect is a bug, not an absent value).
+   *
    * @returns the `Ok` value.
-   * @throws On `Err`, an {@link UnwrapError} carrying the error. On a `Defect`,
-   * re-throws the **original cause** with its original stack, so an unhandled
-   * Defect surfaces at the global handler as the real failure.
    */
   unwrap(this: Result<T, never>): T;
   /**
    * Extract the modeled error.
    *
+   * @remarks
+   * Compiles only when the success channel is empty (`T = never`) — eliminate
+   * the success case first. A `Defect` still **rethrows its original cause**
+   * (a defect is a bug, not an absent value).
+   *
    * @returns the `Err` value.
-   * @throws On `Ok`, an {@link UnwrapError} carrying the value. On a `Defect`,
-   * re-throws the original cause.
    */
   unwrapErr(this: Result<never, E>): E;
   /**

--- a/packages/standard-schema/README.md
+++ b/packages/standard-schema/README.md
@@ -21,8 +21,11 @@ import { z } from "zod";
 
 const parseUser = fromSchema(z.object({ id: z.string() }));
 
-parseUser({ id: "u_1" }).unwrap(); // { id: "u_1" }
-parseUser({ id: 1 }).unwrapErr(); // readonly StandardSchemaV1.Issue[]
+const ok = parseUser({ id: "u_1" });
+if (ok.isOk()) ok.value; // { id: "u_1" }
+
+const bad = parseUser({ id: 1 });
+if (bad.isErr()) bad.error; // readonly StandardSchemaV1.Issue[]
 ```
 
 - `fromSchema(schema)` — returns a validator `(input) => Result<Output, Issues>`

--- a/packages/standard-schema/src/index.spec.ts
+++ b/packages/standard-schema/src/index.spec.ts
@@ -25,12 +25,15 @@ function stringSchema(opts?: {
 
 describe("fromSchema (sync)", () => {
   it("returns Ok with the parsed value on valid input", () => {
-    expect(fromSchema(stringSchema())("hi").unwrap()).toBe("hi");
+    const r = fromSchema(stringSchema())("hi");
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) expect(r.value).toBe("hi");
   });
 
   it("returns Err carrying the issues on invalid input", () => {
     const r = fromSchema(stringSchema())(42);
-    expect(r.unwrapErr()).toEqual([{ message: "expected a string" }]);
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error).toEqual([{ message: "expected a string" }]);
   });
 
   it("throws a TypeError when the schema validates asynchronously", () => {
@@ -66,16 +69,21 @@ describe("fromSchema (sync)", () => {
 
 describe("fromSchemaAsync", () => {
   it("returns Ok on valid input for a synchronous schema", async () => {
-    expect((await fromSchemaAsync(stringSchema())("hi")).unwrap()).toBe("hi");
+    const r = await fromSchemaAsync(stringSchema())("hi");
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) expect(r.value).toBe("hi");
   });
 
   it("returns Ok on valid input for an asynchronous schema", async () => {
-    expect((await fromSchemaAsync(stringSchema({ async: true }))("hi")).unwrap()).toBe("hi");
+    const r = await fromSchemaAsync(stringSchema({ async: true }))("hi");
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) expect(r.value).toBe("hi");
   });
 
   it("returns Err carrying the issues on invalid input", async () => {
     const r = await fromSchemaAsync(stringSchema({ async: true }))(42);
-    expect(r.unwrapErr()).toEqual([{ message: "expected a string" }]);
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error).toEqual([{ message: "expected a string" }]);
   });
 
   it("turns a throwing validator into a Defect (never rejects)", async () => {

--- a/packages/vitest/src/index.spec.ts
+++ b/packages/vitest/src/index.spec.ts
@@ -68,6 +68,14 @@ describe("toBeErr / toBeErrTagged", () => {
     expect(r).toBeErrTagged("MyError"); // one-arg: tag-only, passes
     expect(r).not.toBeErrTagged("MyError", undefined); // explicit undefined: payload {code:1} !== undefined
   });
+
+  it("toBeErrWith compares the error value deeply", () => {
+    expect(Err("boom")).toBeErrWith("boom");
+    expect(Err({ code: 404 })).toBeErrWith({ code: 404 });
+    expect(Err("boom")).not.toBeErrWith("other");
+    expect(Ok(1)).not.toBeErrWith(1);
+    expect(Err({ code: 404, detail: "x" })).toBeErrWith(expect.objectContaining({ code: 404 }));
+  });
 });
 
 describe("toBeDefect", () => {
@@ -115,6 +123,9 @@ describe("failure messages", () => {
 
   it("reports the expected value/tag on the other matchers", () => {
     expect(() => expect(Ok(1)).toBeOkWith(2)).toThrowError(/to be Ok\(2\), but got Ok\(1\)/);
+    expect(() => expect(Err("boom")).toBeErrWith("nope")).toThrowError(
+      /to be Err\("nope"\), but got Err\("boom"\)/,
+    );
     expect(() => expect(Ok(1)).toBeErrTagged("Nope")).toThrowError(
       /to be Err tagged "Nope", but got Ok\(1\)/,
     );
@@ -134,6 +145,9 @@ describe("failure messages", () => {
     expect(() => expect(Ok(1)).not.toBeOkWith(1)).toThrowError(/not to be Ok\(1\)/);
     expect(() => expect(Err("e")).not.toBeErr()).toThrowError(
       /not to be Err, but it was Err\("e"\)/,
+    );
+    expect(() => expect(Err("boom")).not.toBeErrWith("boom")).toThrowError(
+      /not to be Err\("boom"\)/,
     );
     expect(() => expect(Err(new MyError({ code: 1 }))).not.toBeErrTagged("MyError")).toThrowError(
       /not to be Err tagged "MyError"/,

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -229,7 +229,7 @@ export type UnthrownMatchers<R = unknown> = {
    * `expect(result).toBeErrTagged("NotFound", { id })` asserts the tag and payload.
    */
   toBeErrTagged: (tag: string, expected?: unknown) => R;
-  toBeErrWith: (value: unknown) => R;
+  toBeErrWith: (expected: unknown) => R;
   /** `expect(result).toBeDefect()` asserts the result is a `Defect`. */
   toBeDefect: () => R;
 };

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -109,6 +109,21 @@ function toBeErr(this: MatcherState, received: unknown): MatcherResult {
   });
 }
 
+function toBeErrWith(this: MatcherState, received: unknown, expected: unknown): MatcherResult {
+  const { stringify } = this.utils;
+  const { equals } = this;
+  return settle(received, stringify, (result) => {
+    const pass = isErr(result) && equals(result.error, expected);
+    return {
+      pass,
+      message: () =>
+        pass
+          ? `expected result not to be Err(${stringify(expected)})`
+          : `expected result to be Err(${stringify(expected)}), but got ${render(result, stringify)}`,
+    };
+  });
+}
+
 function toBeErrTagged(
   this: MatcherState,
   received: unknown,
@@ -165,9 +180,9 @@ function toBeDefect(this: MatcherState, received: unknown): MatcherResult {
   });
 }
 
-expect.extend({ toBeOk, toBeOkWith, toBeErr, toBeErrTagged, toBeDefect });
+expect.extend({ toBeDefect, toBeErr, toBeErrTagged, toBeErrWith, toBeOk, toBeOkWith });
 
-export { toBeDefect, toBeErr, toBeErrTagged, toBeOk, toBeOkWith };
+export { toBeDefect, toBeErr, toBeErrTagged, toBeErrWith, toBeOk, toBeOkWith };
 
 /**
  * The matchers `@unthrown/vitest` contributes to Vitest's `expect`. For an
@@ -214,6 +229,7 @@ export type UnthrownMatchers<R = unknown> = {
    * `expect(result).toBeErrTagged("NotFound", { id })` asserts the tag and payload.
    */
   toBeErrTagged: (tag: string, expected?: unknown) => R;
+  toBeErrWith: (value: unknown) => R;
   /** `expect(result).toBeDefect()` asserts the result is a `Defect`. */
   toBeDefect: () => R;
 };


### PR DESCRIPTION
## What & why

Makes value extraction **safe by construction**. Previously `unwrap()` compiled on *any* `Result<T, E>` and threw `UnwrapError` at runtime on the wrong variant — a values-not-exceptions library shouldn't let you bypass error handling that easily.

Now the two throwing eliminators are **type-gated**:

```ts
unwrap(this: Result<T, never>): T        // compiles only when the error channel is empty
unwrapErr(this: Result<never, E>): E     // compiles only when the success channel is empty
// async twins gated on AsyncResult<T, never> / AsyncResult<never, E>
```

`.unwrap()` on a fallible `Result<T, E>` is now a **compile error** — eliminate the error channel first (`match` / `recover` / `orElse`), or use the `unwrapOr` / `unwrapOrElse` / `getOrNull` / `getOrUndefined` family (which recover an `Err`). `Ok(1).unwrap()` and error-free results are unaffected. On a `Defect` they still **rethrow the original cause** (panic).

## How it works

- **Runtime is unchanged** — only the `this` types on `ResultMethods` / `AsyncResultMethods`. The internal `Res` class keeps its wider runtime method (never exported), and `AsyncRes`'s delegation gets a sound cast (`r as Result<T, never>`), justified by the external gate.
- **`UnwrapError` is retained** as a defensive guard — its wrong-variant branch is now unreachable through well-typed code (only a cast or a raw-JS caller can reach it).
- Verified with standalone `tsc` probes that the `this`-gate rejects a fallible receiver, accepts the `never`-channel form, and that `AsyncRes implements AsyncResult` survives the gated `this`.

## Also included

- **`toBeErrWith` matcher** added to `@unthrown/vitest` (mirror of `toBeOkWith`, for asserting a plain error value).
- **~41 in-repo call sites migrated** to `isOk()` / `isErr()` narrowing guards. (Core/standard-schema tests can't use the vitest matchers — that would be a circular workspace dependency — so guards, each preceded by a variant assertion so no test can silently pass.)
- `test-d` `@ts-expect-error` guards pinning the gate (sync + async).
- TSDoc, guide prose, and `CLAUDE.md` invariant updated to the gated reality.

## Migration (breaking → major)

Replace `result.unwrap()` on a fallible result with one of:
- `result.match({ ok, err, defect })`
- `result.recover((e) => fallback).unwrap()` / `.orElse(...)`
- `result.unwrapOrElse((e) => { throw … })` (explicit assert-and-panic)
- in tests: `if (result.isOk()) result.value` after asserting the variant

## Verification

Full gate green across all 8 packages: `format`, `lint`, `typecheck` (incl. `test-d`), `knip`, `test` (170 core + interop packages), `build`, `build:docs` (typedoc clean). Reviewed task-by-task plus a whole-branch review (no Critical/Important findings; two stale async-doc fragments fixed in the last commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)