### PR TITLE
feat(core)!: reserve `message` in the TaggedError payload

### DIFF
--- a/.changeset/tagged-error-reserve-message.md
+++ b/.changeset/tagged-error-reserve-message.md
@@ -1,0 +1,31 @@
+---
+"unthrown": major
+---
+
+`TaggedError` now reserves `message` in the payload, alongside `name`. A payload
+field named `message` is rejected at compile time (`message?: never`), and the
+base constructor no longer forwards a payload `message` to `Error`. Define an
+error's message once per subclass the standard way — `override message = "…"`
+(it may interpolate the payload via `this`, since the base populates the fields
+before the subclass field initialiser runs) — so the payload carries only
+structured domain fields, never the human string.
+
+**Breaking:** an error declaring `<{ message: string; … }>` and constructed with
+`new E({ message, … })` no longer type-checks, and the message is no longer taken
+from the payload at runtime. Move the message to an `override message` field and
+drop it from the payload:
+
+```ts
+// before
+class TicketNotFound extends TaggedError("TICKET_NOT_FOUND")<{
+  message: string;
+  ticketId: string;
+}> {}
+new TicketNotFound({ message: "Ticket not found", ticketId });
+
+// after
+class TicketNotFound extends TaggedError("TICKET_NOT_FOUND")<{ ticketId: string }> {
+  override message = "Ticket not found";
+}
+new TicketNotFound({ ticketId });
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,15 @@ was planned).
 4. **`TaggedError` is the error convention** (à la Effect's `Data.TaggedError`):
    a `_tag` discriminant on a class extending `Error`. Core `Result<T, E>` stays
    **generic in `E`** (unconstrained); only the tag-aware utilities require
-   `E extends { _tag: string }`.
+   `E extends { _tag: string }`. The payload carries **only structured domain
+   fields** — both `name` and `message` are **reserved** out of it (each typed
+   `?: never`): `name` is the display label (set via `options.name`), and
+   `message` is `Error`'s human string, defined once per subclass the standard
+   way (`override message = "…"`, which may interpolate the payload via `this`
+   because the base populates the fields before the subclass field initialiser
+   runs). Keeping `message` off the payload is deliberate — contextual detail
+   lives in typed fields, defined per error type, never baked into a per-call
+   string.
 
 ## Load-bearing runtime invariants (tests must guard these)
 
@@ -181,7 +189,9 @@ async work re-enters via `fromPromise` / `fromSafePromise` and composes with
 - tagged errors: `TaggedError(tag, options?)` (the error-class factory; optional
   `options.name` sets `Error.name` independently of the `_tag` discriminant, so a
   tag can be namespaced for collision-safety without leaking into the display
-  name) and `matchTags(result, handlers)` (an exhaustive `{ Ok, Defect } &
+  name; the payload reserves `name` **and** `message` via `?: never`, so the
+  message is set per subclass with `override message = "…"`, never as a payload
+  field) and `matchTags(result, handlers)` (an exhaustive `{ Ok, Defect } &
 per-tag` fold; has an async overload resolving to `Promise<R>`); see the
   `TaggedError` convention in Thesis #4.
 

--- a/docs/guide/tagged-errors.md
+++ b/docs/guide/tagged-errors.md
@@ -20,9 +20,38 @@ new NotFound()._tag; // "NotFound"
 new Forbidden({ user: "bob" }).user; // "bob"
 ```
 
-The class extends `Error` (so `instanceof Error` holds and stacks work), the
-`_tag` is authoritative (a payload can't overwrite it), and a `message` field in
-the payload is forwarded to `Error`.
+The class extends `Error` (so `instanceof Error` holds and stacks work) and the
+`_tag` is authoritative (a payload can't overwrite it).
+
+### Defining the message
+
+`message` is **not** a payload field — it's the human string owned by `Error`,
+not structured data, so it's reserved (a payload `message` is a compile error,
+like `name`). Set it the standard way, **once per subclass**, with `override
+message`:
+
+```ts
+class TicketNotFound extends TaggedError("TicketNotFound")<{ ticketId: string }> {
+  override message = "ticket not found";
+}
+
+new TicketNotFound({ ticketId: "t1" }).message; // "ticket not found"
+```
+
+The field may interpolate the payload via `this` — the base populates the
+payload fields before the subclass field initialiser runs:
+
+```ts
+class InvalidState extends TaggedError("InvalidState")<{ got: string; want: string }> {
+  override message = `expected ${this.want}, got ${this.got}`;
+}
+```
+
+Keeping the message off the payload is deliberate: the contextual detail that
+used to get baked into a per-call string (`` `no manager for ${id}` ``) lives in
+**typed fields** instead — greppable, matchable, and defined once per error type
+rather than drifting across call sites. For a message that needs real branching,
+set `this.message` in a constructor override.
 
 ### Namespacing the tag without renaming the error
 
@@ -34,9 +63,11 @@ collision-safety without that prefix leaking into the display name:
 ```ts
 class RetryableError extends TaggedError("@my-lib/RetryableError", {
   name: "RetryableError",
-})<{ message: string }> {}
+}) {
+  override message = "boom";
+}
 
