### PR TITLE
Fix all findings from the full repository review

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -17,5 +17,8 @@
   "linked": [],
   "access": "public",
   "baseBranch": "main",
-  "updateInternalDependencies": "patch"
+  "updateInternalDependencies": "patch",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }

--- a/.changeset/review-fixes-core.md
+++ b/.changeset/review-fixes-core.md
@@ -16,8 +16,9 @@ Soundness and hardening fixes from a full review:
 - **`matchTags`** routes an unhandled `_tag` (possible only outside the typed
   contract) to the `Defect` handler instead of crashing, and rejects the
   reserved tags `"Ok"`/`"Defect"` at compile time.
-- **`unwrapOr` widens**: `unwrapOr<U>(fallback: U): T | U`, so
-  `r.unwrapOr(null)` now type-checks.
+- **`unwrapOr` / `unwrapOrElse` widen**: `unwrapOr<U>(fallback: U): T | U` and
+  `unwrapOrElse<U>(f: (error: E) => U): T | U`, so `r.unwrapOr(null)` and
+  `r.unwrapOrElse(() => null)` now type-check.
 - `fromPromise`/`fromSafePromise` absorb a non-thenable input instead of
   throwing synchronously; `bind`/`let` reject an array scope as misuse
   (Defect) instead of silently index-spreading it; `Result` instances are

--- a/.changeset/review-fixes-core.md
+++ b/.changeset/review-fixes-core.md
@@ -1,0 +1,24 @@
+---
+"unthrown": minor
+---
+
+Soundness and hardening fixes from a full review:
+
+- **Async combinator callbacks are now a compile error** (`NotThenable`): an
+  `async` callback passed to `map`/`tap`/`tapErr`/`tapDefect`/`mapErr`/
+  `recover`/`let` no longer type-checks. Such code was already broken at
+  runtime — its rejection escaped the pipeline as an unhandled rejection
+  instead of a `Defect`. Lift async work with `fromPromise` + `flatMap`.
+  (`match` handlers may still be async.)
+- **A throw inside `tapErr`/`tapDefect`/`flatTapErr` no longer destroys the
+  failure being observed**: the resulting `Defect`'s cause is now an
+  `AggregateError([thrown, original])`.
+- **`matchTags`** routes an unhandled `_tag` (possible only outside the typed
+  contract) to the `Defect` handler instead of crashing, and rejects the
+  reserved tags `"Ok"`/`"Defect"` at compile time.
+- **`unwrapOr` widens**: `unwrapOr<U>(fallback: U): T | U`, so
+  `r.unwrapOr(null)` now type-checks.
+- `fromPromise`/`fromSafePromise` absorb a non-thenable input instead of
+  throwing synchronously; `bind`/`let` reject an array scope as misuse
+  (Defect) instead of silently index-spreading it; `Result` instances are
+  frozen so a variant cannot be forged by mutation.

--- a/.changeset/review-fixes-satellites.md
+++ b/.changeset/review-fixes-satellites.md
@@ -1,0 +1,21 @@
+---
+"@unthrown/vitest": minor
+"@unthrown/oxlint": minor
+"@unthrown/boxed": patch
+"@unthrown/neverthrow": patch
+"@unthrown/effect": patch
+"@unthrown/pattern": patch
+"@unthrown/standard-schema": patch
+---
+
+- **@unthrown/vitest**: `unthrown` is now a **peerDependency** (the matchers'
+  `isResult` is an `instanceof` check — the previous exact-version dependency
+  could install a second copy of core and silently reject every genuine
+  `Result`). `toBeErrTagged(tag, undefined)` now asserts the payload equals
+  `undefined` instead of degrading to a tag-only match.
+- **@unthrown/oxlint**: `prefer-async-result` no longer offers an autofix on an
+  `async` function's return annotation (the rewrite could not compile); the
+  `oxlint` peer range is now `^1.69.0` (JS plugins require it).
+- **All packages**: core is depended on via `workspace:^` (caret) instead of an
+  exact pin, `LICENSE` ships in every tarball, the legacy `types` fallback
+  points at the CJS declarations, and `engines.node` relaxes to `>=20`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,10 +317,9 @@ channel?**
    `matchTags` covers the everyday exhaustive case.
 
 Also shipped: a root `README` + `LICENSE`, per-package READMEs, and the VitePress
-docs site (guide + generated API reference). **Remaining work is manual** and
-cannot be automated from here: publish `unthrown` + the `@unthrown` scope to npm,
-create the `RELEASE_PAT` secret, and configure npm Trusted Publishers for the
-changesets `release.yml` (plus enabling GitHub Pages for `deploy-docs.yml`).
+docs site (guide + generated API reference). Both the npm packages and the
+GitHub Pages site are live (the release secrets / npm Trusted Publishers are
+configured outside the repo).
 
 ## Toolchain & conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ async work re-enters via `fromPromise` / `fromSafePromise` and composes with
 - defect: `recoverDefect`, `tapDefect`
 - eliminate: `match`, `unwrap`, `unwrapErr`, `unwrapOr` (signature
   `unwrapOr<U>(fallback: U): T | U` — widening, not narrowed to `T`),
-  `unwrapOrElse`, `getOrNull`, `getOrUndefined`
+  `unwrapOrElse` (same `T | U` widening), `getOrNull`, `getOrUndefined`
 - guards: methods `isOk`/`isErr`/`isDefect` **and** standalone
   `isOk`/`isErr`/`isDefect` both narrow (to `OkView`/`ErrView`/`DefectView`) — the
   methods are `this is …` type predicates, so `if (r.isErr()) r.error` compiles.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,10 +54,27 @@ was planned).
   escapes a pipeline as a raw throw.
   This is what lets an HTTP adapter do a single `match({ ok, err, defect })`
   with **no surrounding `try/catch`**.
-- **A `Defect` flows through every method untouched EXCEPT `match()` and
-  `recoverDefect()`.** Therefore `unwrapOr`, `unwrapOrElse`, `getOrNull`,
-  `getOrUndefined` still **throw** on a `Defect` — they recover the modeled `Err`,
-  never an unmodeled defect (a defect is a bug, not an absent value).
+- **A `Defect` flows through every method untouched EXCEPT `match()`,
+  `recoverDefect()`, and `tapDefect()` (which observes it without consuming
+  it).** Therefore `unwrapOr`, `unwrapOrElse`, `getOrNull`, `getOrUndefined`
+  still **throw** on a `Defect` — they recover the modeled `Err`, never an
+  unmodeled defect (a defect is a bug, not an absent value).
+- **A failure-observer throw preserves the original failure.** A throw inside
+  `tapErr` / `tapDefect` / `flatTapErr` produces a `Defect` whose cause is an
+  `AggregateError([thrown, original])` — observing a failure never destroys it.
+  (A throw in the success-channel `tap`/`map` keeps the plain thrown cause.)
+- **Thenable callback returns are rejected at compile time.** Every combinator
+  callback not already constrained to return a `Result` (`map`, `tap*`, `let`,
+  `mapErr`, `recover`) intersects its return with `NotThenable<R>` — an `async`
+  callback is a compile error, because its rejection would bypass
+  qualification. `match` handlers are deliberately exempt (edge elimination).
+- **Result instances are frozen.** `okRes`/`errRes`/`defectRes` return
+  `Object.freeze`d objects, so a variant cannot be forged by mutation; the
+  `readonly` types are real at runtime.
+- **`matchTags` never crashes on an unhandled tag.** Outside the typed contract
+  (widened cast, JS caller) an unknown or reserved (`"Ok"`/`"Defect"`) `_tag`
+  routes to the `Defect` handler; reserved tags in `E` are additionally a
+  compile error.
 - **`unwrap()` is asymmetric.** On `Err` it throws a `UnwrapError` carrying `E`
   (on both the typed `.error` property and the standard `Error.cause`, so an
   `Error`-typed `E` chains its original stack under "caused by").
@@ -102,14 +119,18 @@ async work re-enters via `fromPromise` / `fromSafePromise` and composes with
   mirror of `flatTap` — runs a `Result`-returning effect on the error, keeps the
   original error, threads the effect's error)
 - defect: `recoverDefect`, `tapDefect`
-- eliminate: `match`, `unwrap`, `unwrapErr`, `unwrapOr`, `unwrapOrElse`,
-  `getOrNull`, `getOrUndefined`
+- eliminate: `match`, `unwrap`, `unwrapErr`, `unwrapOr` (signature
+  `unwrapOr<U>(fallback: U): T | U` — widening, not narrowed to `T`),
+  `unwrapOrElse`, `getOrNull`, `getOrUndefined`
 - guards: methods `isOk`/`isErr`/`isDefect` **and** standalone
   `isOk`/`isErr`/`isDefect` both narrow (to `OkView`/`ErrView`/`DefectView`) — the
   methods are `this is …` type predicates, so `if (r.isErr()) r.error` compiles.
   One narrowing concept, two call styles. Plus the standalone `isResult(x)` —
   narrows an `unknown` to `Result<unknown, unknown>` (a prototype check, so a
   plain `{ tag: "Ok" }` look-alike is not matched), for untyped boundaries.
+- types: `NotThenable<R>` — rejects a `PromiseLike` at the type level, so a
+  combinator callback that returns one is a compile error instead of a silently
+  unqualified rejection.
 - constructors: `Ok`, `Err` (there is **no** `Defect` constructor — a defect-state
   `Result` arises only at boundaries; the qualify-time `defect` marker helper is
   injected, not exported)
