### PR TITLE
docs: document the beta pre-release flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,45 @@ Pick the affected packages and a semver bump, and describe the change in one lin
 Purely internal changes (tests, CI, refactors with no API/behaviour impact) don't
 need one.
 
+### Pre-releases (beta)
+
+When a change is breaking, or a batch of changes needs to be validated in a real
+consumer before it becomes a stable major, publish it as a **beta** first instead
+of cutting the major straight to `latest`. This uses [changesets pre
+mode](https://github.com/changesets/changesets/blob/main/docs/prereleases.md); all
+eight packages are `fixed`, so they move together to the same beta version.
+
+The release pipeline needs **no changes** — while a `.changeset/pre.json` is
+present, `changeset publish` (run by `release.yml`) publishes under the `beta`
+dist-tag instead of `latest` automatically. Because every package already has a
+stable release on npm, none of them fall back to `latest`.
+
+```sh
+# 1. Enter pre mode (once, from a clean main). Commit the .changeset/pre.json it
+#    writes and merge it — from here every release is a beta.
+pnpm changeset pre enter beta
+
+# 2. Iterate. Add changesets as usual; each merged "Version Packages" PR ships the
+#    next x.y.z-beta.N to the `beta` tag. Do NOT delete accumulated changesets —
+#    they are all consumed to build the final changelog at exit.
+
+# 3. Graduate. The next "Version Packages" PR after this cuts the stable version to
+#    `latest`.
+pnpm changeset pre exit
+```
+
+Consume a beta from a downstream project with:
+
+```sh
+pnpm add unthrown@beta
+```
+
+> **Note:** while in pre mode on `main` you cannot ship a stable patch to `latest`
+> until `pre exit` — every release is a beta. That is the intended trade for
+> batching breaking changes toward a major. If `main` must keep shipping stable
+> patches in parallel, run pre mode on a dedicated `next` branch instead (and set
+> `branch: next` on the changesets action) rather than on `main`.
+
 ## Pull requests
 
 - Keep PRs focused — one concern each.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,12 +101,13 @@ stable release on npm, none of them fall back to `latest`.
 #    writes and merge it — from here every release is a beta.
 pnpm changeset pre enter beta
 
-# 2. Iterate. Add changesets as usual; each merged "Version Packages" PR ships the
-#    next x.y.z-beta.N to the `beta` tag. Do NOT delete accumulated changesets —
-#    they are all consumed to build the final changelog at exit.
+# 2. Iterate. Add changesets as usual; each merged release PR (the one this repo's
+#    workflow titles "chore: release packages") ships the next x.y.z-beta.N to the
+#    `beta` tag. Do NOT delete accumulated changesets — they are all consumed to
+#    build the final changelog at exit.
 
-# 3. Graduate. The next "Version Packages" PR after this cuts the stable version to
-#    `latest`.
+# 3. Graduate. The next "chore: release packages" PR after this cuts the stable
+#    version to `latest`.
 pnpm changeset pre exit
 ```
 
@@ -118,9 +119,12 @@ pnpm add unthrown@beta
 
 > **Note:** while in pre mode on `main` you cannot ship a stable patch to `latest`
 > until `pre exit` — every release is a beta. That is the intended trade for
-> batching breaking changes toward a major. If `main` must keep shipping stable
-> patches in parallel, run pre mode on a dedicated `next` branch instead (and set
-> `branch: next` on the changesets action) rather than on `main`.
+> batching breaking changes toward a major. Running pre mode on a dedicated `next`
+> branch instead is possible but not a one-line change: the release pipeline is
+> currently hard-wired to `main` in three places — `baseBranch` in
+> `.changeset/config.json`, the `workflow_run` trigger in `release.yml`, and the
+> changesets action's `branch` input would need to point at `next` — so that setup
+> is out of scope for this note.
 
 ## Pull requests
 


### PR DESCRIPTION
## Summary

Adds a **Pre-releases (beta)** section to `CONTRIBUTING.md` so breaking changes can be batched and validated as a beta before a stable major is cut to `latest`, instead of burning majors.

Documents the [changesets pre mode](https://github.com/changesets/changesets/blob/main/docs/prereleases.md) flow:

- `pnpm changeset pre enter beta` → iterate (each merged *Version Packages* PR ships `x.y.z-beta.N` to the `beta` tag) → `pnpm changeset pre exit` to graduate to `latest`.
- Consume with `pnpm add unthrown@beta`.
- Caveat that while in pre mode on `main` every release is a beta until `pre exit`, with the dedicated-`next`-branch alternative.

## Why no pipeline change

While `.changeset/pre.json` exists, `changeset publish` (run by `release.yml`) auto-tags to `beta` instead of `latest` — verified in the changesets CLI (`getReleaseTag`). All 8 `fixed` packages already have a stable release on npm, so none fall back to `latest`. Trusted Publishing keeps working since publishing still originates from `release.yml`.

Docs-only; no code or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)