-const e = new RetryableError({ message: "boom" });
+const e = new RetryableError();
 e._tag; // "@my-lib/RetryableError" — namespaced discriminant
 e.name; // "RetryableError"          — clean stack-trace label
 ```

--- a/packages/core/src/tagged.spec.ts
+++ b/packages/core/src/tagged.spec.ts
@@ -12,7 +12,7 @@ import {
 
 class NotFound extends TaggedError("NotFound") {}
 class Forbidden extends TaggedError("Forbidden")<{ user: string }> {}
-class HttpError extends TaggedError("HttpError")<{ status: number; message: string }> {}
+class HttpError extends TaggedError("HttpError")<{ status: number }> {}
 type ApiError = NotFound | Forbidden | HttpError;
 
 describe("TaggedError", () => {
@@ -32,11 +32,28 @@ describe("TaggedError", () => {
     expect(e).toBeInstanceOf(Forbidden);
   });
 
-  it("forwards a `message` payload field to Error", () => {
-    const e = new HttpError({ status: 500, message: "boom" });
-    expect(e.message).toBe("boom");
-    expect(e.status).toBe(500);
-    expect(e._tag).toBe("HttpError");
+  it("defines Error.message per subclass via a standard `override message` field", () => {
+    class Timeout extends TaggedError("Timeout") {
+      override message = "request timed out";
+    }
+    const e = new Timeout();
+    expect(e.message).toBe("request timed out");
+    expect(e._tag).toBe("Timeout");
+  });
+
+  it("lets the message field interpolate the payload fields via `this`", () => {
+    class RangeErr extends TaggedError("RangeErr")<{ min: number; max: number }> {
+      override message = `expected ${this.min}..${this.max}`;
+    }
+    const e = new RangeErr({ min: 1, max: 9 });
+    expect(e.message).toBe("expected 1..9");
+    expect(e.min).toBe(1);
+    expect(e._tag).toBe("RangeErr");
+  });
+
+  it("leaves Error.message empty when the subclass does not set one", () => {
+    class Bare extends TaggedError("Bare") {}
+    expect(new Bare().message).toBe("");
   });
 
   it("keeps `_tag` authoritative even if the payload tries to set it", () => {
@@ -62,10 +79,10 @@ describe("TaggedError", () => {
   });
 
   it("decouples Error.name from a namespaced _tag via options.name", () => {
-    class Retryable extends TaggedError("@my-lib/Retryable", { name: "Retryable" })<{
-      message: string;
-    }> {}
-    const e = new Retryable({ message: "boom" });
+    class Retryable extends TaggedError("@my-lib/Retryable", { name: "Retryable" }) {
+      override message = "boom";
+    }
+    const e = new Retryable();
     expect(e._tag).toBe("@my-lib/Retryable"); // namespaced discriminant
     expect(e.name).toBe("Retryable"); // clean display name
     expect(e.message).toBe("boom");
@@ -99,7 +116,7 @@ describe("matchTags", () => {
   it("dispatches each tagged error to the handler matching its _tag", () => {
     expect(fold(Err(new NotFound()))).toBe("not-found");
     expect(fold(Err(new Forbidden({ user: "bob" })))).toBe("forbidden:bob");
-    expect(fold(Err(new HttpError({ status: 503, message: "down" })))).toBe("http:503");
+    expect(fold(Err(new HttpError({ status: 503 })))).toBe("http:503");
   });
 
   it("narrows each error variant to its payload in its handler", () => {

--- a/packages/core/src/tagged.spec.ts
+++ b/packages/core/src/tagged.spec.ts
@@ -68,6 +68,14 @@ describe("TaggedError", () => {
     expect(e.user).toBe("Alice");
   });
 
+  it("keeps `message` reserved — a payload `message` cannot set Error.message", () => {
+    class UserError extends TaggedError("UserError")<{ user: string }> {}
+    // An untyped/JS caller sneaks a `message` past the compile-time reservation.
+    const e = new UserError({ user: "Bob", message: "sneaky" } as { user: string });
+    expect(e.message).toBe(""); // dropped — message is not sourced from the payload
+    expect(e.user).toBe("Bob");
+  });
+
   it("distinct tags produce distinct, discriminable classes", () => {
     const errors: ApiError[] = [new NotFound(), new Forbidden({ user: "a" })];
     expect(errors.map((e) => e._tag)).toEqual(["NotFound", "Forbidden"]);

--- a/packages/core/src/tagged.ts
+++ b/packages/core/src/tagged.ts
@@ -105,12 +105,14 @@ export function TaggedError<Tag extends string>(
     constructor(props?: Props) {
       super();
       if (props) Object.assign(this, props);
-      // `_tag` and `name` are authoritative — assigned after the payload so an
-      // untyped caller can't clobber them. `message` is left to `Error` (and to
-      // the subclass's own `override message = …`, whose field initialiser runs
-      // after this constructor returns, once the payload fields are populated).
+      // `_tag`, `name`, and `message` are authoritative — an untyped caller
+      // can't set them via the payload. `_tag`/`name` are re-assigned to their
+      // canonical values; `message` is `Error`'s channel (set per subclass via
+      // `override message = …`, whose field initialiser runs after this
+      // constructor returns), so any payload-supplied `message` is dropped here.
       (this as { _tag: Tag })._tag = tag;
       this.name = displayName;
+      delete (this as { message?: unknown }).message;
       Object.setPrototypeOf(this, new.target.prototype);
     }
   }

--- a/packages/core/src/tagged.ts
+++ b/packages/core/src/tagged.ts
@@ -15,7 +15,7 @@ type Props = Record<string, unknown>;
  * @category Types
  */
 export type TaggedErrorInstance<Tag extends string, A extends Props> = Error &
-  Readonly<Omit<A, "name">> & { readonly _tag: Tag };
+  Readonly<Omit<A, "name" | "message">> & { readonly _tag: Tag };
 
 /**
  * The class constructor returned by {@link TaggedError}. Generic in its payload:
@@ -23,10 +23,13 @@ export type TaggedErrorInstance<Tag extends string, A extends Props> = Error &
  *
  * @remarks
  * When the payload is empty, the constructor takes **no** arguments (the
- * `keyof A extends never ? void : A` trick); otherwise it takes the payload. A
- * `name` key is **rejected** (`name?: never`) because it is reserved for the
- * display label — mirroring how {@link TaggedErrorInstance} excludes it — so the
- * reservation is enforced at the call site, not just ignored at runtime.
+ * `keyof A extends never ? void : A` trick); otherwise it takes the payload. The
+ * `name` and `message` keys are both **rejected** (`name?: never` /
+ * `message?: never`) because both are reserved: `name` is the display label, and
+ * `message` is the human string owned by `Error`. Set the message the standard
+ * way — `override message = "…"` (or a constructor override) on the subclass —
+ * never as a free-form per-call payload field. The reservations are enforced at
+ * the call site, mirroring how {@link TaggedErrorInstance} excludes both.
  *
  * @typeParam Tag - the string literal discriminant.
  *
@@ -34,7 +37,7 @@ export type TaggedErrorInstance<Tag extends string, A extends Props> = Error &
  */
 export type TaggedErrorConstructor<Tag extends string> = {
   new <A extends Props = {}>(
-    args: keyof A extends never ? void : A & { readonly name?: never },
+    args: keyof A extends never ? void : A & { readonly name?: never; readonly message?: never },
   ): TaggedErrorInstance<Tag, A>;
 };
 
@@ -44,8 +47,13 @@ export type TaggedErrorConstructor<Tag extends string> = {
  *
  * @remarks
  * Extend the returned class to declare a concrete error. Supply the payload with
- * an instantiation expression; omit it for a payload-less error. A `message`
- * field in the payload is forwarded to `Error`. The `_tag` always reflects
+ * an instantiation expression; omit it for a payload-less error. The `message`
+ * is **not** a payload field — it is the human string owned by `Error`, not
+ * structured data, so it is reserved. Define it once per subclass the standard
+ * way, `override message = "…"` (it may interpolate the payload via `this`,
+ * which the base populates before the subclass field initialiser runs); a
+ * payload `message` is rejected at compile time, so contextual detail lives in
+ * typed fields, never baked into per-call prose. The `_tag` always reflects
  * `tag` and cannot be overridden by the payload. `name` is likewise reserved —
  * it is the display label (set it with `options.name`); a payload `name` is
  * rejected at compile time (and excluded from the instance type), so it can't
@@ -60,11 +68,14 @@ export type TaggedErrorConstructor<Tag extends string> = {
  * ```ts
  * class RetryableError extends TaggedError("@my-lib/RetryableError", {
  *   name: "RetryableError",
- * })<{ message: string }> {}
+ * }) {
+ *   override message = "operation failed; safe to retry";
+ * }
  *