@@ -227,11 +248,13 @@ library can be "done".
   the modeled `E`)
 - `packages/oxlint` → `@unthrown/oxlint` (an oxlint **JS plugin**, peerDep
   `oxlint`, dep `@oxlint/plugins`; ships `no-ambiguous-error-type` — enforces
-  Thesis #1 against `unknown`/`any`/`Error`/`{}` in `E` — and
-  `prefer-async-result`. Purely syntactic AST rules that resolve the import
-  source via scope analysis so they only fire on unthrown's `Result`. No TypeDoc
-  API page; documented in the Linting guide. Tested with oxlint's `RuleTester`
-  from `oxlint/plugins-dev`.)
+  Thesis #1 against `unknown`/`any`/`Error`/`{}` **and the primitive keywords**
+  in `E` — and `prefer-async-result` (reports `Promise<Result<T, E>>` in favour
+  of `AsyncResult<T, E>`, but withholds the autofix on an `async` function's
+  return annotation, since that must stay a native `Promise`). Purely syntactic
+  AST rules that resolve the import source via scope analysis so they only fire
+  on unthrown's `Result`. No TypeDoc API page; documented in the Linting guide.
+  Tested with oxlint's `RuleTester` from `oxlint/plugins-dev`.)
 - `tools/tsconfig`, `tools/typedoc` → private shared config (`@unthrown/tsconfig`,
   `@unthrown/typedoc`)
 - `docs` → `@unthrown/docs`, the VitePress site (guide + TypeDoc-generated API
@@ -239,6 +262,12 @@ library can be "done".
 
 Never pull `ts-pattern`, `vitest`, or any interop peer (`effect`, `neverthrow`,
 `@bloodyowl/boxed`) into core.
+
+Every satellite package depends on core via `workspace:^` (an exact pin would
+create a dual-copy hazard with the `instanceof`-based `isResult`); for the same
+reason, `@unthrown/vitest` takes core as a **peerDependency**, not a regular
+dependency. Every published package carries `engines: { node: ">=20" }`, ships
+its own `LICENSE`, and sets `files: ["dist"]`.
 
 ### Interop packages (`packages/effect`, `packages/neverthrow`, `packages/boxed`)
 
@@ -264,8 +293,9 @@ channel?**
 1. ✅ **Scaffold the workspace.** Done — pnpm + turbo workspace, dual CJS/ESM
    tsdown build, strict shared tsconfig, oxlint/oxfmt, knip, changesets, CI. The
    core `unthrown` package is split into focused modules, fully TSDoc'd, and
-   covered by a 108-test suite (100% line/function coverage). (Publishing the
-   names to npm remains a manual step.)
+   covered by a test suite held at 100% line/function coverage. (`unthrown`
+   and the `@unthrown` scope are published on npm; releases flow through the
+   changesets `release.yml`.)
 2. ✅ **`packages/core/src/tagged.ts`** — Done. `TaggedError(tag)` factory
    (extends `Error`, `_tag`, no-arg constructor when payload is empty via the
    `keyof A extends never ? void : A` trick) and `matchTags(result, handlers)`:

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -36,6 +36,13 @@ export default defineConfig({
     pageData.frontmatter ??= {};
     pageData.frontmatter.head ??= [];
 
+    // The /api/ pages (except the hand-written overview) are TypeDoc output copied
+    // in at build time — they have no source file in the repo, so "Edit this page"
+    // would 404. docs/api/index.md is the one committed file there.
+    if (pageData.relativePath.startsWith("api/") && pageData.relativePath !== "api/index.md") {
+      pageData.frontmatter.editLink = false;
+    }
+
     pageData.frontmatter.head.push(["link", { rel: "canonical", href: canonicalUrl }]);
 
     const pageTitle = pageData.title || pageData.frontmatter.title || "unthrown";
@@ -131,6 +138,10 @@ export default defineConfig({
     search: {
       provider: "local",
     },
+
+    // The single-page core API reference is a long scroll; surfacing h3s in the
+    // right-rail outline is what makes it navigable.
+    outline: { level: [2, 3] },
 
     editLink: {
       pattern: "https://github.com/btravstack/unthrown/edit/main/docs/:path",

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -110,6 +110,10 @@ export default defineConfig({
             { text: "Pattern Matching", link: "/guide/pattern-matching" },
             { text: "Linting", link: "/guide/linting" },
             { text: "Interop", link: "/guide/interop" },
+            {
+              text: "Validation (standard-schema)",
+              link: "/guide/interop#standard-schema-—-validators-as-results",
+            },
           ],
         },
       ],

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -79,6 +79,11 @@ export default defineConfig({
           items: [
             { text: "Why unthrown?", link: "/guide/why-unthrown" },
             { text: "Comparison", link: "/guide/comparison" },
+            {
+              text: "Migrating from neverthrow",
+              link: "/guide/migrating-from-neverthrow",
+            },
+            { text: "From try/catch", link: "/guide/from-try-catch" },
             { text: "Getting Started", link: "/guide/getting-started" },
             { text: "Core Concepts", link: "/guide/core-concepts" },
           ],

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -15,3 +15,18 @@ This reference is generated from the source with
   `toBeOkWith`, `toBeErr`, `toBeErrTagged`, `toBeDefect`).
 - [**@unthrown/pattern**](./pattern/) — thin `ts-pattern` sugar for the
   natively-matchable `Result` (`P.Ok`/`P.Err`/`P.Defect`, `tag`).
+- [**@unthrown/effect**](./effect/) — bijective `Result ↔ Exit` bridges
+  (Effect has a genuine defect channel, `Cause.die`), plus `toEither` with a
+  mandatory `onDefect`.
+- [**@unthrown/neverthrow**](./neverthrow/) — `to*`/`from*` bridges to
+  neverthrow's `Result`/`ResultAsync`; every `to*` takes a mandatory `onDefect`
+  (neverthrow has no defect channel).
+- [**@unthrown/boxed**](./boxed/) — `to*`/`from*` bridges to Boxed's
+  `Result`/`Future`; every `to*` takes a mandatory `onDefect`.
+- [**@unthrown/standard-schema**](./standard-schema/) — `fromSchema` /
+  `fromSchemaAsync`: run any Standard Schema validator (Zod, Valibot, ArkType)
+  into a `Result` with the validation issues as the modeled error.
+
+`@unthrown/oxlint` (the lint rules `no-ambiguous-error-type` and
+`prefer-async-result`) has no generated API page — it is documented in the
+[Linting guide](../guide/linting).

--- a/docs/guide/async-results.md
+++ b/docs/guide/async-results.md
@@ -55,4 +55,4 @@ The extra `fromPromise` is not ceremony — it is the forced triage decision tha
 guarantees the failure becomes a modeled error or a defect, never an untyped
 `unknown`.
 
-→ Continue to [Tagged Errors](./tagged-errors).
+→ Continue to [Do Notation](./do-notation).

--- a/docs/guide/async-results.md
+++ b/docs/guide/async-results.md
@@ -24,6 +24,10 @@ than a full `PromiseLike` — there is no rejection channel to model. It is stil
 thenable at runtime (that is how `await` collapses it), but it is deliberately
 not interchangeable with a raw promise.
 
+> `AsyncResult` deliberately has no `isOk` / `isErr` / `isDefect`: the state
+> isn't known until it settles. `await` it first — the guards live on the
+> `Result` you get back.
+
 ::: warning Eliminators still reject
 The async eliminators do throw when you ask them to: `await result.unwrap()`
 rejects on an `Err` or `Defect`, just like the synchronous `unwrap()`. It is the

--- a/docs/guide/boundaries.md
+++ b/docs/guide/boundaries.md
@@ -12,7 +12,7 @@ The sanctioned bridge for nullable values. `null` / `undefined` become a modeled
 ```ts
 import { fromNullable } from "unthrown";
 
-fromNullable(map.get(key), () => "missing").unwrap();
+fromNullable(map.get(key), () => "missing").unwrapOr(null);
 ```
 
 This is why `unthrown` ships no `Option` type — absence is expressed with the

--- a/docs/guide/boundaries.md
+++ b/docs/guide/boundaries.md
@@ -12,7 +12,10 @@ The sanctioned bridge for nullable values. `null` / `undefined` become a modeled
 ```ts
 import { fromNullable } from "unthrown";
 
-fromNullable(map.get(key), () => "missing").unwrapOr(null);
+const cache = new Map([["a", 1]]);
+
+fromNullable(cache.get("a"), () => "missing"); // Ok(1)
+fromNullable(cache.get("z"), () => "missing"); // Err("missing")
 ```
 
 This is why `unthrown` ships no `Option` type — absence is expressed with the

--- a/docs/guide/comparison.md
+++ b/docs/guide/comparison.md
@@ -87,4 +87,7 @@ unthrown's bet is narrow on purpose: the modeled-vs-defect split, qualification
 forced at boundaries, and a runtime that can't leak a raw throw — and nothing
 else. If those three are what you want, that's the whole library.
 
-→ Continue to [Getting Started](./getting-started).
+Coming from one of these? See [Migrating from neverthrow](./migrating-from-neverthrow)
+and [From try/catch](./from-try-catch).
+
+→ Continue to [Migrating from neverthrow](./migrating-from-neverthrow).

--- a/docs/guide/do-notation.md
+++ b/docs/guide/do-notation.md
@@ -68,4 +68,4 @@ const profile = await Do()
   .match({ ok: (s) => s, err: () => null, defect: () => null });
 ```
 
-→ Continue to [The Defect Channel](./the-defect-channel).
+→ Continue to [Choosing a Combinator](./choosing-a-combinator).

--- a/docs/guide/do-notation.md
+++ b/docs/guide/do-notation.md
@@ -68,4 +68,31 @@ const profile = await Do()
   .match({ ok: (s) => s, err: () => null, defect: () => null });
 ```
 
+## Why not a generator (`safeTry` / `gen`)?
+
+If you come from neverthrow's `safeTry` or Effect's `gen`, you may miss
+`yield*`-style flattening. The exclusion is deliberate:
+
+```ts
+// Generator style (not in unthrown):
+safeTry(function* () {
+  const user = yield* findUser(id);
+  const plan = yield* findPlan(user);
+  return Ok({ user, plan });
+});
+
+// unthrown's Do-notation — same flattening, no generator machinery:
+Do()
+  .bind("user", () => findUser(id))
+  .bind("plan", ({ user }) => findPlan(user));
+```
+
+The two are semantically equivalent for sequential code. What the generator
+buys — early `return` mid-block, `try`/`finally` around yields — comes at the
+cost of a second composition style, generator-transpilation overhead, and a
+`yield*` operator whose error-channel typing surprises people. One concept,
+one name: `bind` is the way to sequence dependent steps. If your chain is
+long enough that `Do` feels heavy, that is usually a sign the steps deserve
+named functions composed with `flatMap`.
+
 → Continue to [Choosing a Combinator](./choosing-a-combinator).

--- a/docs/guide/from-try-catch.md
+++ b/docs/guide/from-try-catch.md
@@ -1,0 +1,195 @@
+# From try/catch
+
+You don't need a design review to start using `unthrown` — wrap one function,
+see the shape at one call site, and stop there until it's obviously worth
+doing again.
+
+## The smallest possible migration
+
+Say you have a function that throws, called from a `try`/`catch`:
+
+```ts
+function parseConfig(text: string): Config {
+  return JSON.parse(text) as Config; // throws SyntaxError on bad input
+}
+
+function loadConfig(text: string): Config {
+  try {
+    return parseConfig(text);
+  } catch (cause) {
+    console.error("invalid config", cause);
+    return DEFAULT_CONFIG;
+  }
+}
+```
+
+Wrap the throwing function with `fromThrowable`. `qualify` decides which
+causes are modeled and which are bugs — here, a `SyntaxError` is expected;
+anything else is a defect:
+
+```ts
+import { fromThrowable } from "unthrown";
+
+const parseConfig = fromThrowable(
+  (text: string) => JSON.parse(text) as Config,
+  (cause, defect) => (cause instanceof SyntaxError ? ("invalid_json" as const) : defect(cause)),
+);
+// (text: string) => Result<Config, "invalid_json">
+```
+
+The call site drops its `try`/`catch` for a combinator:
+
+```ts
+function loadConfig(text: string): Config {
+  return parseConfig(text).unwrapOr(DEFAULT_CONFIG);
+}
+```
+
+The same move works for a rejecting promise. Before:
+
+```ts
+async function getUser(id: string): Promise<User> {
+  try {
+    const res = await fetch(`/api/users/${id}`);
+    if (!res.ok) throw new NotFoundError(id);
+    return (await res.json()) as User;
+  } catch (cause) {
+    console.error(cause);
+    throw cause; // rethrown — every caller still needs its own try/catch
+  }
+}
+```
+
+Wrap the promise with `fromPromise`:
+
+```ts
+import { fromPromise } from "unthrown";
+
+function getUser(id: string) {
+  return fromPromise(
+    fetch(`/api/users/${id}`).then((res) => {
+      if (!res.ok) throw new NotFoundError(id);
+      return res.json() as Promise<User>;
+    }),
+    (cause, defect) => (cause instanceof NotFoundError ? ("not_found" as const) : defect(cause)),
+  ); // AsyncResult<User, "not_found">
+}
+```
+
+And the call site becomes an ordinary `Result`, `await`ed once:
+
+```ts
+const user = await getUser(id); // Result<User, "not_found">
+user.match({
+  ok: (u) => render(u),
+  err: () => render404(),
+  defect: (cause) => render500(cause),
+});
+```
+
+## You don't have to convert the whole codebase
+
+`Result` composes at whatever boundary you choose to draw it — there's no
+requirement that every function up and down the call stack returns one.
+`unwrap()` exists precisely so you can re-enter throw-land at the edges you
+haven't converted yet, on purpose:
+
+```ts
+// Only the read is converted. Everything downstream still expects a plain
+// Config, or a thrown error — and that's fine, unwrap() is the deliberate seam.
+function loadConfig(text: string): Config {
+  return parseConfig(text).unwrap(); // throws UnwrapError("invalid_json") on bad input
+}
+```
+
+Convert the parts of the codebase where an untyped failure actually costs you
+something — a boundary you keep getting wrong, a `catch` block that silently
+swallows a bug. Leave the rest throwing until it earns the conversion. A
+`Result` two layers deep in a call chain that's `unwrap()`'d immediately by
+its only caller isn't buying you anything yet.
+
+## `try`/`catch` idioms → combinators
+
+Once you've wrapped a boundary, most of what you used to do inside a `catch`
+block has a direct combinator equivalent:
+
+| `try`/`catch` idiom       | unthrown combinator                             | Example                                               |
+| ------------------------- | ----------------------------------------------- | ----------------------------------------------------- |
+| catch-and-default         | `unwrapOr(fallback)`                            | `parseConfig(text).unwrapOr(DEFAULT_CONFIG)`          |
+| catch-and-rethrow-wrapped | `mapErr(f)`                                     | `parseConfig(text).mapErr((e) => new ConfigError(e))` |
+| catch-log-rethrow         | `tapErr(f)`                                     | `parseConfig(text).tapErr((e) => logger.warn(e))`     |
+| `finally` cleanup         | run before eliminating, or in every `match` arm | see below                                             |
+
+`catch-and-default`:
+
+```ts
+// before
+try {
+  return parseConfig(text);
+} catch {
+  return DEFAULT_CONFIG;
+}
+// after
+parseConfig(text).unwrapOr(DEFAULT_CONFIG);
+```
+
+`catch-and-rethrow-wrapped`:
+
+```ts
+// before
+try {
+  return parseConfig(text);
+} catch (cause) {
+  throw new ConfigError(cause);
+}
+// after — ConfigError becomes a modeled Err, not a throw
+parseConfig(text).mapErr((e) => new ConfigError(e));
+```
+
+`catch-log-rethrow`:
+
+```ts
+// before
+try {
+  return parseConfig(text);
+} catch (cause) {
+  logger.warn("bad config", cause);
+  throw cause;
+}
+// after — logs, keeps the original error, still propagates as an Err
+parseConfig(text).tapErr((e) => logger.warn("bad config", e));
+```
+
+`finally` has no combinator counterpart, because a `Result` pipeline has no
+single point that always runs on the way out — `Ok`, `Err`, and `Defect` can
+each take a different path through the chain. Do the cleanup either
+**unconditionally before** the pipeline reaches a combinator that could
+short-circuit, or **inside every arm** of the terminal `match`:
+
+```ts
+const connection = openConnection();
+try {
+  return parseConfig(text).map((c) => apply(connection, c));
+} finally {
+  connection.close();
+}
+
+// after — one exit point still closes the connection on every channel
+const result = parseConfig(text).map((c) => apply(connection, c));
+result.match({
+  ok: (v) => {
+    connection.close();
+    return v;
+  },
+  err: (e) => {
+    connection.close();
+    return handleErr(e);
+  },
+  defect: (cause) => {
+    connection.close();
+    throw cause; // still a bug — let it bubble after cleanup
+  },
+});
+```
+
+→ Continue to [Core Concepts](./core-concepts).

--- a/docs/guide/interop.md
+++ b/docs/guide/interop.md
@@ -47,7 +47,11 @@ toExit(Err("e")); // Exit.fail("e")  — a modeled Cause.fail
 // a Defect would become Exit.die(cause)
 
 // Run an Effect and collect its outcome; a die/interrupt becomes a Defect:
-await fromEffect(Effect.succeed(1)).match({ ok, err, defect: String });
+await fromEffect(Effect.succeed(1)).match({
+  ok: (value) => value,
+  err: (error) => error,
+  defect: String,
+});
 ```
 
 `toEffect` also accepts an `AsyncResult` (the `AsyncResult → Effect` direction),

--- a/docs/guide/linting.md
+++ b/docs/guide/linting.md
@@ -36,7 +36,10 @@ rule keeps them out.
 
 Prefer `AsyncResult<T, E>` over `Promise<Result<T, E>>`. A raw `Promise<Result>`
 can still **reject**, reintroducing the throw channel that `AsyncResult` is
-designed to eliminate. Autofixable.
+designed to eliminate. Autofixable — except on an `async` function's return-type
+annotation, where the rule reports without a fix (an `async` function must
+return a native `Promise`, so rewriting the annotation to `AsyncResult<…>` would
+not compile).
 
 ```ts
 type Slow = Promise<Result<User, NotFound>>; // ✗ → AsyncResult<User, NotFound>

--- a/docs/guide/migrating-from-neverthrow.md
+++ b/docs/guide/migrating-from-neverthrow.md
@@ -33,18 +33,20 @@ do-notation). The rest of the table is where the libraries genuinely differ.
 ### 1. The defect channel
 
 In neverthrow, a throw inside `.map` (or a bug that slips past `mapErr`)
-escapes as a real exception — and an async one can reject the underlying
+escapes as a real exception — and an async one rejects the underlying
 `ResultAsync`. neverthrow's own `_unsafeUnwrap()` is the sharpest version of the
-same gap: it's a documented escape hatch that throws on an `Err`, so one bad
-call site turns a typed `Result` back into an uncaught exception. In practice
-this means every handler still needs a `try`/`catch` as a backstop for
-whatever `mapErr` didn't anticipate — the type says "handled," the runtime
-doesn't fully agree.
+same gap: it's a documented escape hatch that throws on an `Err` (neverthrow
+itself documents it as intended for tests, not production code), yet one bad
+call site in production turns a typed `Result` back into an uncaught exception.
+In practice this means every handler still needs a `try`/`catch` as a backstop
+for whatever the pipeline didn't anticipate — the type says "handled," the
+runtime doesn't fully agree.
 
-In unthrown, a throw inside any combinator becomes a `Defect` instead — a third
-state, not part of `E`, that flows to `match`'s mandatory `defect` arm. The
-handler doesn't need a backstop, because there's no path left for something to
-escape uncaught.
+In unthrown, a throw inside any **combinator** (`.map`, `.flatMap`, `mapErr`,
+…) becomes a `Defect` instead — a third state, not part of `E`, that flows down
+the pipeline and arrives at `match`'s mandatory `defect` arm. So the
+`try`/`catch` around the pipeline goes away: nothing a pipeline step throws can
+escape it as a raw exception.
 
 ```ts
 // neverthrow — a try/catch backstop is load-bearing, not defensive fluff
@@ -56,13 +58,13 @@ function getUser(id: string): ResultAsync<User, NotFoundError> {
 
 app.get("/users/:id", async (req, res) => {
   try {
-    const result = await getUser(req.params.id);
+    const result = await getUser(req.params.id).map((user) => formatUser(user)); // a bug in formatUser rejects the ResultAsync
     result.match(
-      (user) => res.status(200).json(formatUser(user)), // a typo here (formatUesr) throws
+      (view) => res.status(200).json(view),
       (error) => res.status(404).json({ error: error.message }),
     );
   } catch (cause) {
-    // catches the typo above, and anything getUser's mapErr didn't triage —
+    // catches the formatUser bug, and anything else the pipeline let escape —
     // neverthrow has one bucket for "everything else that went wrong"
     console.error(cause);
     res.status(500).json({ error: "internal error" });
@@ -71,7 +73,8 @@ app.get("/users/:id", async (req, res) => {
 ```
 
 ```ts
-// unthrown — the same typo becomes a Defect; no surrounding try/catch
+// unthrown — the same bug becomes a Defect inside the pipeline;
+// no try/catch around it
 import { fromPromise } from "unthrown";
 
 function getUser(id: string) {
@@ -81,20 +84,24 @@ function getUser(id: string) {
 }
 
 app.get("/users/:id", async (req, res) => {
-  const result = await getUser(req.params.id);
-  await result.match({
-    ok: (user) => res.status(200).json(formatUser(user)), // a typo here → Defect, not an uncaught throw
+  const result = await getUser(req.params.id).map((user) => formatUser(user)); // a bug in formatUser → Defect
+  result.match({
+    ok: (view) => res.status(200).json(view),
     err: () => res.status(404).json({ error: "not found" }),
     defect: (cause) => {
-      console.error(cause); // everything unexpected lands here, and only here
+      console.error(cause); // everything the pipeline caught lands here
       res.status(500).json({ error: "internal error" });
     },
   });
 });
 ```
 
-Same handler, same failure mode — but the unthrown version has no `try`/`catch`
-because there's nothing left that can throw past it.
+Same handler, same failure mode — but the unthrown version needs no
+`try`/`catch` around the pipeline, because every combinator converts a throw
+into a `Defect` that arrives at `match`'s `defect` arm. One precise caveat: the
+containment covers the **combinators**, not `match`'s own callbacks — `match`
+invokes your handlers directly, so keep them trivial edge code (send the
+response, log) and put anything failable in a pipeline step above.
 
 ### 2. `qualify` replaces the error mapper
 

--- a/docs/guide/migrating-from-neverthrow.md
+++ b/docs/guide/migrating-from-neverthrow.md
@@ -1,0 +1,126 @@
+# Migrating from neverthrow
+
+Both libraries return failures as values instead of throwing them. Most of the
+API maps one-to-one — the same shape, a different name here and there. The
+migration is mechanical for 90% of your code; the other 10% is where the two
+libraries actually disagree, and that's worth doing on purpose rather than by
+search-and-replace.
+
+## API mapping
+
+| neverthrow                           | unthrown                     | Notes                                                               |
+| ------------------------------------ | ---------------------------- | ------------------------------------------------------------------- |
+| `ok(v)` / `err(e)`                   | `Ok(v)` / `Err(e)`           | constructors are capitalized                                        |
+| `result.andThen(f)`                  | `result.flatMap(f)`          | one name per concept                                                |
+| `result.map(f)` / `mapErr(f)`        | same                         | callbacks must be synchronous                                       |
+| `result.orElse(f)`                   | `orElse(f)`                  | same shape                                                          |
+| `result.match(okFn, errFn)`          | `match({ ok, err, defect })` | the third channel is new — see below                                |
+| `result.unwrapOr(v)`                 | `unwrapOr(v)`                | still throws on a Defect (a bug is not an absent value)             |
+| `ResultAsync`                        | `AsyncResult`                | `await` collapses it to a `Result`; it never rejects                |
+| `ResultAsync.fromPromise(p, mapErr)` | `fromPromise(p, qualify)`    | `qualify` must return `E` **or** `defect(cause)` — triage is forced |
+| `ResultAsync.fromSafePromise(p)`     | `fromSafePromise(p)`         | a rejection becomes a `Defect`, not an `Err`                        |
+| `Result.combine([...])`              | `all([...])`                 | any `Defect` dominates                                              |
+| `Result.combineWithAllErrors`        | —                            | error accumulation is deliberately excluded                         |
+| `safeTry(function* …)`               | `Do().bind(…).let(…)`        | see [Do Notation](./do-notation#why-not-a-generator-safetry-gen)    |
+| `fromThrowable(fn, mapErr)`          | `fromThrowable(fn, qualify)` | same idea, plus the defect arm                                      |
+
+Most rows are a rename. `andThen` → `flatMap` is unthrown's one-name-per-concept
+rule (`flatMap` is what the operation actually is — no `chain`, no `bind` outside
+do-notation). The rest of the table is where the libraries genuinely differ.
+
+## The two real deltas
+
+### 1. The defect channel
+
+In neverthrow, a throw inside `.map` (or a bug that slips past `mapErr`)
+escapes as a real exception — and an async one can reject the underlying
+`ResultAsync`. neverthrow's own `_unsafeUnwrap()` is the sharpest version of the
+same gap: it's a documented escape hatch that throws on an `Err`, so one bad
+call site turns a typed `Result` back into an uncaught exception. In practice
+this means every handler still needs a `try`/`catch` as a backstop for
+whatever `mapErr` didn't anticipate — the type says "handled," the runtime
+doesn't fully agree.
+
+In unthrown, a throw inside any combinator becomes a `Defect` instead — a third
+state, not part of `E`, that flows to `match`'s mandatory `defect` arm. The
+handler doesn't need a backstop, because there's no path left for something to
+escape uncaught.
+
+```ts
+// neverthrow — a try/catch backstop is load-bearing, not defensive fluff
+import { ResultAsync } from "neverthrow";
+
+function getUser(id: string): ResultAsync<User, NotFoundError> {
+  return ResultAsync.fromPromise(fetchUser(id), (cause) => new NotFoundError(String(cause)));
+}
+
+app.get("/users/:id", async (req, res) => {
+  try {
+    const result = await getUser(req.params.id);
+    result.match(
+      (user) => res.status(200).json(formatUser(user)), // a typo here (formatUesr) throws
+      (error) => res.status(404).json({ error: error.message }),
+    );
+  } catch (cause) {
+    // catches the typo above, and anything getUser's mapErr didn't triage —
+    // neverthrow has one bucket for "everything else that went wrong"
+    console.error(cause);
+    res.status(500).json({ error: "internal error" });
+  }
+});
+```
+
+```ts
+// unthrown — the same typo becomes a Defect; no surrounding try/catch
+import { fromPromise } from "unthrown";
+
+function getUser(id: string) {
+  return fromPromise(fetchUser(id), (cause, defect) =>
+    cause instanceof NotFoundError ? ("not_found" as const) : defect(cause),
+  ); // AsyncResult<User, "not_found">
+}
+
+app.get("/users/:id", async (req, res) => {
+  const result = await getUser(req.params.id);
+  await result.match({
+    ok: (user) => res.status(200).json(formatUser(user)), // a typo here → Defect, not an uncaught throw
+    err: () => res.status(404).json({ error: "not found" }),
+    defect: (cause) => {
+      console.error(cause); // everything unexpected lands here, and only here
+      res.status(500).json({ error: "internal error" });
+    },
+  });
+});
+```
+
+Same handler, same failure mode — but the unthrown version has no `try`/`catch`
+because there's nothing left that can throw past it.
+
+### 2. `qualify` replaces the error mapper
+
+neverthrow's `fromPromise` maps _every_ rejection into `E` — the mapper is
+total, and has no way to say "actually, this one is a bug, not a domain
+error." unthrown's `qualify` makes you decide, per cause, which bucket it goes
+in. The mechanical rewrite is:
+
+```ts
+(e) => toE(e)
+// becomes
+(cause, defect) => (isExpected(cause) ? toE(cause) : defect(cause))
+```
+
+If every cause your old mapper handled really was expected, this is a
+one-line change. If some of them were "whatever, stick it in `E` and move on,"
+that's exactly the code smell the defect channel exists to surface — route
+those through `defect(cause)` instead.
+
+## What you can delete after migrating
+
+- the eslint `must-use-result` setup (the `@unthrown/oxlint` rules cover the
+  equivalent surface — see [Linting](./linting));
+- defensive `try`/`catch` around combinator chains — the defect channel is
+  the backstop now;
+- any `E = unknown` / `E = Error` unions that existed to absorb "everything
+  else" — that is the defect channel's job now.
+
+→ Continue to [Getting Started](./getting-started).

--- a/docs/guide/recipes.md
+++ b/docs/guide/recipes.md
@@ -126,6 +126,106 @@ const status = matchTags(result, {
 });
 ```
 
+## 6. An HTTP route end-to-end (Hono)
+
+A complete route, no `try`/`catch` anywhere: `fromSchema` validates the path
+param, `flatMap` feeds the parsed id into a repository call that returns its
+own `AsyncResult`, and `matchTags` folds every tag straight to a status code.
+A throw in `mapErr`'s callback or inside the repository call is caught by that
+combinator and becomes a `Defect` — the same containment as recipe 1 — so a
+bug in any pipeline step surfaces as the `Defect` arm's 500, never an unhandled
+exception:
+
+```ts
+import { Hono } from "hono";
+import { z } from "zod";
+import { fromSchema } from "@unthrown/standard-schema";
+import { matchTags, TaggedError, type AsyncResult } from "unthrown";
+
+class InvalidId extends TaggedError("InvalidId") {}
+
+type User = { id: string; name: string };
+
+// The repository is its own boundary (see recipe 2) — it already hands back a
+// qualified `AsyncResult`, so there's nothing left to triage at the call site.
+declare const userRepo: { findById(id: string): AsyncResult<User, NotFound> };
+
+const parseId = fromSchema(z.string().uuid());
+
+const app = new Hono();
+
+app.get("/users/:id", (c) => {
+  const user = parseId(c.req.param("id"))
+    .mapErr(() => new InvalidId())
+    .toAsync()
+    .flatMap((id) => userRepo.findById(id));
+  // AsyncResult<User, InvalidId | NotFound>
+
+  return matchTags(user, {
+    Ok: (u) => c.json(u, 200),
+    InvalidId: () => c.json({ error: "invalid id" }, 400),
+    NotFound: (e) => c.json({ error: `no user ${e.id}` }, 404),
+    Defect: (cause) => {
+      logger.error(cause); // a real bug — log it, don't leak it
+      return c.json({ error: "Internal Error" }, 500);
+    },
+  });
+});
+```
+
+`matchTags` accepts an `AsyncResult` directly and resolves to a `Promise` —
+Hono awaits whatever the handler returns, so there's no manual `await` to
+remember.
+
+## 7. Form validation with Standard Schema
+
+`fromSchema` turns any [Standard Schema](https://standardschema.dev) validator
+(Zod, Valibot, ArkType, …) into a function returning a `Result` whose error is
+the validator's own **issues array** — not the schema library's exception
+type. Map that array to per-field messages in the `err` arm:
+
+```ts
+import { z } from "zod";
+import { fromSchema, type SchemaIssues } from "@unthrown/standard-schema";
+
+const signupSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+});
+
+const parseSignup = fromSchema(signupSchema);
+
+const fieldOf = (issue: SchemaIssues[number]) => {
+  const segment = issue.path?.[0];
+  const key = typeof segment === "object" ? segment.key : segment;
+  return key === undefined ? "_form" : String(key);
+};
+
+function validateSignup(input: unknown) {
+  return parseSignup(input).match({
+    ok: (data) => ({ ok: true as const, data }),
+    err: (issues) => ({
+      ok: false as const,
+      fieldErrors: issues.reduce<Record<string, string[]>>((byField, issue) => {
+        const field = fieldOf(issue);
+        (byField[field] ??= []).push(issue.message);
+        return byField;
+      }, {}),
+    }),
+    defect: (cause) => {
+      logger.error(cause); // the validator itself threw — a real bug, not a bad form
+      return { ok: false as const, fieldErrors: { _form: ["Something went wrong."] } };
+    },
+  });
+}
+
+validateSignup({ email: "not-an-email", password: "short" });
+// { ok: false, fieldErrors: { email: [...], password: [...] } }
+```
+
+The `defect` arm only fires if the schema itself throws instead of returning
+issues — a bug in the validator, not a bad submission.
+
 → Back to the [Guide](./why-unthrown), or browse the
 [API Reference](/api/core/).
 

--- a/docs/guide/recipes.md
+++ b/docs/guide/recipes.md
@@ -128,3 +128,5 @@ const status = matchTags(result, {
 
 → Back to the [Guide](./why-unthrown), or browse the
 [API Reference](/api/core/).
+
+→ Continue to [Tagged Errors](./tagged-errors).

--- a/docs/guide/recipes.md
+++ b/docs/guide/recipes.md
@@ -150,7 +150,7 @@ type User = { id: string; name: string };
 // qualified `AsyncResult`, so there's nothing left to triage at the call site.
 declare const userRepo: { findById(id: string): AsyncResult<User, NotFound> };
 
-const parseId = fromSchema(z.string().uuid());
+const parseId = fromSchema(z.uuid());
 
 const app = new Hono();
 
@@ -189,7 +189,7 @@ import { z } from "zod";
 import { fromSchema, type SchemaIssues } from "@unthrown/standard-schema";
 
 const signupSchema = z.object({
-  email: z.string().email(),
+  email: z.email(),
   password: z.string().min(8),
 });
 
@@ -225,8 +225,5 @@ validateSignup({ email: "not-an-email", password: "short" });
 
 The `defect` arm only fires if the schema itself throws instead of returning
 issues — a bug in the validator, not a bad submission.
-
-→ Back to the [Guide](./why-unthrown), or browse the
-[API Reference](/api/core/).
 
 → Continue to [Tagged Errors](./tagged-errors).

--- a/docs/guide/why-unthrown.md
+++ b/docs/guide/why-unthrown.md
@@ -100,4 +100,4 @@ modeled errors — and ships just that, in a library small enough to be _done_.
 For a feature-by-feature table across all of these, see
 [Comparison](./comparison).
 
-→ Continue to [Getting Started](./getting-started).
+→ Continue to [Comparison](./comparison).

--- a/docs/guide/why-unthrown.md
+++ b/docs/guide/why-unthrown.md
@@ -17,6 +17,20 @@ returning a `Result<T, E>` so failures are part of the type.
 
 But most of them stop there, and that leaves a gap.
 
+```ts
+// Before: the signature hides every failure — and a bug in a callback
+// escapes as a runtime exception three layers up.
+function getUser(id: string): User; // throws NotFoundError? TimeoutError? TypeError?
+
+// After: anticipated failures are in the type; a thrown bug becomes a
+// Defect that can't masquerade as either.
+function getUser(id: string): Result<User, NotFound | Timeout>;
+
+getUser(id)
+  .map((u) => u.emial.trim()) // typo — TypeError → Defect, NOT an Err
+  .match({ ok: render, err: showMessage, defect: report500 });
+```
+
 ## The gap: unexpected failures
 
 There are really **two** kinds of failure:

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,8 +49,9 @@ function findUser(id: string): Result<User, NotFound> {
 }
 
 // Cross an async boundary — every rejection MUST be triaged.
-const profile = fromPromise(fetch(`/u/${id}`), (cause, defect) =>
-  cause instanceof Response ? new NotFound() : defect(cause),
+// (db.loadProfile rejects with MissingRowError when there is no row.)
+const profile = fromPromise(db.loadProfile(id), (cause, defect) =>
+  cause instanceof MissingRowError ? new NotFound() : defect(cause),
 );
 
 // Handle every channel once, at the edge — no surrounding try/catch.

--- a/packages/boxed/LICENSE
+++ b/packages/boxed/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Benoit Travers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/boxed/README.md
+++ b/packages/boxed/README.md
@@ -37,4 +37,4 @@ fromBoxed(Result.Ok(1)); // Result<number, never>
 
 ## License
 
-[MIT](../../LICENSE) © Benoit TRAVERS
+[MIT](https://github.com/btravstack/unthrown/blob/main/LICENSE) © Benoit TRAVERS

--- a/packages/boxed/package.json
+++ b/packages/boxed/package.json
@@ -23,14 +23,13 @@
     "directory": "packages/boxed"
   },
   "files": [
-    "dist",
-    "docs"
+    "dist"
   ],
   "type": "module",
   "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.mts",
+  "types": "./dist/index.d.cts",
   "exports": {
     ".": {
       "import": {
@@ -52,7 +51,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "unthrown": "workspace:*"
+    "unthrown": "workspace:^"
   },
   "devDependencies": {
     "@bloodyowl/boxed": "catalog:",
@@ -70,6 +69,6 @@
     "@bloodyowl/boxed": "^3"
   },
   "engines": {
-    "node": ">=22.19"
+    "node": ">=20"
   }
 }

--- a/packages/boxed/src/index.spec.ts
+++ b/packages/boxed/src/index.spec.ts
@@ -63,6 +63,49 @@ describe("toBoxedFuture", () => {
       globalThis.queueMicrotask = original;
     }
   });
+
+  it("does not intercept a downstream subscriber's throw as an onDefect bug", async () => {
+    const subscriberBoom = new Error("subscriber-threw");
+    const rethrown: unknown[] = [];
+    const originalQueue = globalThis.queueMicrotask;
+    globalThis.queueMicrotask = (cb: () => void) => {
+      try {
+        cb();
+      } catch (e) {
+        rethrown.push(e);
+      }
+    };
+    // The subscriber throw escapes through Boxed's synchronous fan-out into
+    // toBoxedFuture's internal (void-ed) promise chain — contain that
+    // unhandled rejection so it doesn't fail the run, and restore vitest's
+    // own listeners afterwards.
+    const unhandled: unknown[] = [];
+    const priorListeners = process.listeners("unhandledRejection");
+    process.removeAllListeners("unhandledRejection");
+    process.on("unhandledRejection", (reason) => {
+      unhandled.push(reason);
+    });
+    try {
+      const defect = fromSafePromise(Promise.reject(new Error("bug")));
+      const future = toBoxedFuture(defect, () => "triaged");
+      future.tap(() => {
+        throw subscriberBoom;
+      });
+      await new Promise((r) => setTimeout(r, 0));
+      // Our handler must not reroute the subscriber throw...
+      expect(rethrown).toEqual([]);
+      // ...it surfaces through the promise machinery (Boxed's pre-existing
+      // behaviour), and the Future still resolved.
+      expect(unhandled).toEqual([subscriberBoom]);
+      expect((await future.toPromise()).isError()).toBe(true);
+    } finally {
+      process.removeAllListeners("unhandledRejection");
+      for (const listener of priorListeners) {
+        process.on("unhandledRejection", listener);
+      }
+      globalThis.queueMicrotask = originalQueue;
+    }
+  });
 });
 
 describe("fromBoxedFuture", () => {

--- a/packages/boxed/src/index.spec.ts
+++ b/packages/boxed/src/index.spec.ts
@@ -1,5 +1,5 @@
 import { Future, Result as BoxedResult } from "@bloodyowl/boxed";
-import { Err, Ok, type Result } from "unthrown";
+import { Err, fromSafePromise, Ok, type Result } from "unthrown";
 import { describe, expect, it } from "vitest";
 
 import { fromBoxed, fromBoxedFuture, toBoxed, toBoxedFuture } from "./index.js";
@@ -39,6 +39,29 @@ describe("toBoxedFuture", () => {
       (cause) => `bug:${String(cause)}`,
     ).toPromise();
     expect(defR.isError() && defR.getError()).toBe(`bug:${String(boom)}`);
+  });
+
+  it("surfaces a throwing onDefect out-of-band instead of hanging the Future", async () => {
+    const boomDefect = new Error("onDefect-threw");
+    const rethrown: unknown[] = [];
+    const original = globalThis.queueMicrotask;
+    globalThis.queueMicrotask = (cb: () => void) => {
+      try {
+        cb();
+      } catch (e) {
+        rethrown.push(e);
+      }
+    };
+    try {
+      const defect = fromSafePromise(Promise.reject(new Error("bug")));
+      toBoxedFuture(defect, () => {
+        throw boomDefect;
+      });
+      await new Promise((r) => setTimeout(r, 0));
+      expect(rethrown).toEqual([boomDefect]);
+    } finally {
+      globalThis.queueMicrotask = original;
+    }
   });
 });
 

--- a/packages/boxed/src/index.ts
+++ b/packages/boxed/src/index.ts
@@ -83,8 +83,9 @@ export function toBoxedFuture<T, E>(
 ): Future<BoxedResult<T, E>> {
   return Future.make<BoxedResult<T, E>>((resolve) => {
     void settle(asyncResult).then((result) => {
+      let boxed: BoxedResult<T, E>;
       try {
-        resolve(toBoxed(result, onDefect));
+        boxed = toBoxed(result, onDefect);
       } catch (cause) {
         // A throwing onDefect is a bug in the caller's triage. Swallowing it
         // would leave the Future pending forever; rethrow out-of-band so it
@@ -92,7 +93,12 @@ export function toBoxedFuture<T, E>(
         queueMicrotask(() => {
           throw cause;
         });
+        return;
       }
+      // Deliberately outside the try: `resolve` fans out synchronously to the
+      // Future's subscribers, and a subscriber's throw is Boxed's failure to
+      // surface, not an onDefect bug for us to reroute.
+      resolve(boxed);
     });
   });
 }

--- a/packages/boxed/src/index.ts
+++ b/packages/boxed/src/index.ts
@@ -29,6 +29,16 @@ import type { AsyncResult, Result } from "unthrown";
  * @typeParam E - the modeled error type.
  * @param result - the result to convert.
  * @param onDefect - folds a Defect's unknown cause into a modeled `E`.
+ *
+ * @example
+ * ```ts
+ * import { Err } from "unthrown";
+ * import { toBoxed } from "@unthrown/boxed";
+ *
+ * // A Defect has no home in Boxed's Result — you must fold it into E:
+ * const boxed = toBoxed(Err("nope"), (cause) => `bug: ${String(cause)}`);
+ * boxed.isError(); // => true
+ * ```
  */
 export function toBoxed<T, E>(
   result: Result<T, E>,
@@ -51,6 +61,15 @@ export function toBoxed<T, E>(
  * @typeParam T - the success value type.
  * @typeParam E - the modeled error type.
  * @param result - the Boxed result to convert.
+ *
+ * @example
+ * ```ts
+ * import { Result as BoxedResult } from "@bloodyowl/boxed";
+ * import { fromBoxed } from "@unthrown/boxed";
+ *
+ * const result = fromBoxed(BoxedResult.Ok(1));
+ * result.isOk(); // => true
+ * ```
  */
 export function fromBoxed<T, E>(result: BoxedResult<T, E>): Result<T, E> {
   return result.match({
@@ -76,6 +95,16 @@ export function fromBoxed<T, E>(result: BoxedResult<T, E>): Result<T, E> {
  * @typeParam E - the modeled error type.
  * @param asyncResult - the async result to convert.
  * @param onDefect - folds a Defect's unknown cause into a modeled `E`.
+ *
+ * @example
+ * ```ts
+ * import { fromSafePromise } from "unthrown";
+ * import { toBoxedFuture } from "@unthrown/boxed";
+ *
+ * const asyncResult = fromSafePromise(Promise.resolve(1));
+ * const future = toBoxedFuture(asyncResult, (cause) => `bug: ${String(cause)}`);
+ * (await future.toPromise()).isOk(); // => true
+ * ```
  */
 export function toBoxedFuture<T, E>(
   asyncResult: AsyncResult<T, E>,
@@ -117,6 +146,15 @@ export function toBoxedFuture<T, E>(
  * @typeParam T - the success value type.
  * @typeParam E - the modeled error type.
  * @param future - the Boxed future to convert.
+ *
+ * @example
+ * ```ts
+ * import { Future, Result as BoxedResult } from "@bloodyowl/boxed";
+ * import { fromBoxedFuture } from "@unthrown/boxed";
+ *
+ * const result = await fromBoxedFuture(Future.value(BoxedResult.Ok(1)));
+ * result.isOk(); // => true
+ * ```
  */
 export function fromBoxedFuture<T, E>(future: Future<BoxedResult<T, E>>): AsyncResult<T, E> {
   return fromSafePromise(future.toPromise()).flatMap((result) => fromBoxed(result));

--- a/packages/boxed/src/index.ts
+++ b/packages/boxed/src/index.ts
@@ -32,12 +32,15 @@ import type { AsyncResult, Result } from "unthrown";
  *
  * @example
  * ```ts
- * import { Err } from "unthrown";
+ * import { fromThrowable } from "unthrown";
  * import { toBoxed } from "@unthrown/boxed";
  *
- * // A Defect has no home in Boxed's Result — you must fold it into E:
- * const boxed = toBoxed(Err("nope"), (cause) => `bug: ${String(cause)}`);
- * boxed.isError(); // => true
+ * // Mint a Defect, then convert: it has no home in Boxed's Result, so onDefect folds it into E.
+ * const defective = fromThrowable((): number => {
+ *   throw new Error("boom");
+ * }, (cause, defect) => defect(cause))();
+ * const boxed = toBoxed(defective, (cause) => `bug: ${String(cause)}`);
+ * boxed.isError(); // => true — the Error carries "bug: Error: boom"
  * ```
  */
 export function toBoxed<T, E>(
@@ -101,9 +104,10 @@ export function fromBoxed<T, E>(result: BoxedResult<T, E>): Result<T, E> {
  * import { fromSafePromise } from "unthrown";
  * import { toBoxedFuture } from "@unthrown/boxed";
  *
- * const asyncResult = fromSafePromise(Promise.resolve(1));
- * const future = toBoxedFuture(asyncResult, (cause) => `bug: ${String(cause)}`);
- * (await future.toPromise()).isOk(); // => true
+ * // A rejection inside fromSafePromise is a Defect; onDefect folds it into E on the way out.
+ * const defective = fromSafePromise(Promise.reject(new Error("boom")));
+ * const future = toBoxedFuture(defective, (cause) => `bug: ${String(cause)}`);
+ * (await future.toPromise()).isError(); // => true — the Error carries "bug: Error: boom"
  * ```
  */
 export function toBoxedFuture<T, E>(

--- a/packages/boxed/src/index.ts
+++ b/packages/boxed/src/index.ts
@@ -68,6 +68,10 @@ export function fromBoxed<T, E>(result: BoxedResult<T, E>): Result<T, E> {
  * reason. The `AsyncResult` is awaited (it never rejects) and its settled
  * `Result` is converted, then resolved into the `Future`.
  *
+ * `onDefect` must not throw: Boxed's `Future` has no failure channel, so a
+ * throw is re-raised out-of-band (uncaught) rather than left as a hung
+ * `Future`.
+ *
  * @typeParam T - the success value type.
  * @typeParam E - the modeled error type.
  * @param asyncResult - the async result to convert.
@@ -79,7 +83,16 @@ export function toBoxedFuture<T, E>(
 ): Future<BoxedResult<T, E>> {
   return Future.make<BoxedResult<T, E>>((resolve) => {
     void settle(asyncResult).then((result) => {
-      resolve(toBoxed(result, onDefect));
+      try {
+        resolve(toBoxed(result, onDefect));
+      } catch (cause) {
+        // A throwing onDefect is a bug in the caller's triage. Swallowing it
+        // would leave the Future pending forever; rethrow out-of-band so it
+        // surfaces as an uncaught error instead of a silent hang.
+        queueMicrotask(() => {
+          throw cause;
+        });
+      }
     });
   });
 }

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Benoit Travers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -40,4 +40,4 @@ and complete API.
 
 ## License
 
-[MIT](../../LICENSE) © Benoit TRAVERS
+[MIT](https://github.com/btravstack/unthrown/blob/main/LICENSE) © Benoit TRAVERS

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,14 +25,13 @@
     "directory": "packages/core"
   },
   "files": [
-    "dist",
-    "docs"
+    "dist"
   ],
   "type": "module",
   "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.mts",
+  "types": "./dist/index.d.cts",
   "exports": {
     ".": {
       "import": {
@@ -66,6 +65,6 @@
     "vitest": "catalog:"
   },
   "engines": {
-    "node": ">=22.19"
+    "node": ">=20"
   }
 }

--- a/packages/core/src/async-result.spec.ts
+++ b/packages/core/src/async-result.spec.ts
@@ -182,6 +182,29 @@ describe("AsyncResult error channel", () => {
     expect((await asyncDefect().flatTapErr(f)).isDefect()).toBe(true);
     expect(f).not.toHaveBeenCalled();
   });
+
+  it("tapErr: a throwing callback preserves the original error in an AggregateError", async () => {
+    const thrown = new Error("boom");
+    const r = await asyncErr("original").tapErr(() => {
+      throw thrown;
+    });
+    expect(r.tag).toBe("Defect");
+    if (r.isDefect()) {
+      expect(r.cause).toBeInstanceOf(AggregateError);
+      expect((r.cause as AggregateError).errors).toEqual([thrown, "original"]);
+    }
+  });
+
+  it("flatTapErr: a throwing callback preserves the original error in an AggregateError", async () => {
+    const thrown = new Error("boom");
+    const r = await asyncErr("original").flatTapErr(() => {
+      throw thrown;
+    });
+    expect(r.tag).toBe("Defect");
+    if (r.isDefect()) {
+      expect((r.cause as AggregateError).errors).toEqual([thrown, "original"]);
+    }
+  });
 });
 
 describe("AsyncResult Defect channel", () => {
@@ -203,6 +226,18 @@ describe("AsyncResult Defect channel", () => {
     const r = await asyncDefect().tapDefect((c) => seen.push(c));
     expect(seen).toEqual([boom]);
     expect(r.isDefect()).toBe(true);
+  });
+
+  it("tapDefect: a throwing callback preserves the original cause in an AggregateError", async () => {
+    const original = new Error("original-bug");
+    const thrown = new Error("logger-failed");
+    const r = await fromSafePromise(Promise.reject(original)).tapDefect(() => {
+      throw thrown;
+    });
+    expect(r.tag).toBe("Defect");
+    if (r.isDefect()) {
+      expect((r.cause as AggregateError).errors).toEqual([thrown, original]);
+    }
   });
 });
 

--- a/packages/core/src/async-result.spec.ts
+++ b/packages/core/src/async-result.spec.ts
@@ -279,4 +279,18 @@ describe("AsyncResult eliminators", () => {
     await expect(asyncDefect().getOrNull()).rejects.toBe(boom);
     await expect(asyncDefect().getOrUndefined()).rejects.toBe(boom);
   });
+
+  it("Promise.all adopts AsyncResults, settling to Results", async () => {
+    const [a, b] = await Promise.all([Ok(1).toAsync(), Err("e").toAsync()]);
+    expect(a!.tag).toBe("Ok");
+    expect(b!.tag).toBe("Err");
+  });
+
+  it("an AsyncResult can be awaited more than once", async () => {
+    const ar = Ok(1).toAsync();
+    const first = await ar;
+    const second = await ar;
+    expect(first.tag).toBe("Ok");
+    expect(second.tag).toBe("Ok");
+  });
 });

--- a/packages/core/src/constructors.spec.ts
+++ b/packages/core/src/constructors.spec.ts
@@ -112,6 +112,18 @@ describe("method guards narrow (parity with the standalone guards)", () => {
   });
 });
 
