### PR TITLE
feat(core): let mapErr escalate an error to the defect channel

### DIFF
--- a/.changeset/maperr-defect.md
+++ b/.changeset/maperr-defect.md
@@ -7,4 +7,10 @@ takes the injected `defect` marker as a second argument (like `fromPromise` /
 `fromThrowable`'s `qualify`): return `defect(cause)` to move that error to the
 defect channel, or a new error to keep it modeled. The error type is inferred as
 `Exclude<R, Defect>`, so `(e, defect) => defect(e)` empties the error channel to
-`never`. Backward-compatible — existing `mapErr((e) => e2)` calls are unchanged.
+`never`. **Behavioral caveat for point-free callers:** the callback is now invoked with
+two arguments, so an existing arity-≥2 function passed point-free changes
+behavior — e.g. `mapErr(JSON.stringify)` now receives the `defect` marker as
+JSON's _replacer_ and produces a `Defect` instead of `Err("…")`. Single-
+parameter callbacks (`mapErr((e) => …)`) are unchanged. If you pass functions
+point-free, wrap them: `mapErr((e) => JSON.stringify(e))`. Consider whether
+this warrants a major release for your consumers before merging.

--- a/.changeset/maperr-defect.md
+++ b/.changeset/maperr-defect.md
@@ -1,0 +1,10 @@
+---
+"unthrown": minor
+---
+
+`mapErr` can now escalate a modeled error to the defect channel. Its callback
+takes the injected `defect` marker as a second argument (like `fromPromise` /
+`fromThrowable`'s `qualify`): return `defect(cause)` to move that error to the
+defect channel, or a new error to keep it modeled. The error type is inferred as
+`Exclude<R, Defect>`, so `(e, defect) => defect(e)` empties the error channel to
+`never`. Backward-compatible — existing `mapErr((e) => e2)` calls are unchanged.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,10 @@ was planned).
 - **A `Defect` flows through every method untouched EXCEPT `match()` and
   `recoverDefect()`.** Therefore `unwrapOr`, `unwrapOrElse`, `getOrNull`,
   `getOrUndefined` still **throw** on a `Defect` — they recover the modeled `Err`,
-  never an unmodeled defect (a defect is a bug, not an absent value).
+  never an unmodeled defect (a defect is a bug, not an absent value). (An
+  _existing_ `Defect` is still untouched by `mapErr` — its callback runs only on
+  `Err`; `mapErr` can now turn that `Err` itself into a `Defect` via the injected
+  `defect` marker, which is a distinct thing from a defect passing through.)
 - **`unwrap()` is asymmetric.** On `Err` it throws a `UnwrapError` carrying `E`
   (on both the typed `.error` property and the standard `Error.cause`, so an
   `Error`-typed `E` chains its original stack under "caused by").
@@ -98,9 +101,11 @@ async work re-enters via `fromPromise` / `fromSafePromise` and composes with
   pure value). On `AsyncResult`, `bind`'s `f` may return a `Result` or an
   `AsyncResult`. A throw in either becomes a `Defect`; `Err`/`Defect`
   short-circuits/passes through. To go async, lift with `toAsync()`.