- * const e = new RetryableError({ message: "boom" });
- * e._tag; // "@my-lib/RetryableError" — namespaced discriminant
- * e.name; // "RetryableError"          — clean display name
+ * const e = new RetryableError();
+ * e._tag;    // "@my-lib/RetryableError" — namespaced discriminant
+ * e.name;    // "RetryableError"          — clean display name
+ * e.message; // "operation failed; safe to retry" — the standard Error.message
  * ```
  *
  * @typeParam Tag - the string literal discriminant.
@@ -92,10 +103,12 @@ export function TaggedError<Tag extends string>(
     readonly _tag!: Tag;
 
     constructor(props?: Props) {
-      super(typeof props?.["message"] === "string" ? (props["message"] as string) : undefined);
+      super();
       if (props) Object.assign(this, props);
-      // The tag is authoritative — assign it after the payload so it can't be
-      // clobbered. `name` is the display label, independent of the discriminant.
+      // `_tag` and `name` are authoritative — assigned after the payload so an
+      // untyped caller can't clobber them. `message` is left to `Error` (and to
+      // the subclass's own `override message = …`, whose field initialiser runs
+      // after this constructor returns, once the payload fields are populated).
       (this as { _tag: Tag })._tag = tag;
       this.name = displayName;
       Object.setPrototypeOf(this, new.target.prototype);

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -246,10 +246,22 @@ class WithCode extends TaggedError("WithCode")<{ code: number }> {}
 new WithCode({ code: 1 });
 // @ts-expect-error - a `name` payload key is reserved, not constructable
 new WithCode({ code: 1, name: "nope" });
+// @ts-expect-error - a `message` payload key is reserved (owned by Error)
+new WithCode({ code: 1, message: "nope" });
 // Even a forced `name` payload does not narrow `Error.name`: it stays `string`.
 type _nameNotShadowed = Expect<
   Equal<TaggedErrorInstance<"X", { code: number; name: "lit" }>["name"], string>
 >;
+// Likewise a forced `message` payload does not narrow `Error.message`.
+type _messageNotShadowed = Expect<
+  Equal<TaggedErrorInstance<"X", { code: number; message: "lit" }>["message"], string>
+>;
+// The message is defined per subclass the standard way — `override message`,
+// which may interpolate the payload via `this`.
+class WithMsg extends TaggedError("WithMsg")<{ ticketId: string }> {
+  override message = `ticket ${this.ticketId} not found`;
+}
+new WithMsg({ ticketId: "t1" });
 
 // ---------------------------------------------------------------------------
 // Thenable callbacks are rejected: an async callback's rejection would bypass


### PR DESCRIPTION
## What

`message` is `Error`'s human string, not structured payload data — so it is now **reserved out of the `TaggedError` payload** (`message?: never`), exactly the way `name` already is. The base constructor no longer forwards a payload `message` to `Error`; instead you define the message **once per subclass** the standard way:

```ts
// before — message rode inside the payload, passed at every call site
class TicketNotFound extends TaggedError("TICKET_NOT_FOUND")<{
  message: string;
  ticketId: string;
}> {}
new TicketNotFound({ message: "Ticket not found", ticketId });