+describe("Result instances are frozen — a variant cannot be forged by mutation", () => {
+  it("freezes instances so tag cannot be mutated", () => {
+    const r = Ok(1);
+    expect(Object.isFrozen(r)).toBe(true);
+    expect(() => {
+      (r as { tag: string }).tag = "Err";
+    }).toThrow(TypeError);
+    expect(r.isOk()).toBe(true);
+    expect(Object.isFrozen(Err("e"))).toBe(true);
+  });
+});
+
 describe("UnwrapError", () => {
   it("carries the offending error and is an Error instance", () => {
     const e = new UnwrapError("payload");

--- a/packages/core/src/constructors.spec.ts
+++ b/packages/core/src/constructors.spec.ts
@@ -24,6 +24,23 @@ describe("constructors", () => {
     expect(r.isDefect()).toBe(false);
     expect(r.unwrapErr()).toBe("nope");
   });
+
+  it("Err(undefined) and Err(null) are real Errs — discrimination is by tag, never payload presence", () => {
+    const u = Err(undefined);
+    expect(u.tag).toBe("Err");
+    expect(u.isErr()).toBe(true);
+    if (u.isErr()) expect(u.error).toBeUndefined();
+    const n = Err(null);
+    if (n.isErr()) expect(n.error).toBeNull();
+  });
+
+  it("Ok(Err(x)) does not flatten — a Result is an ordinary value", () => {
+    const nested = Ok(Err("inner"));
+    expect(nested.tag).toBe("Ok");
+    if (nested.isOk()) {
+      expect(nested.value.tag).toBe("Err");
+    }
+  });
 });
 
 describe("standalone guards narrow and expose the relevant field", () => {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -254,7 +254,7 @@ class Res<T, E> {
     }
   }
 
-  unwrapOr(this: Result<T, E>, fallback: T): T {
+  unwrapOr<U>(this: Result<T, E>, fallback: U): T | U {
     if (this.tag === "Ok") return this.value;
     if (this.tag === "Defect") throw this.cause;
     return fallback;
@@ -662,7 +662,7 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
   unwrapErr(): Promise<E> {
     return this.promise.then((r) => r.unwrapErr());
   }
-  unwrapOr(fallback: T): Promise<T> {
+  unwrapOr<U>(fallback: U): Promise<T | U> {
     return this.promise.then((r) => r.unwrapOr(fallback));
   }
   unwrapOrElse(f: (error: E) => T): Promise<T> {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -177,7 +177,7 @@ class Res<T, E> {
       f(this.error);
       return this;
     } catch (cause) {
-      return defectRes(cause);
+      return observerThrowToDefect(cause, this.error);
     }
   }
 
@@ -188,7 +188,7 @@ class Res<T, E> {
       // Keep the original error on the effect's success; an Err/Defect threads through.
       return r.tag === "Ok" ? this : passThrough(r);
     } catch (cause) {
-      return defectRes(cause);
+      return observerThrowToDefect(cause, this.error);
     }
   }
 
@@ -210,7 +210,7 @@ class Res<T, E> {
       f(this.cause);
       return this;
     } catch (cause) {
-      return defectRes(cause);
+      return observerThrowToDefect(cause, this.cause);
     }
   }
 
@@ -375,6 +375,24 @@ export function isResult(x: unknown): x is Result<unknown, unknown> {
  */
 function passThrough<T, E>(self: Result<unknown, unknown>): Result<T, E> {
   return self as unknown as Result<T, E>;
+}
+
+/**
+ * A throw inside a *failure observer* (`tapErr` / `tapDefect` / `flatTapErr`)
+ * must not destroy the failure being observed — that is the exact place (e.g. a
+ * failing error-logger) where losing the underlying failure hurts most. The
+ * resulting Defect aggregates both: `errors[0]` is the observer's throw,
+ * `errors[1]` the original failure.
+ *
+ * @internal
+ */
+function observerThrowToDefect<T, E>(thrown: unknown, original: unknown): Result<T, E> {
+  return defectRes(
+    new AggregateError(
+      [thrown, original],
+      "unthrown: a failure-observer callback threw; errors[0] is the callback's throw, errors[1] the original failure",
+    ),
+  );
 }
 
 /**
@@ -570,7 +588,7 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
           f(r.error);
           return r;
         } catch (cause) {
-          return defectRes<T, E>(cause);
+          return observerThrowToDefect<T, E>(cause, r.error);
         }
       }),
     );
@@ -587,7 +605,7 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
           // Keep the original error on success; an Err/Defect from `f` wins.
           return inner.tag === "Ok" ? passThrough(r) : passThrough(inner);
         } catch (cause) {
-          return defectRes(cause);
+          return observerThrowToDefect(cause, r.error);
         }
       }),
     );
@@ -616,7 +634,7 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
           f(r.cause);
           return r;
         } catch (cause) {
-          return defectRes<T, E>(cause);
+          return observerThrowToDefect<T, E>(cause, r.cause);
         }
       }),
     );

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -14,7 +14,15 @@
 // The only other casts are the builders' construction (`as OkView`/…) and the
 // `bind`/`let` scope merge (a computed key can't be spelled at the type level).
 
-import type { AsyncResult, Bound, DefectView, ErrView, OkView, Result } from "./types.js";
+import type {
+  AsyncResult,
+  Bound,
+  DefectView,
+  ErrView,
+  NotThenable,
+  OkView,
+  Result,
+} from "./types.js";
 
 /**
  * Thrown by a {@link Result}'s `unwrap` / `unwrapErr` when the assertion is
@@ -56,7 +64,7 @@ export class UnwrapError<E = unknown> extends Error {
  * @internal
  */
 class Res<T, E> {
-  map<U>(this: Result<T, E>, f: (value: T) => U): Result<U, E> {
+  map<U>(this: Result<T, E>, f: (value: T) => U & NotThenable<U>): Result<U, E> {
     if (this.tag !== "Ok") return passThrough(this);
     try {
       return okRes(f(this.value));
@@ -74,7 +82,7 @@ class Res<T, E> {
     }
   }
 
-  tap(this: Result<T, E>, f: (value: T) => void): Result<T, E> {
+  tap<R>(this: Result<T, E>, f: (value: T) => R & NotThenable<R>): Result<T, E> {
     if (this.tag !== "Ok") return this;
     try {
       f(this.value);
@@ -118,7 +126,7 @@ class Res<T, E> {
   let<K extends string, U>(
     this: Result<T, E>,
     name: K,
-    f: (scope: T) => U,
+    f: (scope: T) => U & NotThenable<U>,
   ): Result<Bound<T, K, U>, E> {
     if (this.tag !== "Ok") return passThrough(this);
     try {
@@ -136,7 +144,7 @@ class Res<T, E> {
     return okRes(value);
   }
 
-  mapErr<E2>(this: Result<T, E>, f: (error: E) => E2): Result<T, E2> {
+  mapErr<E2>(this: Result<T, E>, f: (error: E) => E2 & NotThenable<E2>): Result<T, E2> {
     if (this.tag !== "Err") return passThrough(this);
     try {
       return errRes(f(this.error));
@@ -154,7 +162,7 @@ class Res<T, E> {
     }
   }
 
-  recover<U>(this: Result<T, E>, f: (error: E) => U): Result<T | U, never> {
+  recover<U>(this: Result<T, E>, f: (error: E) => U & NotThenable<U>): Result<T | U, never> {
     if (this.tag !== "Err") return passThrough(this);
     try {
       return okRes(f(this.error));
@@ -163,7 +171,7 @@ class Res<T, E> {
     }
   }
 
-  tapErr(this: Result<T, E>, f: (error: E) => void): Result<T, E> {
+  tapErr<R>(this: Result<T, E>, f: (error: E) => R & NotThenable<R>): Result<T, E> {
     if (this.tag !== "Err") return this;
     try {
       f(this.error);
@@ -196,7 +204,7 @@ class Res<T, E> {
     }
   }
 
-  tapDefect(this: Result<T, E>, f: (cause: unknown) => void): Result<T, E> {
+  tapDefect<R>(this: Result<T, E>, f: (cause: unknown) => R & NotThenable<R>): Result<T, E> {
     if (this.tag !== "Defect") return this;
     try {
       f(this.cause);
@@ -412,7 +420,7 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
     return this.promise.then(onfulfilled, onrejected);
   }
 
-  map<U>(f: (value: T) => U): AsyncResult<U, E> {
+  map<U>(f: (value: T) => U & NotThenable<U>): AsyncResult<U, E> {
     return new AsyncRes<U, E>(
       this.promise.then((r) => {
         if (r.tag !== "Ok") return passThrough(r);
@@ -438,7 +446,7 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
     );
   }
 
-  tap(f: (value: T) => void): AsyncResult<T, E> {
+  tap<R>(f: (value: T) => R & NotThenable<R>): AsyncResult<T, E> {
     return new AsyncRes<T, E>(
       this.promise.then((r) => {
         if (r.tag !== "Ok") return r;
@@ -490,7 +498,10 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
     );
   }
 
-  let<K extends string, U>(name: K, f: (scope: T) => U): AsyncResult<Bound<T, K, U>, E> {
+  let<K extends string, U>(
+    name: K,
+    f: (scope: T) => U & NotThenable<U>,
+  ): AsyncResult<Bound<T, K, U>, E> {
     return new AsyncRes<Bound<T, K, U>, E>(
       this.promise.then((r) => {
         if (r.tag !== "Ok") return passThrough(r);
@@ -512,7 +523,7 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
     );
   }
 
-  mapErr<E2>(f: (error: E) => E2): AsyncResult<T, E2> {
+  mapErr<E2>(f: (error: E) => E2 & NotThenable<E2>): AsyncResult<T, E2> {
     return new AsyncRes<T, E2>(
       this.promise.then((r) => {
         if (r.tag !== "Err") return passThrough(r);
@@ -538,7 +549,7 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
     );
   }
 
-  recover<U>(f: (error: E) => U): AsyncResult<T | U, never> {
+  recover<U>(f: (error: E) => U & NotThenable<U>): AsyncResult<T | U, never> {
     return new AsyncRes<T | U, never>(
       this.promise.then((r) => {
         if (r.tag !== "Err") return passThrough(r);
@@ -551,7 +562,7 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
     );
   }
 
-  tapErr(f: (error: E) => void): AsyncResult<T, E> {
+  tapErr<R>(f: (error: E) => R & NotThenable<R>): AsyncResult<T, E> {
     return new AsyncRes<T, E>(
       this.promise.then((r) => {
         if (r.tag !== "Err") return r;
@@ -597,7 +608,7 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
     );
   }
 
-  tapDefect(f: (cause: unknown) => void): AsyncResult<T, E> {
+  tapDefect<R>(f: (cause: unknown) => R & NotThenable<R>): AsyncResult<T, E> {
     return new AsyncRes<T, E>(
       this.promise.then((r) => {
         if (r.tag !== "Defect") return r;

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -303,10 +303,14 @@ const RESULT_PROTO = Res.prototype;
  * @internal
  */
 export function okRes<T, E>(value: T): Result<T, E> {
-  return Object.assign(Object.create(RESULT_PROTO), {
-    tag: "Ok" as const,
-    value,
-  }) as OkView<T, E>;
+  // Frozen so the `readonly` surface is real at runtime: a variant cannot be
+  // forged by mutating `tag`/payload after construction.
+  return Object.freeze(
+    Object.assign(Object.create(RESULT_PROTO), {
+      tag: "Ok" as const,
+      value,
+    }),
+  ) as OkView<T, E>;
 }
 
 /**
@@ -315,10 +319,12 @@ export function okRes<T, E>(value: T): Result<T, E> {
  * @internal
  */
 export function errRes<T, E>(error: E): Result<T, E> {
-  return Object.assign(Object.create(RESULT_PROTO), {
-    tag: "Err" as const,
-    error,
-  }) as ErrView<E, T>;
+  return Object.freeze(
+    Object.assign(Object.create(RESULT_PROTO), {
+      tag: "Err" as const,
+      error,
+    }),
+  ) as ErrView<E, T>;
 }
 
 /**
@@ -327,10 +333,12 @@ export function errRes<T, E>(error: E): Result<T, E> {
  * @internal
  */
 export function defectRes<T, E>(cause: unknown): Result<T, E> {
-  return Object.assign(Object.create(RESULT_PROTO), {
-    tag: "Defect" as const,
-    cause,
-  }) as DefectView<T, E>;
+  return Object.freeze(
+    Object.assign(Object.create(RESULT_PROTO), {
+      tag: "Defect" as const,
+      cause,
+    }),
+  ) as DefectView<T, E>;
 }
 
 /**

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -260,7 +260,7 @@ class Res<T, E> {
     return fallback;
   }
 
-  unwrapOrElse(this: Result<T, E>, f: (error: E) => T): T {
+  unwrapOrElse<U>(this: Result<T, E>, f: (error: E) => U): T | U {
     if (this.tag === "Ok") return this.value;
     if (this.tag === "Defect") throw this.cause;
     return f(this.error);
@@ -665,7 +665,7 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
   unwrapOr<U>(fallback: U): Promise<T | U> {
     return this.promise.then((r) => r.unwrapOr(fallback));
   }
-  unwrapOrElse(f: (error: E) => T): Promise<T> {
+  unwrapOrElse<U>(f: (error: E) => U): Promise<T | U> {
     return this.promise.then((r) => r.unwrapOrElse(f));
   }
   getOrNull(): Promise<T | null> {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -414,7 +414,7 @@ function observerThrowToDefect<T, E>(thrown: unknown, original: unknown): Result
  * @internal
  */
 function scopeOf(value: unknown): object {
-  if (typeof value !== "object" || value === null) {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new TypeError("bind/let requires an object scope — start a do-chain with Do()");
   }
   return value;

--- a/packages/core/src/do.spec.ts
+++ b/packages/core/src/do.spec.ts
@@ -77,6 +77,11 @@ describe("Do / bind / let", () => {
         .isDefect(),
     ).toBe(true);
   });
+
+  it("bind on an array scope is misuse and becomes a Defect (not a silent index-spread)", () => {
+    const r = Ok([1, 2]).bind("a", () => Ok("x"));
+    expect(r.tag).toBe("Defect");
+  });
 });
 
 describe("Do / bind / let — async", () => {

--- a/packages/core/src/do.spec.ts
+++ b/packages/core/src/do.spec.ts
@@ -82,6 +82,21 @@ describe("Do / bind / let", () => {
     const r = Ok([1, 2]).bind("a", () => Ok("x"));
     expect(r.tag).toBe("Defect");
   });
+
+  it('bind("__proto__", …) stores an own property and never pollutes Object.prototype', () => {
+    const r = Do().bind("__proto__", () => Ok({ polluted: true }));
+    expect(r.tag).toBe("Ok");
+    expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
+    if (r.isOk()) {
+      expect(Object.getOwnPropertyDescriptor(r.value, "__proto__")).toBeDefined();
+    }
+  });
+
+  it('let("__proto__", …) likewise stays an own property', () => {
+    const r = Do().let("__proto__", () => ({ polluted: true }));
+    expect(r.tag).toBe("Ok");
+    expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
+  });
 });
 
 describe("Do / bind / let — async", () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,7 @@ export type {
   DefectView,
   ErrOf,
   ErrView,
+  NotThenable,
   OkOf,
   OkView,
   ResultMethods,

--- a/packages/core/src/interop.spec.ts
+++ b/packages/core/src/interop.spec.ts
@@ -4,6 +4,7 @@ import {
   type AsyncResult,
   fromNullable,
   fromPromise,
+  fromSafePromise,
   fromThrowable,
   Ok,
   type Result,
@@ -110,5 +111,21 @@ describe("fromPromise — error-channel inference", () => {
     const typed: AsyncResult<never, "known"> = ar;
     // `boom` matches the modeled arm, so it lands in Err — not a Defect.
     expect((await typed).unwrapErr()).toBe("known");
+  });
+});
+
+describe("fromPromise — non-thenable absorption", () => {
+  it("fromPromise tolerates a non-thenable input instead of throwing synchronously", async () => {
+    const r = await fromPromise(42 as unknown as Promise<number>, (c, d) => d(c));
+    expect(r.tag).toBe("Ok");
+    if (r.isOk()) expect(r.value).toBe(42);
+  });
+});
+
+describe("fromSafePromise — non-thenable absorption", () => {
+  it("fromSafePromise tolerates a non-thenable input instead of throwing synchronously", async () => {
+    const r = await fromSafePromise("x" as unknown as Promise<string>);
+    expect(r.tag).toBe("Ok");
+    if (r.isOk()) expect(r.value).toBe("x");
   });
 });

--- a/packages/core/src/interop.ts
+++ b/packages/core/src/interop.ts
@@ -259,8 +259,10 @@ function foldRecord(results: ResultRecord): Result<unknown, unknown> {
   let firstDefect: Result<unknown, unknown> | undefined;
   const values: Record<string, unknown> = {};
   for (const [key, r] of Object.entries(results)) {
-    if (r.tag === "Defect") firstDefect ??= r;
-    else if (r.tag === "Err") firstErr ??= r;
+    if (r.tag === "Defect") {
+      firstDefect ??= r;
+      break; // any Defect dominates — nothing later can change the outcome
+    } else if (r.tag === "Err") firstErr ??= r;
     else
       Object.defineProperty(values, key, {
         value: r.value,

--- a/packages/core/src/interop.ts
+++ b/packages/core/src/interop.ts
@@ -139,7 +139,10 @@ export function fromPromise<T, R>(
 ): AsyncResult<T, Exclude<R, Defect>> {
   type E = Exclude<R, Defect>;
   const triage = qualify as (cause: unknown, defect: (cause: unknown) => Defect) => E | Defect;
-  const p = typeof promise === "function" ? Promise.resolve().then(promise) : promise;
+  // Promise.resolve() also absorbs a non-thenable passed from untyped code, so
+  // this boundary never throws synchronously — it exists to prevent throws.
+  const p =
+    typeof promise === "function" ? Promise.resolve().then(promise) : Promise.resolve(promise);
   const settled: Promise<Result<T, E>> = p.then(
     (value) => okRes<T, E>(value),
     (cause) => qualifyToResult<T, E>(cause, triage),
@@ -173,7 +176,10 @@ export function fromPromise<T, R>(
 export function fromSafePromise<T>(
   promise: Promise<T> | (() => Promise<T>),
 ): AsyncResult<T, never> {
-  const p = typeof promise === "function" ? Promise.resolve().then(promise) : promise;
+  // Promise.resolve() also absorbs a non-thenable passed from untyped code, so
+  // this boundary never throws synchronously — it exists to prevent throws.
+  const p =
+    typeof promise === "function" ? Promise.resolve().then(promise) : Promise.resolve(promise);
   const settled: Promise<Result<T, never>> = p.then(
     (value) => okRes<T, never>(value),
     (cause) => defectRes<T, never>(cause),

--- a/packages/core/src/result.spec.ts
+++ b/packages/core/src/result.spec.ts
@@ -367,6 +367,53 @@ describe("Result.tapDefect", () => {
   });
 });
 
+describe("failure-observer throws preserve the original failure", () => {
+  it("tapErr: a throwing callback yields a Defect aggregating [thrown, original]", () => {
+    const boom = new Error("boom");
+    const r = Err("original").tapErr(() => {
+      throw boom;
+    });
+    expect(r.tag).toBe("Defect");
+    if (r.isDefect()) {
+      expect(r.cause).toBeInstanceOf(AggregateError);
+      expect((r.cause as AggregateError).errors).toEqual([boom, "original"]);
+    }
+  });
+
+  it("tapDefect: a throwing callback yields a Defect aggregating [thrown, original cause]", () => {
+    const original = new Error("original-bug");
+    const defect = defectOf(original);
+    const boom = new Error("logger-failed");
+    const r = defect.tapDefect(() => {
+      throw boom;
+    });
+    expect(r.tag).toBe("Defect");
+    if (r.isDefect()) {
+      expect((r.cause as AggregateError).errors).toEqual([boom, original]);
+    }
+  });
+
+  it("flatTapErr: a throwing callback yields a Defect aggregating [thrown, original]", () => {
+    const boom = new Error("boom");
+    const r = Err("original").flatTapErr(() => {
+      throw boom;
+    });
+    expect(r.tag).toBe("Defect");
+    if (r.isDefect()) {
+      expect((r.cause as AggregateError).errors).toEqual([boom, "original"]);
+    }
+  });
+
+  it("tap (success channel) is unchanged: the Defect cause is the thrown value itself", () => {
+    const boom = new Error("boom");
+    const r = Ok(1).tap(() => {
+      throw boom;
+    });
+    expect(r.tag).toBe("Defect");
+    if (r.isDefect()) expect(r.cause).toBe(boom);
+  });
+});
+
 describe("Result.match", () => {
   it("dispatches each of the three channels", () => {
     const fold = (r: Result<number, string>) =>

--- a/packages/core/src/tagged.spec.ts
+++ b/packages/core/src/tagged.spec.ts
@@ -127,4 +127,26 @@ describe("matchTags", () => {
     });
     expect(out).toBe("ok:1");
   });
+
+  it("routes an error with an unhandled _tag to the Defect handler instead of crashing", () => {
+    class Known extends TaggedError("Known") {}
+    const rogue = { _tag: "Rogue" } as unknown as Known;
+    const out = matchTags(Err(rogue), {
+      Ok: () => "ok",
+      Defect: (cause) => `defect:${(cause as { _tag: string })._tag}`,
+      Known: () => "known",
+    });
+    expect(out).toBe("defect:Rogue");
+  });
+
+  it("routes an error whose _tag is the reserved 'Ok' to the Defect handler", () => {
+    class Known extends TaggedError("Known") {}
+    const rogue = { _tag: "Ok" } as unknown as Known;
+    const out = matchTags(Err(rogue), {
+      Ok: () => "ok",
+      Defect: () => "defect",
+      Known: () => "known",
+    });
+    expect(out).toBe("defect");
+  });
 });

--- a/packages/core/src/tagged.spec.ts
+++ b/packages/core/src/tagged.spec.ts
@@ -149,4 +149,26 @@ describe("matchTags", () => {
     });
     expect(out).toBe("defect");
   });
+
+  it("routes an error whose _tag is the reserved 'Defect' to the Defect handler", () => {
+    class Known extends TaggedError("Known") {}
+    const rogue = { _tag: "Defect" } as unknown as Known;
+    const out = matchTags(Err(rogue), {
+      Ok: () => "ok",
+      Defect: () => "defect",
+      Known: () => "known",
+    });
+    expect(out).toBe("defect");
+  });
+
+  it("routes a rogue _tag that collides with an inherited Object.prototype member (e.g. 'constructor') to the Defect handler, not the prototype's value", () => {
+    class Known extends TaggedError("Known") {}
+    const rogue = { _tag: "constructor" } as unknown as Known;
+    const out = matchTags(Err(rogue), {
+      Ok: () => "ok",
+      Defect: (cause) => `defect:${(cause as { _tag: string })._tag}`,
+      Known: () => "known",
+    });
+    expect(out).toBe("defect:constructor");
+  });
 });

--- a/packages/core/src/tagged.ts
+++ b/packages/core/src/tagged.ts
@@ -122,6 +122,16 @@ export type TagHandlers<T, E extends { _tag: string }, R> = {
 } & { [K in E["_tag"]]: (error: Extract<E, { _tag: K }>) => R };
 
 /**
+ * The channel-handler names are reserved: an error tag named `"Ok"` or
+ * `"Defect"` would collide with them inside {@link TagHandlers}, so
+ * {@link matchTags} rejects such unions at the call site.
+ *
+ * @internal
+ */
+type ReservedTagError =
+  'unthrown: error tags "Ok" and "Defect" are reserved by matchTags — rename the colliding tag (TaggedError\'s options.name can keep the display name)';
+
+/**
  * Exhaustively fold a {@link Result} (or {@link AsyncResult}) whose error type is
  * a tagged union, dispatching each error to the handler matching its `_tag`.
  *
@@ -129,7 +139,10 @@ export type TagHandlers<T, E extends { _tag: string }, R> = {
  * The `handlers` object must provide `Ok`, `Defect`, and exactly one function
  * per error tag; each tag's handler receives the narrowed error variant. A
  * missing tag is a compile error. For an `AsyncResult`, the fold resolves to a
- * `Promise<R>`.
+ * `Promise<R>`. At runtime, an error whose `_tag` has no handler (possible only
+ * outside the typed contract) is routed to the `Defect` handler — an unmodeled
+ * tag is an unmodeled failure. Tags named `"Ok"` or `"Defect"` are rejected at
+ * compile time.
  *
  * @typeParam T - the success value type.
  * @typeParam E - the tagged error union (`E extends { _tag: string }`).
@@ -160,19 +173,28 @@ export type TagHandlers<T, E extends { _tag: string }, R> = {
  */
 export function matchTags<T, E extends { _tag: string }, R>(
   result: Result<T, E>,
-  handlers: TagHandlers<T, E, R>,
+  handlers: TagHandlers<T, E, R> &
+    ([Extract<E["_tag"], "Ok" | "Defect">] extends [never] ? unknown : ReservedTagError),
 ): R;
 export function matchTags<T, E extends { _tag: string }, R>(
   result: AsyncResult<T, E>,
-  handlers: TagHandlers<T, E, R>,
+  handlers: TagHandlers<T, E, R> &
+    ([Extract<E["_tag"], "Ok" | "Defect">] extends [never] ? unknown : ReservedTagError),
 ): Promise<R>;
 export function matchTags<T, E extends { _tag: string }, R>(
   result: Result<T, E> | AsyncResult<T, E>,
   handlers: TagHandlers<T, E, R>,
 ): R | Promise<R> {
   const onErr = (error: E): R => {
-    const handler = handlers[error._tag as E["_tag"]] as unknown as (e: E) => R;
-    return handler(error);
+    const tag = error._tag as E["_tag"];
+    const handler =
+      tag === "Ok" || tag === "Defect"
+        ? undefined
+        : (handlers[tag] as unknown as ((e: E) => R) | undefined);
+    // An unhandled or reserved tag can only arise outside the typed contract (a
+    // widened cast, a JS caller). That is an unmodeled failure — route it to the
+    // Defect handler rather than crashing on `undefined(error)`.
+    return handler ? handler(error) : handlers.Defect(error);
   };
   // Both Result and AsyncResult share `match`; the cast picks one signature for
   // the call while the public overloads keep the return type correct.

--- a/packages/core/src/tagged.ts
+++ b/packages/core/src/tagged.ts
@@ -187,8 +187,11 @@ export function matchTags<T, E extends { _tag: string }, R>(
 ): R | Promise<R> {
   const onErr = (error: E): R => {
     const tag = error._tag as E["_tag"];
+    // `Object.hasOwn` guards against a rogue tag (e.g. "constructor") resolving
+    // through the prototype chain to an unrelated `Object.prototype` member —
+    // only an own property of `handlers` counts as a real handler.
     const handler =
-      tag === "Ok" || tag === "Defect"
+      tag === "Ok" || tag === "Defect" || !Object.hasOwn(handlers, tag)
         ? undefined
         : (handlers[tag] as unknown as ((e: E) => R) | undefined);
     // An unhandled or reserved tag can only arise outside the typed contract (a

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -274,6 +274,10 @@ type _nameNotShadowed = Expect<
   ar.mapErr(async (e) => e);
   // @ts-expect-error — async recover callback is banned (async surface)
   ar.recover(async () => 0);
+  // @ts-expect-error — async tapErr callback is banned (async surface)
+  ar.tapErr(async () => {});
+  // @ts-expect-error — async tapDefect callback is banned (async surface)
+  ar.tapDefect(async () => {});
   const emptyAsync = Ok({}).toAsync();
   // @ts-expect-error — async let callback is banned (async surface)
   emptyAsync.let("x", async () => 1);

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -228,6 +228,14 @@ matchTags(tagged, { Ok: () => 1, Defect: () => 2, TagA: () => 3, TagB: () => 4 }
 // @ts-expect-error - the TagB handler is missing
 matchTags(tagged, { Ok: () => 1, Defect: () => 2, TagA: () => 3 });
 
+// matchTags rejects error unions containing the reserved tags "Ok" / "Defect".
+{
+  class Reserved extends TaggedError("Defect") {}
+  const bad = Err(new Reserved()) as Result<number, InstanceType<typeof Reserved>>;
+  // @ts-expect-error — a tag named "Defect" would collide with the channel handler
+  matchTags(bad, { Ok: () => 0, Defect: () => 0 });
+}
+
 // `_tag` is the literal; `options.name` is independent (still a literal `_tag`)
 class Named extends TaggedError("@scope/Named", { name: "Named" }) {}
 type _namedTag = Expect<Equal<(typeof Named)["prototype"]["_tag"], "@scope/Named">>;

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -242,3 +242,52 @@ new WithCode({ code: 1, name: "nope" });
 type _nameNotShadowed = Expect<
   Equal<TaggedErrorInstance<"X", { code: number; name: "lit" }>["name"], string>
 >;
+
+// ---------------------------------------------------------------------------
+// Thenable callbacks are rejected: an async callback's rejection would bypass
+// qualification and float as an unhandled rejection (Thesis #3).
+// ---------------------------------------------------------------------------
+{
+  const r = Ok(1) as Result<number, "e">;
+  const ar = r.toAsync();
+
+  // @ts-expect-error — async tap callback is banned (sync surface)
+  r.tap(async () => {});
+  // @ts-expect-error — async map callback is banned (sync surface)
+  r.map(async (n) => n + 1);
+  // @ts-expect-error — async mapErr callback is banned
+  r.mapErr(async (e) => e);
+  // @ts-expect-error — async recover callback is banned
+  r.recover(async () => 0);
+  // @ts-expect-error — async tapErr callback is banned
+  r.tapErr(async () => {});
+  // @ts-expect-error — async tapDefect callback is banned
+  r.tapDefect(async () => {});
+  // @ts-expect-error — async let callback is banned
+  Ok({}).let("x", async () => 1);
+
+  // @ts-expect-error — async tap callback is banned (async surface)
+  ar.tap(async () => {});
+  // @ts-expect-error — async map callback is banned (async surface)
+  ar.map(async (n) => n + 1);
+  // @ts-expect-error — async mapErr callback is banned (async surface)
+  ar.mapErr(async (e) => e);
+  // @ts-expect-error — async recover callback is banned (async surface)
+  ar.recover(async () => 0);
+  const emptyAsync = Ok({}).toAsync();
+  // @ts-expect-error — async let callback is banned (async surface)
+  emptyAsync.let("x", async () => 1);
+
+  // Synchronous callbacks still infer exactly as before.
+  const mapped = r.map((n) => n + 1);
+  type _MapKeeps = Expect<Equal<typeof mapped, Result<number, "e">>>;
+  const recovered = r.recover((e) => e.length);
+  type _RecoverKeeps = Expect<Equal<typeof recovered, Result<number, never>>>;
+
+  // match handlers may still be async (edge elimination is not a combinator).
+  void r.match({
+    ok: async (n) => n,
+    err: async (e) => e.length,
+    defect: async () => 0,
+  });
+}

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -303,3 +303,11 @@ type _nameNotShadowed = Expect<
     defect: async () => 0,
   });
 }
+
+// --- unwrapOr widens: the fallback may be a different type ----
+
+{
+  const r = Ok(1) as Result<number, "e">;
+  const widened = r.unwrapOr(null);
+  type _Widens = Expect<Equal<typeof widened, number | null>>;
+}

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -311,3 +311,11 @@ type _nameNotShadowed = Expect<
   const widened = r.unwrapOr(null);
   type _Widens = Expect<Equal<typeof widened, number | null>>;
 }
+
+// --- unwrapOrElse widens: the fallback function may return a different type ----
+
+{
+  const r = Ok(1) as Result<number, "e">;
+  const widened = r.unwrapOrElse(() => null);
+  type _Widens = Expect<Equal<typeof widened, number | null>>;
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -193,8 +193,10 @@ export type ResultMethods<T, E> = {
   /**
    * Run a side effect on the error and pass the `Result` through unchanged.
    *
-   * Runs only on `Err`. If `f` throws, the throw becomes a `Defect`. An async
-   * callback is rejected at compile time ({@link NotThenable}).
+   * Runs only on `Err`. If `f` throws, the result is a `Defect` whose cause is
+   * an `AggregateError` of `[thrown, original failure]` — observing a failure
+   * never destroys it. An async callback is rejected at compile time
+   * ({@link NotThenable}).
    *
    * @param f - the side effect (its return value is ignored).
    */
@@ -208,9 +210,10 @@ export type ResultMethods<T, E> = {
    * returns a `Result`, but its **success value is discarded** — on the effect's
    * `Ok` the original `Err` flows through unchanged, while an `Err` (or `Defect`)
    * from `f` short-circuits and threads its error (`Result<T, E | E2>`). Runs only
-   * on `Err`; `Ok` and `Defect` pass through. If `f` throws, the throw becomes a
-   * `Defect`. Use it for a failable effect _during_ error handling (e.g. writing
-   * the error to an audit log that may itself fail).
+   * on `Err`; `Ok` and `Defect` pass through. If `f` throws, the result is a
+   * `Defect` whose cause is an `AggregateError` of `[thrown, original failure]` —
+   * observing a failure never destroys it. Use it for a failable effect _during_
+   * error handling (e.g. writing the error to an audit log that may itself fail).
    *
    * @typeParam E2 - the error type the effect may introduce.
    * @param f - the failable side effect; its `Ok` value is ignored.
@@ -233,8 +236,10 @@ export type ResultMethods<T, E> = {
   recoverDefect<U, E2>(f: (cause: unknown) => Result<U, E2>): Result<T | U, E | E2>;
   /**
    * Run a side effect on a present `Defect`'s cause (e.g. logging) and pass the
-   * `Defect` through unchanged. If `f` throws, the throw becomes a new `Defect`.
-   * An async callback is rejected at compile time ({@link NotThenable}).
+   * `Defect` through unchanged. If `f` throws, the result is a `Defect` whose
+   * cause is an `AggregateError` of `[thrown, original failure]` — observing a
+   * failure never destroys it. An async callback is rejected at compile time
+   * ({@link NotThenable}).
    *
    * @param f - the side effect over the unknown cause.
    */
@@ -512,16 +517,19 @@ export type AsyncResultMethods<T, E> = {
    */
   recover<U>(f: (error: E) => U & NotThenable<U>): AsyncResult<T | U, never>;
   /**
-   * Asynchronous {@link ResultMethods.tapErr | tapErr}. `f` is synchronous; a
-   * throw becomes a `Defect`. An async callback is rejected at compile time
-   * ({@link NotThenable}).
+   * Asynchronous {@link ResultMethods.tapErr | tapErr}. `f` is synchronous; if it
+   * throws, the result is a `Defect` whose cause is an `AggregateError` of
+   * `[thrown, original failure]` — observing a failure never destroys it. An
+   * async callback is rejected at compile time ({@link NotThenable}).
    */
   tapErr<R>(f: (error: E) => R & NotThenable<R>): AsyncResult<T, E>;
   /**
    * Asynchronous {@link ResultMethods.flatTapErr | flatTapErr} — the
    * error-channel mirror of `flatTap`. `f` may return a `Result` **or** an
    * `AsyncResult`; its `Ok` value is discarded, an `Err`/`Defect` from `f`
-   * threads through, and a throw becomes a `Defect`.
+   * threads through, and if `f` throws, the result is a `Defect` whose cause is
+   * an `AggregateError` of `[thrown, original failure]` — observing a failure
+   * never destroys it.
    */
   flatTapErr<E2>(
     f: (error: E) => Result<unknown, E2> | AsyncResult<unknown, E2>,
@@ -535,8 +543,10 @@ export type AsyncResultMethods<T, E> = {
     f: (cause: unknown) => Result<U, E2> | AsyncResult<U, E2>,
   ): AsyncResult<T | U, E | E2>;
   /**
-   * Asynchronous {@link ResultMethods.tapDefect | tapDefect}. An async callback
-   * is rejected at compile time ({@link NotThenable}).
+   * Asynchronous {@link ResultMethods.tapDefect | tapDefect}. If `f` throws, the
+   * result is a `Defect` whose cause is an `AggregateError` of `[thrown,
+   * original failure]` — observing a failure never destroys it. An async
+   * callback is rejected at compile time ({@link NotThenable}).
    */
   tapDefect<R>(f: (cause: unknown) => R & NotThenable<R>): AsyncResult<T, E>;
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -19,6 +19,26 @@ export type Prettify<T> = { [K in keyof T]: T[K] } & {};
 export type Bound<T, K extends string, U> = Prettify<Omit<T, K> & { readonly [P in K]: U }>;
 
 /**
+ * Compile-time rejection of a thenable callback result — the type-level
+ * enforcement of "combinator callbacks are synchronous" (see the
+ * {@link AsyncResult} remarks).
+ *
+ * @remarks
+ * Resolves to `unknown` (a no-op in an intersection) for any non-thenable `R`,
+ * and to an explanatory string-literal type when `R` is a `PromiseLike` — so an
+ * `async` callback fails to compile with the explanation in the error. Without
+ * this, `async () => …` would be assignable to `() => void`, and its rejection
+ * would escape the pipeline as an unhandled rejection instead of a `Defect`.
+ * Lift async work with {@link fromPromise} and compose it with `flatMap`.
+ *
+ * @typeParam R - the callback's inferred return type.
+ * @category Types
+ */
+export type NotThenable<R> = [R] extends [PromiseLike<unknown>]
+  ? "unthrown: combinator callbacks are synchronous — lift async work with fromPromise and compose with flatMap"
+  : unknown;
+
+/**
  * The fluent method surface every {@link Result} variant carries — the
  * combinators (`map`, `flatMap`, `mapErr`, `match`, `unwrap`, …), documented one
  * per entry below. Factored out so the three variants ({@link OkView},
@@ -41,10 +61,12 @@ export type ResultMethods<T, E> = {
    * Runs `f` only on `Ok`; `Err` and `Defect` pass through untouched. If `f`
    * throws, the thrown value is captured as a `Defect`.
    *
+   * An async callback is rejected at compile time ({@link NotThenable}).
+   *
    * @typeParam U - the mapped success type.
    * @param f - maps the current success value to a new one.
    */
-  map<U>(f: (value: T) => U): Result<U, E>;
+  map<U>(f: (value: T) => U & NotThenable<U>): Result<U, E>;
   /**
    * Sequence a dependent, `Result`-returning step (monadic bind).
    *
@@ -60,11 +82,12 @@ export type ResultMethods<T, E> = {
    * Run a side effect on the success value and pass the `Result` through
    * unchanged.
    *
-   * Runs only on `Ok`. If `f` throws, the throw becomes a `Defect`.
+   * Runs only on `Ok`. If `f` throws, the throw becomes a `Defect`. An async
+   * callback is rejected at compile time ({@link NotThenable}).
    *
    * @param f - the side effect (its return value is ignored).
    */
-  tap(f: (value: T) => void): Result<T, E>;
+  tap<R>(f: (value: T) => R & NotThenable<R>): Result<T, E>;
   /**
    * Run a **failable** side effect on the success value, keeping the original
    * value but threading the effect's error.
@@ -112,14 +135,15 @@ export type ResultMethods<T, E> = {
    * @remarks
    * `f` receives the scope and returns a value (not a `Result`); it is added as
    * `{ ...scope, [name]: value }`. Runs only on `Ok`; `Err`/`Defect` pass
-   * through. A throw becomes a `Defect`.
+   * through. A throw becomes a `Defect`. An async callback is rejected at
+   * compile time ({@link NotThenable}).
    *
    * @typeParam K - the key the value is stored under.
    * @typeParam U - the value type.
    * @param name - the scope key.
    * @param f - computes a value from the accumulated scope.
    */
-  let<K extends string, U>(name: K, f: (scope: T) => U): Result<Bound<T, K, U>, E>;
+  let<K extends string, U>(name: K, f: (scope: T) => U & NotThenable<U>): Result<Bound<T, K, U>, E>;
   /**
    * Replace the success value with a constant `value`.
    *
@@ -133,12 +157,13 @@ export type ResultMethods<T, E> = {
    * Transform the modeled error with `f`.
    *
    * Runs `f` only on `Err`; `Ok` passes through and a `Defect` is **never**
-   * touched. If `f` throws, the throw becomes a `Defect`.
+   * touched. If `f` throws, the throw becomes a `Defect`. An async callback is
+   * rejected at compile time ({@link NotThenable}).
    *
    * @typeParam E2 - the mapped error type.
    * @param f - maps the current error to a new one.
    */
-  mapErr<E2>(f: (error: E) => E2): Result<T, E2>;
+  mapErr<E2>(f: (error: E) => E2 & NotThenable<E2>): Result<T, E2>;
   /**
    * Recover from an `Err` by producing another `Result`.
    *
@@ -158,20 +183,22 @@ export type ResultMethods<T, E> = {
    * The result type is `Result<T | U, never>`, but `never` describes only the
    * **error** channel — a `Defect` can still be present at runtime, so do not
    * read `never` as "total". Runs `f` only on `Err`; `Ok` and `Defect` pass
-   * through. If `f` throws, the throw becomes a `Defect`.
+   * through. If `f` throws, the throw becomes a `Defect`. An async callback is
+   * rejected at compile time ({@link NotThenable}).
    *
    * @typeParam U - the recovered success type.
    * @param f - produces a success value from the current error.
    */
-  recover<U>(f: (error: E) => U): Result<T | U, never>;
+  recover<U>(f: (error: E) => U & NotThenable<U>): Result<T | U, never>;
   /**
    * Run a side effect on the error and pass the `Result` through unchanged.
    *
-   * Runs only on `Err`. If `f` throws, the throw becomes a `Defect`.
+   * Runs only on `Err`. If `f` throws, the throw becomes a `Defect`. An async
+   * callback is rejected at compile time ({@link NotThenable}).
    *
    * @param f - the side effect (its return value is ignored).
    */
-  tapErr(f: (error: E) => void): Result<T, E>;
+  tapErr<R>(f: (error: E) => R & NotThenable<R>): Result<T, E>;
   /**
    * Run a **failable** side effect on the error, keeping the original error but
    * threading the effect's own error.
@@ -207,10 +234,11 @@ export type ResultMethods<T, E> = {
   /**
    * Run a side effect on a present `Defect`'s cause (e.g. logging) and pass the
    * `Defect` through unchanged. If `f` throws, the throw becomes a new `Defect`.
+   * An async callback is rejected at compile time ({@link NotThenable}).
    *
    * @param f - the side effect over the unknown cause.
    */
-  tapDefect(f: (cause: unknown) => void): Result<T, E>;
+  tapDefect<R>(f: (cause: unknown) => R & NotThenable<R>): Result<T, E>;
 
   /**
    * Exhaustively fold all three runtime states into a single value of type `R`.
@@ -420,9 +448,10 @@ export type Awaitable<T> = {
 export type AsyncResultMethods<T, E> = {
   /**
    * Asynchronous {@link ResultMethods.map | map}: transforms the success value
-   * with `f`. `f` is synchronous; a throw becomes a `Defect`.
+   * with `f`. `f` is synchronous; a throw becomes a `Defect`. An async callback
+   * is rejected at compile time ({@link NotThenable}).
    */
-  map<U>(f: (value: T) => U): AsyncResult<U, E>;
+  map<U>(f: (value: T) => U & NotThenable<U>): AsyncResult<U, E>;
   /**
    * Asynchronous {@link ResultMethods.flatMap | flatMap}. Unlike the sync form,
    * `f` may return a `Result` **or** an `AsyncResult` (never a raw `Promise`); a
@@ -431,9 +460,10 @@ export type AsyncResultMethods<T, E> = {
   flatMap<U, E2>(f: (value: T) => Result<U, E2> | AsyncResult<U, E2>): AsyncResult<U, E | E2>;
   /**
    * Asynchronous {@link ResultMethods.tap | tap}. `f` is synchronous; a throw
-   * becomes a `Defect`.
+   * becomes a `Defect`. An async callback is rejected at compile time
+   * ({@link NotThenable}).
    */
-  tap(f: (value: T) => void): AsyncResult<T, E>;
+  tap<R>(f: (value: T) => R & NotThenable<R>): AsyncResult<T, E>;
   /**
    * Asynchronous {@link ResultMethods.flatTap | flatTap} — a failable tap that
    * keeps the original value. `f` may return a `Result` **or** an `AsyncResult`;
@@ -454,17 +484,22 @@ export type AsyncResultMethods<T, E> = {
   ): AsyncResult<Bound<T, K, U>, E | E2>;
   /**
    * Asynchronous {@link ResultMethods.let | let} (do-notation). `f` returns a
-   * plain value, bound under `name`.
+   * plain value, bound under `name`. An async callback is rejected at compile
+   * time ({@link NotThenable}).
    */
-  let<K extends string, U>(name: K, f: (scope: T) => U): AsyncResult<Bound<T, K, U>, E>;
+  let<K extends string, U>(
+    name: K,
+    f: (scope: T) => U & NotThenable<U>,
+  ): AsyncResult<Bound<T, K, U>, E>;
   /** Asynchronous {@link ResultMethods.as | as}: replaces the value with `value`. */
   as<U>(value: U): AsyncResult<U, E>;
 
   /**
    * Asynchronous {@link ResultMethods.mapErr | mapErr}. `f` is synchronous; a
-   * throw becomes a `Defect`.
+   * throw becomes a `Defect`. An async callback is rejected at compile time
+   * ({@link NotThenable}).
    */
-  mapErr<E2>(f: (error: E) => E2): AsyncResult<T, E2>;
+  mapErr<E2>(f: (error: E) => E2 & NotThenable<E2>): AsyncResult<T, E2>;
   /**
    * Asynchronous {@link ResultMethods.orElse | orElse}. `f` may return a `Result`
    * or an `AsyncResult`.
@@ -472,14 +507,16 @@ export type AsyncResultMethods<T, E> = {
   orElse<U, E2>(f: (error: E) => Result<U, E2> | AsyncResult<U, E2>): AsyncResult<T | U, E2>;
   /**
    * Asynchronous {@link ResultMethods.recover | recover}. `f` is synchronous; a
-   * throw becomes a `Defect`.
+   * throw becomes a `Defect`. An async callback is rejected at compile time
+   * ({@link NotThenable}).
    */
-  recover<U>(f: (error: E) => U): AsyncResult<T | U, never>;
+  recover<U>(f: (error: E) => U & NotThenable<U>): AsyncResult<T | U, never>;
   /**
    * Asynchronous {@link ResultMethods.tapErr | tapErr}. `f` is synchronous; a
-   * throw becomes a `Defect`.
+   * throw becomes a `Defect`. An async callback is rejected at compile time
+   * ({@link NotThenable}).
    */
-  tapErr(f: (error: E) => void): AsyncResult<T, E>;
+  tapErr<R>(f: (error: E) => R & NotThenable<R>): AsyncResult<T, E>;
   /**
    * Asynchronous {@link ResultMethods.flatTapErr | flatTapErr} — the
    * error-channel mirror of `flatTap`. `f` may return a `Result` **or** an
@@ -497,8 +534,11 @@ export type AsyncResultMethods<T, E> = {
   recoverDefect<U, E2>(
     f: (cause: unknown) => Result<U, E2> | AsyncResult<U, E2>,
   ): AsyncResult<T | U, E | E2>;
-  /** Asynchronous {@link ResultMethods.tapDefect | tapDefect}. */
-  tapDefect(f: (cause: unknown) => void): AsyncResult<T, E>;
+  /**
+   * Asynchronous {@link ResultMethods.tapDefect | tapDefect}. An async callback
+   * is rejected at compile time ({@link NotThenable}).
+   */
+  tapDefect<R>(f: (cause: unknown) => R & NotThenable<R>): AsyncResult<T, E>;
 
   /**
    * Asynchronous {@link ResultMethods.match | match}. Handlers are synchronous;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -279,11 +279,12 @@ export type ResultMethods<T, E> = {
   /**
    * The success value, or `fallback` on `Err`.
    *
-   * @param fallback - returned when the result is an `Err`.
+   * @typeParam U - the fallback type (may differ from `T`; the return widens to `T | U`).
+   * @param fallback - returned when the result is an `Err` (may be a different type; the return widens to `T | U`).
    * @throws Re-throws on a `Defect` — a Defect is a bug, not an absent value, so
    * it is never silently replaced.
    */
-  unwrapOr(fallback: T): T;
+  unwrapOr<U>(fallback: U): T | U;
   /**
    * The success value, or `f(error)` on `Err`.
    *
@@ -567,7 +568,7 @@ export type AsyncResultMethods<T, E> = {
   /** Asynchronous {@link ResultMethods.unwrapErr | unwrapErr}. */
   unwrapErr(): Promise<E>;
   /** Asynchronous {@link ResultMethods.unwrapOr | unwrapOr}. */
-  unwrapOr(fallback: T): Promise<T>;
+  unwrapOr<U>(fallback: U): Promise<T | U>;
   /** Asynchronous {@link ResultMethods.unwrapOrElse | unwrapOrElse}. */
   unwrapOrElse(f: (error: E) => T): Promise<T>;
   /** Asynchronous {@link ResultMethods.getOrNull | getOrNull}. */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -288,10 +288,11 @@ export type ResultMethods<T, E> = {
   /**
    * The success value, or `f(error)` on `Err`.
    *
-   * @param f - lazily computes the fallback from the error.
+   * @typeParam U - the fallback type (may differ from `T`; the return widens to `T | U`).
+   * @param f - lazily computes the fallback from the error (may return a different type; the return widens to `T | U`).
    * @throws Re-throws on a `Defect`.
    */
-  unwrapOrElse(f: (error: E) => T): T;
+  unwrapOrElse<U>(f: (error: E) => U): T | U;
   /**
    * The success value, or `null` on `Err`.
    *
@@ -573,7 +574,7 @@ export type AsyncResultMethods<T, E> = {
   /** Asynchronous {@link ResultMethods.unwrapOr | unwrapOr}. */
   unwrapOr<U>(fallback: U): Promise<T | U>;
   /** Asynchronous {@link ResultMethods.unwrapOrElse | unwrapOrElse}. */
-  unwrapOrElse(f: (error: E) => T): Promise<T>;
+  unwrapOrElse<U>(f: (error: E) => U): Promise<T | U>;
   /** Asynchronous {@link ResultMethods.getOrNull | getOrNull}. */
   getOrNull(): Promise<T | null>;
   /** Asynchronous {@link ResultMethods.getOrUndefined | getOrUndefined}. */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -420,8 +420,11 @@ export type Result<T, E> = OkView<T, E> | ErrView<E, T> | DefectView<T, E>;
  * An {@link AsyncResult}'s internal promise never rejects, so `await`-ing one
  * always yields a {@link Result} and never throws — there is no rejection
  * channel to model, and none is advertised. At runtime it is still a thenable
- * (the only way `await` can collapse it); the narrowing simply keeps it from
- * being treated as a raw promise (e.g. dropped into `Promise.all`).
+ * (the only way `await` can collapse it), and `Promise.all` / `Promise.resolve`
+ * will still adopt it — harmlessly, since it settles to a `Result` and never
+ * rejects. What the narrowing prevents is treating it as a full promise:
+ * `.catch()` / `.finally()` do not type-check, because there is no rejection to
+ * handle.
  *
  * @typeParam T - the value `await` resolves to.
  *

--- a/packages/effect/LICENSE
+++ b/packages/effect/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Benoit Travers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/effect/README.md
+++ b/packages/effect/README.md
@@ -42,4 +42,4 @@ onDefect)` **forces** you to triage the defect into `E` (Thesis #3). `fromEither
 
 ## License
 
-[MIT](../../LICENSE) © Benoit TRAVERS
+[MIT](https://github.com/btravstack/unthrown/blob/main/LICENSE) © Benoit TRAVERS

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -23,14 +23,13 @@
     "directory": "packages/effect"
   },
   "files": [
-    "dist",
-    "docs"
+    "dist"
   ],
   "type": "module",
   "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.mts",
+  "types": "./dist/index.d.cts",
   "exports": {
     ".": {
       "import": {
@@ -52,7 +51,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "unthrown": "workspace:*"
+    "unthrown": "workspace:^"
   },
   "devDependencies": {
     "@types/node": "catalog:",
@@ -70,6 +69,6 @@
     "effect": "^3"
   },
   "engines": {
-    "node": ">=22.19"
+    "node": ">=20"
   }
 }

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -66,6 +66,15 @@ export function toExit<T, E>(result: Result<T, E>): Exit.Exit<T, E> {
  * @typeParam T - the success value type.
  * @typeParam E - the modeled error type.
  * @param exit - the exit to convert.
+ *
+ * @example
+ * ```ts
+ * import { Exit } from "effect";
+ * import { fromExit } from "@unthrown/effect";
+ *
+ * const result = fromExit(Exit.succeed(1));
+ * result.isOk(); // => true
+ * ```
  */
 export function fromExit<T, E>(exit: Exit.Exit<T, E>): Result<T, E> {
   return Exit.match(exit, {
@@ -94,6 +103,16 @@ export function fromExit<T, E>(exit: Exit.Exit<T, E>): Result<T, E> {
  * @typeParam E - the modeled error type.
  * @param result - the result to convert.
  * @param onDefect - folds a Defect's unknown cause into a modeled `E`.
+ *
+ * @example
+ * ```ts
+ * import { Err } from "unthrown";
+ * import { toEither } from "@unthrown/effect";
+ *
+ * // A Defect has no home in Either — you must fold it into E:
+ * const either = toEither(Err("nope"), (cause) => `bug: ${String(cause)}`);
+ * either._tag; // => "Left"
+ * ```
  */
 export function toEither<T, E>(
   result: Result<T, E>,
@@ -116,6 +135,15 @@ export function toEither<T, E>(
  * @typeParam T - the success value type.
  * @typeParam E - the modeled error type.
  * @param either - the either to convert.
+ *
+ * @example
+ * ```ts
+ * import { Either } from "effect";
+ * import { fromEither } from "@unthrown/effect";
+ *
+ * const result = fromEither(Either.right(1));
+ * result.isOk(); // => true
+ * ```
  */
 export function fromEither<T, E>(either: Either.Either<T, E>): Result<T, E> {
   return Either.match(either, {
@@ -136,6 +164,16 @@ export function fromEither<T, E>(either: Either.Either<T, E>): Result<T, E> {
  * @typeParam T - the success value type.
  * @typeParam E - the modeled error type.
  * @param source - the result, or async result, to lift.
+ *
+ * @example
+ * ```ts
+ * import { Effect } from "effect";
+ * import { Ok } from "unthrown";
+ * import { toEffect } from "@unthrown/effect";
+ *
+ * const effect = toEffect(Ok(1));
+ * await Effect.runPromise(effect); // => 1
+ * ```
  */
 export function toEffect<T, E>(source: Result<T, E>): Effect.Effect<T, E>;
 export function toEffect<T, E>(source: AsyncResult<T, E>): Effect.Effect<T, E>;
@@ -161,6 +199,15 @@ export function toEffect<T, E>(source: Result<T, E> | AsyncResult<T, E>): Effect
  * @typeParam T - the success value type.
  * @typeParam E - the modeled error type.
  * @param effect - the effect to run.
+ *
+ * @example
+ * ```ts
+ * import { Effect } from "effect";
+ * import { fromEffect } from "@unthrown/effect";
+ *
+ * const result = await fromEffect(Effect.succeed(1));
+ * result.isOk(); // => true
+ * ```
  */
 export function fromEffect<T, E>(effect: Effect.Effect<T, E>): AsyncResult<T, E> {
   return fromSafePromise(Effect.runPromiseExit(effect)).flatMap((exit) => fromExit(exit));

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -106,12 +106,15 @@ export function fromExit<T, E>(exit: Exit.Exit<T, E>): Result<T, E> {
  *
  * @example
  * ```ts
- * import { Err } from "unthrown";
+ * import { fromThrowable } from "unthrown";
  * import { toEither } from "@unthrown/effect";
  *
- * // A Defect has no home in Either — you must fold it into E:
- * const either = toEither(Err("nope"), (cause) => `bug: ${String(cause)}`);
- * either._tag; // => "Left"
+ * // Mint a Defect, then convert: it has no home in Either, so onDefect folds it into E.
+ * const defective = fromThrowable((): number => {
+ *   throw new Error("boom");
+ * }, (cause, defect) => defect(cause))();
+ * const either = toEither(defective, (cause) => `bug: ${String(cause)}`);
+ * either._tag; // => "Left" — carrying "bug: Error: boom"
  * ```
  */
 export function toEither<T, E>(

--- a/packages/neverthrow/LICENSE
+++ b/packages/neverthrow/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Benoit Travers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/neverthrow/README.md
+++ b/packages/neverthrow/README.md
@@ -33,4 +33,4 @@ fromNeverthrow(ntOk(1)); // Result<number, never>
 
 ## License
 
-[MIT](../../LICENSE) © Benoit TRAVERS
+[MIT](https://github.com/btravstack/unthrown/blob/main/LICENSE) © Benoit TRAVERS

--- a/packages/neverthrow/package.json
+++ b/packages/neverthrow/package.json
@@ -22,14 +22,13 @@
     "directory": "packages/neverthrow"
   },
   "files": [
-    "dist",
-    "docs"
+    "dist"
   ],
   "type": "module",
   "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.mts",
+  "types": "./dist/index.d.cts",
   "exports": {
     ".": {
       "import": {
@@ -51,7 +50,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "unthrown": "workspace:*"
+    "unthrown": "workspace:^"
   },
   "devDependencies": {
     "@types/node": "catalog:",
@@ -69,6 +68,6 @@
     "neverthrow": "^8"
   },
   "engines": {
-    "node": ">=22.19"
+    "node": ">=20"
   }
 }

--- a/packages/neverthrow/src/index.ts
+++ b/packages/neverthrow/src/index.ts
@@ -34,6 +34,16 @@ import type { AsyncResult, Result } from "unthrown";
  * @typeParam E - the modeled error type.
  * @param result - the result to convert.
  * @param onDefect - folds a Defect's unknown cause into a modeled `E`.
+ *
+ * @example
+ * ```ts
+ * import { Err } from "unthrown";
+ * import { toNeverthrow } from "@unthrown/neverthrow";
+ *
+ * // A Defect has no home in neverthrow — you must fold it into E:
+ * const nt = toNeverthrow(Err("nope"), (cause) => `bug: ${String(cause)}`);
+ * nt.isErr(); // => true
+ * ```
  */
 export function toNeverthrow<T, E>(
   result: Result<T, E>,
@@ -56,6 +66,15 @@ export function toNeverthrow<T, E>(
  * @typeParam T - the success value type.
  * @typeParam E - the modeled error type.
  * @param result - the neverthrow result to convert.
+ *
+ * @example
+ * ```ts
+ * import { ok } from "neverthrow";
+ * import { fromNeverthrow } from "@unthrown/neverthrow";
+ *
+ * const result = fromNeverthrow(ok(1));
+ * result.isOk(); // => true
+ * ```
  */
 export function fromNeverthrow<T, E>(result: NeverthrowResult<T, E>): Result<T, E> {
   return result.isOk() ? Ok(result.value) : Err(result.error);
@@ -78,6 +97,17 @@ export function fromNeverthrow<T, E>(result: NeverthrowResult<T, E>): Result<T, 
  * @typeParam E - the modeled error type.
  * @param asyncResult - the async result to convert.
  * @param onDefect - folds a Defect's unknown cause into a modeled `E`.
+ *
+ * @example
+ * ```ts
+ * import { fromSafePromise } from "unthrown";
+ * import { toNeverthrowAsync } from "@unthrown/neverthrow";
+ *
+ * const asyncResult = fromSafePromise(Promise.resolve(1));
+ * const nt = toNeverthrowAsync(asyncResult, (cause) => `bug: ${String(cause)}`);
+ * const result = await nt;
+ * result.isOk(); // => true
+ * ```
  */
 export function toNeverthrowAsync<T, E>(
   asyncResult: AsyncResult<T, E>,
@@ -99,6 +129,15 @@ export function toNeverthrowAsync<T, E>(
  * @typeParam T - the success value type.
  * @typeParam E - the modeled error type.
  * @param resultAsync - the neverthrow async result to convert.
+ *
+ * @example
+ * ```ts
+ * import { okAsync } from "neverthrow";
+ * import { fromNeverthrowAsync } from "@unthrown/neverthrow";
+ *
+ * const result = await fromNeverthrowAsync(okAsync(1));
+ * result.isOk(); // => true
+ * ```
  */
 export function fromNeverthrowAsync<T, E>(
   resultAsync: NeverthrowResultAsync<T, E>,

--- a/packages/neverthrow/src/index.ts
+++ b/packages/neverthrow/src/index.ts
@@ -37,12 +37,15 @@ import type { AsyncResult, Result } from "unthrown";
  *
  * @example
  * ```ts
- * import { Err } from "unthrown";
+ * import { fromThrowable } from "unthrown";
  * import { toNeverthrow } from "@unthrown/neverthrow";
  *
- * // A Defect has no home in neverthrow — you must fold it into E:
- * const nt = toNeverthrow(Err("nope"), (cause) => `bug: ${String(cause)}`);
- * nt.isErr(); // => true
+ * // Mint a Defect, then convert: it has no home in neverthrow, so onDefect folds it into E.
+ * const defective = fromThrowable((): number => {
+ *   throw new Error("boom");
+ * }, (cause, defect) => defect(cause))();
+ * const nt = toNeverthrow(defective, (cause) => `bug: ${String(cause)}`);
+ * nt.isErr(); // => true — the Err carries "bug: Error: boom"
  * ```
  */
 export function toNeverthrow<T, E>(
@@ -103,10 +106,10 @@ export function fromNeverthrow<T, E>(result: NeverthrowResult<T, E>): Result<T, 
  * import { fromSafePromise } from "unthrown";
  * import { toNeverthrowAsync } from "@unthrown/neverthrow";
  *
- * const asyncResult = fromSafePromise(Promise.resolve(1));
- * const nt = toNeverthrowAsync(asyncResult, (cause) => `bug: ${String(cause)}`);
- * const result = await nt;
- * result.isOk(); // => true
+ * // A rejection inside fromSafePromise is a Defect; onDefect folds it into E on the way out.
+ * const defective = fromSafePromise(Promise.reject(new Error("boom")));
+ * const result = await toNeverthrowAsync(defective, (cause) => `bug: ${String(cause)}`);
+ * result.isErr(); // => true — the Err carries "bug: Error: boom"
  * ```
  */
 export function toNeverthrowAsync<T, E>(

--- a/packages/neverthrow/src/index.ts
+++ b/packages/neverthrow/src/index.ts
@@ -70,6 +70,10 @@ export function fromNeverthrow<T, E>(result: NeverthrowResult<T, E>): Result<T, 
  * same reason. The `AsyncResult` is awaited (it never rejects) and each settled
  * `Result` is converted.
  *
+ * A throwing `onDefect` surfaces as a rejection of the returned
+ * `ResultAsync`'s inner promise — neverthrow's own failure mode; do not throw
+ * from triage.
+ *
  * @typeParam T - the success value type.
  * @typeParam E - the modeled error type.
  * @param asyncResult - the async result to convert.

--- a/packages/oxlint/LICENSE
+++ b/packages/oxlint/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Benoit Travers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/oxlint/README.md
+++ b/packages/oxlint/README.md
@@ -50,4 +50,4 @@ import unthrown from "@unthrown/oxlint";
 
 ## License
 
-[MIT](../../LICENSE) © Benoit TRAVERS
+[MIT](https://github.com/btravstack/unthrown/blob/main/LICENSE) © Benoit TRAVERS

--- a/packages/oxlint/package.json
+++ b/packages/oxlint/package.json
@@ -50,7 +50,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@oxlint/plugins": "catalog:"
+    "@oxlint/plugins": "^1.71.0"
   },
   "devDependencies": {
     "@types/node": "catalog:",
@@ -62,7 +62,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "oxlint": "^1"
+    "oxlint": "^1.69.0"
   },
   "engines": {
     "node": ">=20"

--- a/packages/oxlint/package.json
+++ b/packages/oxlint/package.json
@@ -29,7 +29,7 @@
   "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.mts",
+  "types": "./dist/index.d.cts",
   "exports": {
     ".": {
       "import": {
@@ -65,6 +65,6 @@
     "oxlint": "^1"
   },
   "engines": {
-    "node": ">=22.19"
+    "node": ">=20"
   }
 }

--- a/packages/oxlint/src/rules/prefer-async-result.test.ts
+++ b/packages/oxlint/src/rules/prefer-async-result.test.ts
@@ -41,5 +41,20 @@ ruleTester.run("prefer-async-result", preferAsyncResult, {
       errors: [{ messageId: "preferAsyncResult" }],
       output: null,
     },
+    // An async function's return annotation is reported but NOT auto-fixed:
+    // `async function` must return a native Promise, so rewriting the annotation
+    // to AsyncResult<…> would not compile.
+    {
+      code: `import { AsyncResult, type Result } from "unthrown";
+async function f(): Promise<Result<number, string>> { return null as never; }`,
+      errors: [{ messageId: "preferAsyncResult" }],
+      output: null,
+    },
+    {
+      code: `import { AsyncResult, type Result } from "unthrown";
+const f = async (): Promise<Result<number, string>> => null as never;`,
+      errors: [{ messageId: "preferAsyncResult" }],
+      output: null,
+    },
   ],
 });

--- a/packages/oxlint/src/rules/prefer-async-result.ts
+++ b/packages/oxlint/src/rules/prefer-async-result.ts
@@ -43,6 +43,13 @@ export const preferAsyncResult = defineRule({
     };
 
     return {
+      // Spans are file-relative, but `createOnce` runs once per lint *run* (not
+      // per file) — without a reset, a non-async annotation in a later file at
+      // the same offsets as an earlier file's async one would wrongly lose its
+      // autofix, and the set would grow unbounded across a whole project lint.
+      before: () => {
+        asyncReturnSpans.clear();
+      },
       FunctionDeclaration: trackAsyncFunction,
       FunctionExpression: trackAsyncFunction,
       ArrowFunctionExpression: trackAsyncFunction,

--- a/packages/oxlint/src/rules/prefer-async-result.ts
+++ b/packages/oxlint/src/rules/prefer-async-result.ts
@@ -1,3 +1,4 @@
+import type { ESTree } from "@oxlint/plugins";
 import { defineRule } from "@oxlint/plugins";
 
 import { getImportSource } from "../helpers/get-import-source.js";
@@ -28,7 +29,23 @@ export const preferAsyncResult = defineRule({
     fixable: "code",
   },
   createOnce: (context) => {
+    // Spans of return-type annotations on `async` functions: a report inside
+    // one carries no autofix, because an `async` function must return a
+    // native `Promise` — rewriting the annotation to `AsyncResult<…>` would
+    // not compile. Function nodes are visited before their return-type
+    // children, so the set is populated in time.
+    const asyncReturnSpans = new Set<string>();
+    const trackAsyncFunction = (node: ESTree.Function | ESTree.ArrowFunctionExpression) => {
+      if (node.async && node.returnType) {
+        const t = node.returnType.typeAnnotation;
+        asyncReturnSpans.add(`${t.start}:${t.end}`);
+      }
+    };
+
     return {
+      FunctionDeclaration: trackAsyncFunction,
+      FunctionExpression: trackAsyncFunction,
+      ArrowFunctionExpression: trackAsyncFunction,
       TSTypeReference: (node) => {
         if (!isIdentifierTypeName(node, ["Promise"])) return;
         if (!hasTypeArguments(node, 1)) return;
@@ -41,9 +58,12 @@ export const preferAsyncResult = defineRule({
         const scope = context.sourceCode.getScope(node);
         if (getImportSource(scope, inner.typeName) !== MODULE) return;
 
-        // Only autofix when `AsyncResult` is already importable — otherwise the
-        // rewrite would reference an undefined name. Report without a fix instead.
-        const canFix = hasNamedImport(scope, "AsyncResult", MODULE);
+        // Withhold the fix when this annotation is an `async` function's
+        // return type — see the `asyncReturnSpans` comment above — or when
+        // `AsyncResult` isn't importable (the rewrite would reference an
+        // undefined name).
+        const inAsyncReturn = asyncReturnSpans.has(`${node.start}:${node.end}`);
+        const canFix = !inAsyncReturn && hasNamedImport(scope, "AsyncResult", MODULE);
 
         context.report({
           node,

--- a/packages/pattern/LICENSE
+++ b/packages/pattern/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Benoit Travers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pattern/README.md
+++ b/packages/pattern/README.md
@@ -40,4 +40,4 @@ when you need ts-pattern's guards, nested patterns, or wildcards.
 
 ## License
 
-[MIT](../../LICENSE) © Benoit TRAVERS
+[MIT](https://github.com/btravstack/unthrown/blob/main/LICENSE) © Benoit TRAVERS

--- a/packages/pattern/package.json
+++ b/packages/pattern/package.json
@@ -22,14 +22,13 @@
     "directory": "packages/pattern"
   },
   "files": [
-    "dist",
-    "docs"
+    "dist"
   ],
   "type": "module",
   "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.mts",
+  "types": "./dist/index.d.cts",
   "exports": {
     ".": {
       "import": {
@@ -51,7 +50,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "unthrown": "workspace:*"
+    "unthrown": "workspace:^"
   },
   "devDependencies": {
     "@types/node": "catalog:",
@@ -69,6 +68,6 @@
     "ts-pattern": "^5"
   },
   "engines": {
-    "node": ">=22.19"
+    "node": ">=20"
   }
 }

--- a/packages/pattern/tsdown.config.ts
+++ b/packages/pattern/tsdown.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from "tsdown";
-
-// Keep peer/workspace deps out of the bundle and out of the declaration files
-// so their types are referenced, not inlined.
-export default defineConfig({
-  external: ["unthrown", "ts-pattern"],
-});

--- a/packages/standard-schema/LICENSE
+++ b/packages/standard-schema/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Benoit Travers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/standard-schema/README.md
+++ b/packages/standard-schema/README.md
@@ -38,4 +38,4 @@ library (Zod, Valibot, …) provides the runtime.
 
 ## License
 
-[MIT](../../LICENSE) © Benoit TRAVERS
+[MIT](https://github.com/btravstack/unthrown/blob/main/LICENSE) © Benoit TRAVERS

--- a/packages/standard-schema/package.json
+++ b/packages/standard-schema/package.json
@@ -25,14 +25,13 @@
     "directory": "packages/standard-schema"
   },
   "files": [
-    "dist",
-    "docs"
+    "dist"
   ],
   "type": "module",
   "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.mts",
+  "types": "./dist/index.d.cts",
   "exports": {
     ".": {
       "import": {
@@ -55,7 +54,7 @@
   },
   "dependencies": {
     "@standard-schema/spec": "catalog:",
-    "unthrown": "workspace:*"
+    "unthrown": "workspace:^"
   },
   "devDependencies": {
     "@types/node": "catalog:",
@@ -69,6 +68,6 @@
     "vitest": "catalog:"
   },
   "engines": {
-    "node": ">=22.19"
+    "node": ">=20"
   }
 }

--- a/packages/vitest/LICENSE
+++ b/packages/vitest/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Benoit Travers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -44,4 +44,4 @@ Matchers: `toBeOk`, `toBeOkWith`, `toBeErr`, `toBeErrTagged(tag, expected?)`, `t
 
 ## License
 
-[MIT](../../LICENSE) © Benoit TRAVERS
+[MIT](https://github.com/btravstack/unthrown/blob/main/LICENSE) © Benoit TRAVERS

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -23,13 +23,12 @@
     "directory": "packages/vitest"
   },
   "files": [
-    "dist",
-    "docs"
+    "dist"
   ],
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.mts",
+  "types": "./dist/index.d.cts",
   "exports": {
     ".": {
       "import": {
@@ -50,9 +49,6 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
-  "dependencies": {
-    "unthrown": "workspace:*"
-  },
   "devDependencies": {
     "@types/node": "catalog:",
     "@unthrown/tsconfig": "workspace:*",
@@ -62,12 +58,14 @@
     "typedoc": "catalog:",
     "typedoc-plugin-markdown": "catalog:",
     "typescript": "catalog:",
+    "unthrown": "workspace:^",
     "vitest": "catalog:"
   },
   "peerDependencies": {
+    "unthrown": "workspace:^",
     "vitest": "^4"
   },
   "engines": {
-    "node": ">=22.19"
+    "node": ">=20"
   }
 }

--- a/packages/vitest/src/index.spec.ts
+++ b/packages/vitest/src/index.spec.ts
@@ -62,6 +62,12 @@ describe("toBeErr / toBeErrTagged", () => {
     const r: Result<number, MyError> = Err(new MyError({ code: 42 }));
     expect(r).not.toBeErrTagged("Other", { code: 42 });
   });
+
+  it("toBeErrTagged with an explicitly-passed undefined payload asserts the payload, not tag-only", () => {
+    const r: Result<number, MyError> = Err(new MyError({ code: 1 }));
+    expect(r).toBeErrTagged("MyError"); // one-arg: tag-only, passes
+    expect(r).not.toBeErrTagged("MyError", undefined); // explicit undefined: payload {code:1} !== undefined
+  });
 });
 
 describe("toBeDefect", () => {

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -173,11 +173,35 @@ export { toBeDefect, toBeErr, toBeErrTagged, toBeOk, toBeOkWith };
  * The matchers `@unthrown/vitest` contributes to Vitest's `expect`. For an
  * `AsyncResult`, `await` the assertion; `toBeOkWith` compares deeply.
  *
+ * @remarks
+ * Import the package once (e.g. in a test setup file) to register the
+ * matchers and pull in this type augmentation.
+ *
  * @typeParam R - the assertion's chaining return type.
+ *
+ * @example
+ * ```ts
+ * import "@unthrown/vitest";
+ * import { Ok, fromSafePromise } from "unthrown";
+ * import { expect, test } from "vitest";
+ *
+ * test("sync", () => {
+ *   expect(Ok(1)).toBeOkWith(1);
+ * });
+ *
+ * test("async", async () => {
+ *   await expect(fromSafePromise(Promise.resolve(1))).toBeOk();
+ * });
+ * ```
+ *
+ * @see {@link https://btravstack.github.io/unthrown/guide/testing | The Testing guide}
  */
 export type UnthrownMatchers<R = unknown> = {
+  /** `expect(Ok(1)).toBeOk()` asserts the result is `Ok`, regardless of value. */
   toBeOk: () => R;
+  /** `expect(Ok(1)).toBeOkWith(1)` asserts the result is `Ok` with a deeply-equal value. */
   toBeOkWith: (value: unknown) => R;
+  /** `expect(Err("nope")).toBeErr()` asserts the result is `Err`, regardless of the error. */
   toBeErr: () => R;
   /**
    * Assert an `Err` whose error has `_tag === tag`. Optionally pass `expected`
@@ -186,8 +210,11 @@ export type UnthrownMatchers<R = unknown> = {
    * `expect.objectContaining(...)`) matches partially. An explicitly-passed
    * `undefined` asserts the payload equals `undefined` (it does not degrade
    * to tag-only).
+   *
+   * `expect(result).toBeErrTagged("NotFound", { id })` asserts the tag and payload.
    */
   toBeErrTagged: (tag: string, expected?: unknown) => R;
+  /** `expect(result).toBeDefect()` asserts the result is a `Defect`. */
   toBeDefect: () => R;
 };
 

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -115,9 +115,25 @@ function toBeErrTagged(
   tag: string,
   expected?: unknown,
 ): MatcherResult {
+  // Arity, not `expected !== undefined`, decides whether a payload assertion
+  // was requested: `arguments.length` distinguishes an omitted second
+  // argument (tag-only, length 2) from an explicitly-passed `undefined`
+  // (length 3), so `toBeErrTagged(tag, undefined)` asserts the payload
+  // equals `undefined` instead of silently degrading to tag-only.
+  //
+  // A rest-args parameter list (`...args: [tag] | [tag, expected]`), as
+  // sketched for this fix, would make that arity observable at the type
+  // level too — but it does not typecheck against vitest's `expect.extend`:
+  // `RawMatcherFn`'s `Parameters<Matchers<T>[K]>` derives the plain optional
+  // tuple `[tag: string, expected?: unknown]` from the public
+  // `UnthrownMatchers` type, and TS cannot prove that shape is assignable
+  // into a tuple *union* (only into a plain trailing-optional tuple, which
+  // is what this parameter list already is). `arguments.length` gets the
+  // same runtime distinction without perturbing the signature that
+  // `expect.extend` — and the public `UnthrownMatchers` type — expect.
+  const hasExpected = arguments.length > 2;
   const { stringify } = this.utils;
   const { equals } = this;
-  const hasExpected = expected !== undefined;
   const label = hasExpected
     ? `Err tagged ${stringify(tag)} matching ${stringify(expected)}`
     : `Err tagged ${stringify(tag)}`;
@@ -167,7 +183,9 @@ export type UnthrownMatchers<R = unknown> = {
    * Assert an `Err` whose error has `_tag === tag`. Optionally pass `expected`
    * to also match the error's payload (its own props minus `_tag`/`name`): a
    * plain object matches exactly, an asymmetric matcher (e.g.
-   * `expect.objectContaining(...)`) matches partially.
+   * `expect.objectContaining(...)`) matches partially. An explicitly-passed
+   * `undefined` asserts the payload equals `undefined` (it does not degrade
+   * to tag-only).
    */
   toBeErrTagged: (tag: string, expected?: unknown) => R;
   toBeDefect: () => R;

--- a/packages/vitest/tsdown.config.ts
+++ b/packages/vitest/tsdown.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from "tsdown";
-
-// Keep peer/workspace deps out of the bundle and out of the declaration files
-// so their types are referenced, not inlined.
-export default defineConfig({
-  external: ["unthrown", "vitest"],
-});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,9 +21,6 @@ catalogs:
     '@commitlint/config-conventional':
       specifier: 21.1.0
       version: 21.1.0
-    '@oxlint/plugins':
-      specifier: 1.71.0
-      version: 1.71.0
     '@standard-schema/spec':
       specifier: 1.1.0
       version: 1.1.0
@@ -289,7 +286,7 @@ importers:
   packages/oxlint:
     dependencies:
       '@oxlint/plugins':
-        specifier: 'catalog:'
+        specifier: ^1.71.0
         version: 1.71.0
     devDependencies:
       '@types/node':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,7 +148,7 @@ importers:
   packages/boxed:
     dependencies:
       unthrown:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
     devDependencies:
       '@bloodyowl/boxed':
@@ -215,7 +215,7 @@ importers:
   packages/effect:
     dependencies:
       unthrown:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
     devDependencies:
       '@types/node':
@@ -252,7 +252,7 @@ importers:
   packages/neverthrow:
     dependencies:
       unthrown:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
     devDependencies:
       '@types/node':
@@ -317,7 +317,7 @@ importers:
   packages/pattern:
     dependencies:
       unthrown:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
     devDependencies:
       '@types/node':
@@ -357,7 +357,7 @@ importers:
         specifier: 'catalog:'
         version: 1.1.0
       unthrown:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
     devDependencies:
       '@types/node':
@@ -389,10 +389,6 @@ importers:
         version: 4.1.8(@types/node@24.13.2)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   packages/vitest:
-    dependencies:
-      unthrown:
-        specifier: workspace:*
-        version: link:../core
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -418,6 +414,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      unthrown:
+        specifier: workspace:^
+        version: link:../core
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@types/node@24.13.2)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,6 @@ catalog:
   "@btravstack/theme": 1.5.0
   "@standard-schema/spec": 1.1.0
   "@commitlint/config-conventional": 21.1.0
-  "@oxlint/plugins": 1.71.0
   "@types/node": 24.13.2
   "@vitest/coverage-v8": 4.1.8
   effect: 3.21.4


### PR DESCRIPTION
## Summary

Fixes every finding from the 2026-07-08 full-repository review, across core soundness, runtime hardening, packaging, the oxlint plugin, satellites, docs, and release plumbing. 33 commits; every task was implemented TDD-style, individually spec-reviewed, and the branch passed a final whole-branch review ("ready to merge") with all findings fixed.

### Core (`unthrown`)
- **`NotThenable`**: async callbacks passed to `map`/`tap`/`tapErr`/`tapDefect`/`let`/`mapErr`/`recover` are now a compile error on both surfaces — such code already broke the "no failure escapes a pipeline" guarantee at runtime (the rejection floated unhandled). `match`/`unwrapOrElse` handlers stay exempt (edge elimination).
- A throw inside `tapErr`/`tapDefect`/`flatTapErr` no longer destroys the failure being observed: the Defect's cause is now `AggregateError([thrown, original])`.
- `matchTags` routes unhandled/rogue tags (incl. prototype-chain tricks like `"constructor"`) to the `Defect` handler instead of crashing, and rejects reserved `"Ok"`/`"Defect"` tags at compile time.
- `unwrapOr` / `unwrapOrElse` widen: `<U>(…): T | U`.
- `fromPromise`/`fromSafePromise` absorb non-thenable inputs; `bind`/`let` reject an array scope as misuse (Defect); Result instances are frozen (variants can't be forged by mutation); `foldRecord` breaks early on a dominating Defect; the false `Promise.all` claim in the `Awaitable` docs is corrected.
- New pinning tests: `Err(undefined/null)`, `Ok(Err)` non-flattening, `__proto__` do-notation keys, thenable adoption, double-await.

### Packaging (all 8 packages)
- `workspace:*` → `workspace:^` (exact pins created a dual-copy hazard with the `instanceof`-based `isResult`); **`@unthrown/vitest` now takes core as a peerDependency**.
- `LICENSE` ships in every tarball; legacy `types` fallback points at the CJS declarations; `engines.node` relaxed to `>=20`; `docs/` dropped from `files`; dead tsdown `external` configs removed (byte-identical dist verified).

### Satellites
- **oxlint**: `prefer-async-result` no longer offers an autofix on an `async` function's return annotation (the rewrite couldn't compile) and resets its span state per file; peer range corrected to `^1.69.0`.
- **vitest**: `toBeErrTagged(tag, undefined)` now asserts the payload instead of degrading to tag-only.
- **boxed**: a throwing `onDefect` no longer hangs the returned `Future` (out-of-band rethrow, scoped so subscriber throws aren't intercepted).

### Docs
- Landing-page hero sample fixed (the old `fetch`/`instanceof Response` qualify had an unreachable `err` branch); API overview lists all 7 packages; dead "Edit this page" links suppressed on generated API pages; "Continue →" reading trail follows the sidebar; right-rail outline shows h3s.
- New guides: **Migrating from neverthrow** (verified against both libraries by execution) and **From try/catch**; new recipes: a Hono route end-to-end and form validation with `@unthrown/standard-schema`; "Why not a generator (`safeTry`)?" rationale in Do Notation; `@example` blocks across all satellite APIs (the `onDefect` folds genuinely execute).
- CLAUDE.md synced with all of the above (every claim code-verified in review).

### Release
- Changesets for a unified **3.1.0 minor**. `.changeset/config.json` now sets `onlyUpdatePeerDependentsWhenOutOfRange` — without it, the new vitest peerDependency + the fixed group would have silently forced an unintended **4.0.0 major** across all packages (verified via `assembleReleasePlan` before and after).

Also (separate branch): `feat/maperr-defect`'s changeset now documents the point-free arity hazard instead of claiming backward compatibility. Note for that branch's future merge: carry `NotThenable` onto the new `mapErr` signature's return when resolving the conflict.

## Test plan
- Full gate green: `pnpm format --check && pnpm lint && pnpm typecheck && pnpm knip && pnpm test && pnpm build` (222 core tests incl. type-level, all satellites).
- Docs site builds clean (`pnpm --filter @unthrown/docs build`), all `build:docs` typedoc-warning-free.
- `pnpm changeset status`: unified 3.1.0 minor across the fixed group.
- Tarball dry-runs: LICENSE included, no `docs/`, correct types fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)