-- error: `mapErr`, `orElse`, `recover`, `tapErr`, `flatTapErr` (the error-channel
-  mirror of `flatTap` — runs a `Result`-returning effect on the error, keeps the
-  original error, threads the effect's error)
+- error: `mapErr` (transform the error, **or escalate it to a defect** via the
+  injected `defect` marker — `(error, defect) => E2 | Defect`, inferred as
+  `Exclude<R, Defect>`), `orElse`, `recover`, `tapErr`, `flatTapErr` (the
+  error-channel mirror of `flatTap` — runs a `Result`-returning effect on the
+  error, keeps the original error, threads the effect's error)
 - defect: `recoverDefect`, `tapDefect`
 - eliminate: `match`, `unwrap`, `unwrapErr`, `unwrapOr`, `unwrapOrElse`,
   `getOrNull`, `getOrUndefined`
@@ -112,7 +117,8 @@ async work re-enters via `fromPromise` / `fromSafePromise` and composes with
   plain `{ tag: "Ok" }` look-alike is not matched), for untyped boundaries.
 - constructors: `Ok`, `Err` (there is **no** `Defect` constructor — a defect-state
   `Result` arises only at boundaries; the qualify-time `defect` marker helper is
-  injected, not exported)
+  injected, not exported — `mapErr` is a second injection point for it, alongside
+  `fromPromise`/`fromThrowable`'s `qualify`)
 - interop: `fromNullable`, `fromThrowable`, `fromPromise`, `fromSafePromise`
 - aggregate: `all` / `allAsync` take a **tuple/array** (a fixed tuple keeps
   positional types; a dynamic `Result<T, E>[]` / `AsyncResult<T, E>[]` collapses

--- a/docs/guide/choosing-a-combinator.md
+++ b/docs/guide/choosing-a-combinator.md
@@ -26,24 +26,34 @@ The `→ Result<…>` half of each signature is the tell — it shows how the co
 moves the channels: `flatMap` widens `E` to `E | E2`, `recover` empties it to
 `never`, `orElse` widens the value to `T | U`.
 
-| I want to…                                     | use               | signature                                                    | channel |
-| ---------------------------------------------- | ----------------- | ------------------------------------------------------------ | ------- |
-| transform the success value                    | `map`             | `(v: T) => U` → `Result<U, E>`                               | Ok      |
-| chain a `Result`-returning step                | `flatMap`         | `(v: T) => Result<U, E2>` → `Result<U, E \| E2>`             | Ok      |
-| run a side effect, keep the value              | `tap`             | `(v: T) => void` → `Result<T, E>`                            | Ok      |
-| run a **failable** side effect, keep the value | `flatTap`         | `(v: T) => Result<unknown, E2>` → `Result<T, E \| E2>`       | Ok      |
-| sequence steps into a named scope              | `Do`/`bind`/`let` | `bind(k, (scope) => Result<U, E2>)` → `Result<{…}, E \| E2>` | Ok      |
-| replace the value with a constant              | `as`              | `(value: U)` → `Result<U, E>`                                | Ok      |
-| transform the error                            | `mapErr`          | `(e: E) => E2` → `Result<T, E2>`                             | Err     |
-| try a fallback that returns a `Result`         | `orElse`          | `(e: E) => Result<U, E2>` → `Result<T \| U, E2>`             | Err     |
-| turn an error into a success value             | `recover`         | `(e: E) => U` → `Result<T \| U, never>`                      | Err     |
-| run a side effect on the error                 | `tapErr`          | `(e: E) => void` → `Result<T, E>`                            | Err     |
-| run a **failable** side effect on the error    | `flatTapErr`      | `(e: E) => Result<unknown, E2>` → `Result<T, E \| E2>`       | Err     |
-| recover from a defect (rare)                   | `recoverDefect`   | `(cause) => Result<U, E2>` → `Result<T \| U, E \| E2>`       | Defect  |
-| observe a defect, e.g. log it                  | `tapDefect`       | `(cause) => void` → `Result<T, E>`                           | Defect  |
-| handle all three channels at the edge          | `match`           | `{ ok, err, defect }` → `R`                                  | all     |
-| combine an array of `Result`s                  | `all`             | `Result<T, E>[]` → `Result<T[], E>`                          | —       |
-| combine a record of `Result`s                  | `allFromDict`     | `{ [k]: Result<T, E> }` → `Result<{ [k]: T }, E>`            | —       |
+| I want to…                                      | use               | signature                                                    | channel |
+| ----------------------------------------------- | ----------------- | ------------------------------------------------------------ | ------- |
+| transform the success value                     | `map`             | `(v: T) => U` → `Result<U, E>`                               | Ok      |
+| chain a `Result`-returning step                 | `flatMap`         | `(v: T) => Result<U, E2>` → `Result<U, E \| E2>`             | Ok      |
+| run a side effect, keep the value               | `tap`             | `(v: T) => void` → `Result<T, E>`                            | Ok      |
+| run a **failable** side effect, keep the value  | `flatTap`         | `(v: T) => Result<unknown, E2>` → `Result<T, E \| E2>`       | Ok      |
+| sequence steps into a named scope               | `Do`/`bind`/`let` | `bind(k, (scope) => Result<U, E2>)` → `Result<{…}, E \| E2>` | Ok      |
+| replace the value with a constant               | `as`              | `(value: U)` → `Result<U, E>`                                | Ok      |
+| transform the error, or escalate it to a defect | `mapErr`          | `(e: E, defect) => R` → `Result<T, Exclude<R, Defect>>`      | Err     |
+| try a fallback that returns a `Result`          | `orElse`          | `(e: E) => Result<U, E2>` → `Result<T \| U, E2>`             | Err     |
+| turn an error into a success value              | `recover`         | `(e: E) => U` → `Result<T \| U, never>`                      | Err     |
+| run a side effect on the error                  | `tapErr`          | `(e: E) => void` → `Result<T, E>`                            | Err     |
+| run a **failable** side effect on the error     | `flatTapErr`      | `(e: E) => Result<unknown, E2>` → `Result<T, E \| E2>`       | Err     |
+| recover from a defect (rare)                    | `recoverDefect`   | `(cause) => Result<U, E2>` → `Result<T \| U, E \| E2>`       | Defect  |
+| observe a defect, e.g. log it                   | `tapDefect`       | `(cause) => void` → `Result<T, E>`                           | Defect  |
+| handle all three channels at the edge           | `match`           | `{ ok, err, defect }` → `R`                                  | all     |
+| combine an array of `Result`s                   | `all`             | `Result<T, E>[]` → `Result<T[], E>`                          | —       |
+| combine a record of `Result`s                   | `allFromDict`     | `{ [k]: Result<T, E> }` → `Result<{ [k]: T }, E>`            | —       |
+
+::: tip `mapErr` can also escalate to a defect
+`mapErr`'s callback receives an injected `defect` marker as a second argument —
+the same shape as `fromPromise` / `fromThrowable`'s `qualify`. Return
+`defect(cause)` to move that error out of `E` entirely and into the defect
+channel; return a plain value to keep it modeled. The resulting error type is
+inferred as `Exclude<R, Defect>` (`R` being the callback's return type), so a
+callback that always escalates (`(e, defect) => defect(e)`) empties `E` to
+`never`. See [The Defect Channel](./the-defect-channel#escalating-errors-to-defects).
+:::
 
 ## Behavior at a glance
 
@@ -52,18 +62,18 @@ untouched. This grid is the whole story — notice the `Defect` column is
 "passes ▸" everywhere except `recoverDefect` and `match`, which is the one
 invariant to remember:
 
-| method                  | on `Ok`  | on `Err`        | on `Defect` | resulting `E`   |
-| ----------------------- | -------- | --------------- | ----------- | --------------- |
-| `map`                   | runs `f` | passes ▸        | passes ▸    | `E`             |
-| `flatMap`               | runs `f` | passes ▸        | passes ▸    | `E \| E2`       |
-| `tap` / `flatTap`       | runs `f` | passes ▸        | passes ▸    | `E` / `E \| E2` |
-| `mapErr`                | passes ▸ | runs `f`        | passes ▸    | `E2`            |
-| `orElse`                | passes ▸ | runs `f`        | passes ▸    | `E2`            |
-| `recover`               | passes ▸ | runs `f` → `Ok` | passes ▸    | `never`         |
-| `tapErr` / `flatTapErr` | passes ▸ | runs `f`        | passes ▸    | `E` / `E \| E2` |
-| `recoverDefect`         | passes ▸ | passes ▸        | runs `f`    | `E \| E2`       |
-| `tapDefect`             | passes ▸ | passes ▸        | runs `f`    | `E`             |
-| `match`                 | `ok()`   | `err()`         | `defect()`  | —               |
+| method                  | on `Ok`  | on `Err`                            | on `Defect` | resulting `E`        |
+| ----------------------- | -------- | ----------------------------------- | ----------- | -------------------- |
+| `map`                   | runs `f` | passes ▸                            | passes ▸    | `E`                  |
+| `flatMap`               | runs `f` | passes ▸                            | passes ▸    | `E \| E2`            |
+| `tap` / `flatTap`       | runs `f` | passes ▸                            | passes ▸    | `E` / `E \| E2`      |
+| `mapErr`                | passes ▸ | runs `f` (may escalate to `Defect`) | passes ▸    | `Exclude<R, Defect>` |
+| `orElse`                | passes ▸ | runs `f`                            | passes ▸    | `E2`                 |
+| `recover`               | passes ▸ | runs `f` → `Ok`                     | passes ▸    | `never`              |
+| `tapErr` / `flatTapErr` | passes ▸ | runs `f`                            | passes ▸    | `E` / `E \| E2`      |
+| `recoverDefect`         | passes ▸ | passes ▸                            | runs `f`    | `E \| E2`            |
+| `tapDefect`             | passes ▸ | passes ▸                            | runs `f`    | `E`                  |
+| `match`                 | `ok()`   | `err()`                             | `defect()`  | —                    |
 
 ::: tip `recover`'s `never` under-describes the runtime
 `recover` empties only the **error** channel to `never` — a `Defect` can still be

--- a/docs/guide/the-defect-channel.md
+++ b/docs/guide/the-defect-channel.md
@@ -86,6 +86,32 @@ try {
 }
 ```
 
+## Escalating errors to defects
+
+`recoverDefect` goes one direction: `Defect` → `Result`. `mapErr` can go the
+other way. Its callback receives the same injected `defect` marker as
+`fromPromise` / `fromThrowable`'s `qualify` — return `defect(cause)` to move a
+_modeled_ error out of `E` and into the defect channel, because you've decided
+it's no longer something the caller should have to handle as domain logic.
+
+```ts
+type ParseError = { _tag: "Corrupt" } | { _tag: "TooLarge" };
+
+// selective — keep some errors modeled, escalate the rest
+result.mapErr((e: ParseError, defect) => (e._tag === "Corrupt" ? defect(e) : e));
+// type: Result<T, { _tag: "TooLarge" }> — "Corrupt" is subtracted from E
+
+// blanket — every remaining error is now unrecoverable
+result.mapErr((e, defect) => defect(e));
+// type: Result<T, never>
+```
+
+The error type is inferred as `Exclude<R, Defect>` (`R` being the callback's
+return type) — the escalated arm is _subtracted_ from `E`, the same rule
+`fromPromise` / `fromThrowable` use for `qualify`. This is backward-compatible:
+a callback that never calls `defect` (`mapErr((e) => e2)`) behaves exactly as
+before.
+
 ## The only door: `recoverDefect`
 
 When you genuinely need to handle a defect — say, to convert a third-party

--- a/packages/core/src/async-result.spec.ts
+++ b/packages/core/src/async-result.spec.ts
@@ -138,6 +138,11 @@ describe("AsyncResult error channel", () => {
     expect((await asyncErr("e").mapErr((s) => `${s}!`)).unwrapErr()).toBe("e!");
   });
 
+  it("escalates an error to a Defect (async)", async () => {
+    const r = await asyncErr("boom").mapErr((e, defect) => defect(e));
+    expect(r.isDefect()).toBe(true);
+  });
+
   it("orElse recovers an Err", async () => {
     expect((await asyncErr("e").orElse(() => Ok(9))).unwrap()).toBe(9);
   });

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -14,6 +14,7 @@
 // The only other casts are the builders' construction (`as OkView`/…) and the
 // `bind`/`let` scope merge (a computed key can't be spelled at the type level).
 
+import { type Defect, defect, isDefectMarker } from "./defect.js";
 import type { AsyncResult, Bound, DefectView, ErrView, OkView, Result } from "./types.js";
 
 /**
@@ -136,10 +137,13 @@ class Res<T, E> {
     return okRes(value);
   }
 
-  mapErr<E2>(this: Result<T, E>, f: (error: E) => E2): Result<T, E2> {
+  mapErr<R>(
+    this: Result<T, E>,
+    f: (error: E, defect: (cause: unknown) => Defect) => R,
+  ): Result<T, Exclude<R, Defect>> {
     if (this.tag !== "Err") return passThrough(this);
     try {
-      return errRes(f(this.error));
+      return errOrDefect(f(this.error, defect) as Exclude<R, Defect> | Defect);
     } catch (cause) {
       return defectRes(cause);
     }
@@ -323,6 +327,12 @@ export function defectRes<T, E>(cause: unknown): Result<T, E> {
     tag: "Defect" as const,
     cause,
   }) as DefectView<T, E>;
+}
+
+// A qualify-style callback returns `E | Defect`; route it to the matching Result
+// variant. Shared by `mapErr` (sync + async) so the triage isn't duplicated.
+function errOrDefect<T, E>(r: E | Defect): Result<T, E> {
+  return isDefectMarker(r) ? defectRes<T, E>(r.cause) : errRes<T, E>(r);
 }
 
 /**
@@ -512,12 +522,14 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
     );
   }
 
-  mapErr<E2>(f: (error: E) => E2): AsyncResult<T, E2> {
-    return new AsyncRes<T, E2>(
+  mapErr<R>(
+    f: (error: E, defect: (cause: unknown) => Defect) => R,
+  ): AsyncResult<T, Exclude<R, Defect>> {
+    return new AsyncRes<T, Exclude<R, Defect>>(
       this.promise.then((r) => {
         if (r.tag !== "Err") return passThrough(r);
         try {
-          return errRes(f(r.error));
+          return errOrDefect(f(r.error, defect) as Exclude<R, Defect> | Defect);
         } catch (cause) {
           return defectRes(cause);
         }

--- a/packages/core/src/result.spec.ts
+++ b/packages/core/src/result.spec.ts
@@ -186,6 +186,19 @@ describe("Result.mapErr", () => {
         .isDefect(),
     ).toBe(true);
   });
+
+  it("escalates an error to the defect channel via the injected defect marker", () => {
+    const r = Err("boom").mapErr((e, defect) => defect(e));
+    expect(r.isDefect()).toBe(true);
+    expect(r.match({ ok: () => "ok", err: () => "err", defect: (c) => c })).toBe("boom");
+  });
+
+  it("selectively escalates: the non-escalated error stays an Err", () => {
+    const keep = Err<"A" | "B">("A").mapErr((e, defect) => (e === "B" ? defect(e) : e));
+    expect(keep.unwrapErr()).toBe("A");
+    const gone = Err<"A" | "B">("B").mapErr((e, defect) => (e === "B" ? defect(e) : e));
+    expect(gone.isDefect()).toBe(true);
+  });
 });
 
 describe("Result.orElse", () => {

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -242,3 +242,19 @@ new WithCode({ code: 1, name: "nope" });
 type _nameNotShadowed = Expect<
   Equal<TaggedErrorInstance<"X", { code: number; name: "lit" }>["name"], string>
 >;
+
+// --- mapErr can escalate an error to the defect channel ----------------------
+declare const rUnion: Result<number, { _tag: "A" } | { _tag: "B" }>;
+// backward compat: a 1-arg callback infers the same E2
+const _me1 = rUnion.mapErr((e) => e._tag);
+type _me1t = Expect<Equal<typeof _me1, Result<number, "A" | "B">>>;
+// selective escalation narrows E (the escalated arm is subtracted)
+const _me2 = rUnion.mapErr((e, defect) => (e._tag === "B" ? defect(e) : e));
+type _me2t = Expect<Equal<typeof _me2, Result<number, { _tag: "A" }>>>;
+// blanket escalation empties the error channel
+const _me3 = rUnion.mapErr((e, defect) => defect(e));
+type _me3t = Expect<Equal<typeof _me3, Result<number, never>>>;
+// async twin behaves the same
+declare const arUnion: AsyncResult<number, { _tag: "A" } | { _tag: "B" }>;
+const _me4 = arUnion.mapErr((e, defect) => defect(e));
+type _me4t = Expect<Equal<typeof _me4, AsyncResult<number, never>>>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,7 @@
 // unthrown — public type surface. Pure types, no runtime.
 
+import type { Defect } from "./defect.js";
+
 /**
  * Flatten an intersection into a single object literal so accumulated `bind` /
  * `let` scopes display cleanly (`{ a; b }` rather than `{ a } & { b }`).
@@ -130,15 +132,20 @@ export type ResultMethods<T, E> = {
   as<U>(value: U): Result<U, E>;
 
   /**
-   * Transform the modeled error with `f`.
+   * Transform the modeled error — to a new error, or **escalate it to a defect**.
    *
-   * Runs `f` only on `Err`; `Ok` passes through and a `Defect` is **never**
-   * touched. If `f` throws, the throw becomes a `Defect`.
+   * Runs `f` only on `Err`; `Ok` passes through and an existing `Defect` is
+   * **never** touched. `f` returns either a new modeled error (kept as `Err`) or
+   * `defect(cause)` — the marker injected as its second argument, exactly like
+   * {@link fromThrowable}'s `qualify` — to move that error to the defect channel.
+   * The result's error type is `Exclude<R, Defect>` (the escalated arm is
+   * subtracted), so `(e, defect) => defect(e)` yields `Result<T, never>`. If `f`
+   * throws, the throw becomes a `Defect`.
    *
-   * @typeParam E2 - the mapped error type.
-   * @param f - maps the current error to a new one.
+   * @typeParam R - `f`'s return type; the new error `E2` is `Exclude<R, Defect>`.
+   * @param f - maps the error to a new one, or escalates it via `defect(cause)`.
    */
-  mapErr<E2>(f: (error: E) => E2): Result<T, E2>;
+  mapErr<R>(f: (error: E, defect: (cause: unknown) => Defect) => R): Result<T, Exclude<R, Defect>>;
   /**
    * Recover from an `Err` by producing another `Result`.
    *
@@ -461,10 +468,13 @@ export type AsyncResultMethods<T, E> = {
   as<U>(value: U): AsyncResult<U, E>;
 
   /**
-   * Asynchronous {@link ResultMethods.mapErr | mapErr}. `f` is synchronous; a
-   * throw becomes a `Defect`.
+   * Asynchronous {@link ResultMethods.mapErr | mapErr}. `f` is synchronous and may
+   * escalate an error to a defect via the injected `defect` marker; a throw
+   * becomes a `Defect`.
    */
-  mapErr<E2>(f: (error: E) => E2): AsyncResult<T, E2>;
+  mapErr<R>(
+    f: (error: E, defect: (cause: unknown) => Defect) => R,
+  ): AsyncResult<T, Exclude<R, Defect>>;
   /**
    * Asynchronous {@link ResultMethods.orElse | orElse}. `f` may return a `Result`
    * or an `AsyncResult`.


### PR DESCRIPTION
## What & why

Adds a way to **reclassify a modeled error into the defect channel** — the typed inverse of `recoverDefect` (which goes Defect→Result). `mapErr`'s callback gains the injected `defect` marker as a second argument, exactly like `fromPromise`/`fromThrowable`'s `qualify`:

```ts
mapErr<R>(f: (error: E, defect: (cause: unknown) => Defect) => R): Result<T, Exclude<R, Defect>>
```

Return a new error to keep it modeled, or `defect(cause)` to move it to the defect channel. `Exclude<R, Defect>` subtracts the escalated arm, so one primitive covers all three shapes:

```ts
r.mapErr((e, defect) => e._tag === "Corrupt" ? defect(e) : e)  // selective → narrows E
r.mapErr((e, defect) => defect(e))                             // blanket → Result<T, never>
r.mapErr((e, defect) => e._tag === "Impossible" ? defect(e) : e) // single "can't happen"
```

## Design notes

- **Reuses existing machinery** — the `(x, defect) => E | Defect` shape, the `Exclude<R, Defect>` inference, the injected (non-public) `defect` marker, and the `isDefectMarker(r) ? defectRes(r.cause) : errRes(r)` triage all mirror `fromThrowable`/`qualifyToResult`. No new pattern, factored into a shared `errOrDefect` helper.
- **Backward-compatible (verified)** — existing `mapErr((e) => e2)` infers identically (a 1-arg callback is assignable to the 2-arg type; `Exclude<E2, Defect> = E2` because `Defect` is a module-private `unique symbol`, so it's unforgeable and never accidentally excludes a domain error). No call-site migration.
- **Scope: just `mapErr`.** `orElse`/`recover`/`flatTapErr` return Results/values, so threading `defect` there gets muddy — escalation elsewhere composes via `mapErr` in the chain.
- **`mapErr` on `mapErr`, not a new method** — fits "one concept, one name": it's still "decide what the error becomes," now including "an escalated defect."
- Invariants preserved: an *existing* `Defect` still passes through untouched (`f` runs only on `Err`); a throw in `f` still becomes a `Defect`. The async twin keeps its callback synchronous.

## Verification

Full gate green across all 8 packages: `format`, `lint`, `typecheck` (incl. `test-d` — backward-compat, selective, blanket, async inference), `knip`, `test` (173 core + interop), `build`, `build:docs` (typedoc clean). Reviewed task-by-task plus a whole-branch review (no Critical/Important findings). `minor` changeset (additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)