// after — payload is structured fields only; message is defined on the class
class TicketNotFound extends TaggedError("TICKET_NOT_FOUND")<{ ticketId: string }> {
  override message = "Ticket not found";
}
new TicketNotFound({ ticketId });
```

The `override message` field may interpolate the payload via `this` (the base populates the fields before the subclass field initialiser runs). For branchy logic, set `this.message` in a constructor override.

## Why

Contextual detail baked into a per-call message string is unparseable data — it belongs in **typed fields**, defined once per error type, not drifting across call sites. Reserving `message` makes that structural, and mirrors the existing `name` reservation.

## Breaking change

- A payload field named `message` is now a **compile error**.
- `Error.message` is no longer taken from the payload at runtime.

Migration: move the message to an `override message` field and drop it from the payload. A `major` changeset is included.

> Note on `@unthrown/vitest`: with the field pattern, `message` becomes an **own enumerable** property, so it now appears in `toBeErrTagged`'s payload comparison (previously excluded only by the accident of being non-enumerable). Assertions that exact-match a payload should include `message`. Left as-is here; a follow-up could have `payloadOf` ignore Error's own keys.

## Verification

`typecheck`, `test` (193, 100% line/function coverage), `lint`, `format`, `knip`, `build`, `build:docs` — all green. Runtime + type-level tests updated (`tagged.spec.ts`, `types.test-d.ts`); guide (`tagged-errors.md`) and the `CLAUDE.md` thesis updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)