### PR TITLE
docs: document the tap vs flatTap fire-and-forget footgun

### DIFF
--- a/docs/guide/choosing-a-combinator.md
+++ b/docs/guide/choosing-a-combinator.md
@@ -123,6 +123,46 @@ you nest a `Result<Result<…>>`).
 the original (a validation or write whose _outcome_ matters but whose _value_
 you don't need). `tapErr`/`flatTapErr` are the same pair on the error channel.
 
+**`tap` vs `flatTap`** — decided by what the _effect_ returns, not by what you do
+with its value (both keep the original). An effect that cannot fail — logging, a
+metric — is `tap`; an effect that returns a `Result`/`AsyncResult` **must** be
+sequenced with `flatTap` on the matching surface, because a `tap` callback cannot
+thread it. `tapErr`/`flatTapErr` split the same way on the error channel.
+
+::: warning A `Result`-returning effect inside `tap` is a fire-and-forget
+`tap` ignores its callback's return value, so the effect's outcome is lost — in
+one of two shapes:
+
+- a **sync `Result`** returned from the callback compiles (a `Result` is not a
+  thenable), but its `Err` is silently discarded;
+- an **`AsyncResult`** is rejected at compile time (it is awaitable, so
+  `NotThenable` catches it) — and the tempting "fix" of wrapping the call in
+  braces compiles, but leaves the effect **floating**: never awaited, its
+  `Err`/`Defect` unobserved.
+
+```ts
+.tap((user) => {
+  auditLog.record(user); // AsyncResult — floats, never awaited
+})
+```
+
+Sequence the effect instead. A `Result`-returning effect goes in `flatTap` on
+either surface; an `AsyncResult`-returning one only in the **async** `flatTap` —
+the sync one takes only a `Result`, so lift a still-sync chain with `.toAsync()`
+first ([Result and AsyncResult](#result-and-asyncresult)). A raw `Promise` gets
+qualified through `fromPromise` / `fromSafePromise` before either. Here the
+chain is already an `AsyncResult`, so `flatTap` takes the effect directly, awaits
+it, and short-circuits on its failure:
+
+```ts
+.flatTap((user) => auditLog.record(user))
+```
+
+If a fire-and-forget is deliberate, say so in a comment at the call site —
+otherwise the same effect ends up `tap`ped at one site and `flatTap`ped at
+another, and a reviewer has to guess which one is the bug.
+:::
+
 **`orElse` vs `recover`** — both run on `Err`. `recover` produces a plain success
 value (emptying the error channel to `never`); `orElse` produces another `Result`
 (which may still be an `Err`).

--- a/docs/guide/choosing-a-combinator.md
+++ b/docs/guide/choosing-a-combinator.md
@@ -129,7 +129,7 @@ metric — is `tap`; an effect that returns a `Result`/`AsyncResult` **must** be
 sequenced with `flatTap` on the matching surface, because a `tap` callback cannot
 thread it. `tapErr`/`flatTapErr` split the same way on the error channel.
 
-::: warning A `Result`-returning effect inside `tap` is a fire-and-forget
+::: warning A failable effect inside `tap` is silently dropped
 `tap` ignores its callback's return value, so the effect's outcome is lost — in
 one of two shapes:
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -85,6 +85,15 @@ export type ResultMethods<T, E> = {
    * Runs only on `Ok`. If `f` throws, the throw becomes a `Defect`. An async
    * callback is rejected at compile time ({@link NotThenable}).
    *
+   * @remarks
+   * `f`'s return value is **ignored** — a `Result` returned by the effect
+   * compiles but is discarded, `Err` and all. If the effect can fail, sequence
+   * it instead of tapping it: a `Result`-returning effect goes in
+   * {@link ResultMethods.flatTap | flatTap}; an `AsyncResult`-returning effect
+   * cannot be sequenced from the sync surface — lift the chain with
+   * {@link ResultMethods.toAsync | toAsync} and use the async
+   * {@link AsyncResultMethods.flatTap | flatTap} (which accepts both).
+   *
    * @param f - the side effect (its return value is ignored).
    */
   tap<R>(f: (value: T) => R & NotThenable<R>): Result<T, E>;
@@ -197,6 +206,14 @@ export type ResultMethods<T, E> = {
    * an `AggregateError` of `[thrown, original failure]` — observing a failure
    * never destroys it. An async callback is rejected at compile time
    * ({@link NotThenable}).
+   *
+   * @remarks
+   * As with {@link ResultMethods.tap | tap}, `f`'s return value is ignored — a
+   * failable `Result`-returning effect belongs in
+   * {@link ResultMethods.flatTapErr | flatTapErr}; an `AsyncResult`-returning
+   * one needs the chain lifted with {@link ResultMethods.toAsync | toAsync}
+   * first (the async {@link AsyncResultMethods.flatTapErr | flatTapErr}
+   * accepts both).
    *
    * @param f - the side effect (its return value is ignored).
    */
@@ -485,7 +502,12 @@ export type AsyncResultMethods<T, E> = {
   /**
    * Asynchronous {@link ResultMethods.tap | tap}. `f` is synchronous; a throw
    * becomes a `Defect`. An async callback is rejected at compile time
-   * ({@link NotThenable}).
+   * ({@link NotThenable}) — and so is a returned `AsyncResult` (it is
+   * awaitable). Beware the near-miss: _calling_ an `AsyncResult`-returning
+   * effect inside the callback without returning it compiles and leaves the
+   * effect floating — fire-and-forget, never awaited, its `Err`/`Defect`
+   * unobserved. If the effect returns a `Result`/`AsyncResult`, use
+   * {@link AsyncResultMethods.flatTap | flatTap}.
    */
   tap<R>(f: (value: T) => R & NotThenable<R>): AsyncResult<T, E>;
   /**
@@ -539,7 +561,10 @@ export type AsyncResultMethods<T, E> = {
    * Asynchronous {@link ResultMethods.tapErr | tapErr}. `f` is synchronous; if it
    * throws, the result is a `Defect` whose cause is an `AggregateError` of
    * `[thrown, original failure]` — observing a failure never destroys it. An
-   * async callback is rejected at compile time ({@link NotThenable}).
+   * async callback is rejected at compile time ({@link NotThenable}). The
+   * {@link AsyncResultMethods.tap | tap} fire-and-forget caveat applies here
+   * too — a failable effect belongs in
+   * {@link AsyncResultMethods.flatTapErr | flatTapErr}.
    */
   tapErr<R>(f: (error: E) => R & NotThenable<R>): AsyncResult<T, E>;
   /**


### PR DESCRIPTION
## What & why

Documents the `.tap` vs `.flatTap` footgun from #78: an effect returning a `Result`/`AsyncResult` cannot thread its outcome through a `tap` callback, and the failure mode is silent in both shapes —

- a **sync `Result`** returned from the callback compiles (it is not a thenable) but is discarded, `Err` and all;
- an **`AsyncResult`** is rejected at compile time by `NotThenable` (it is awaitable), and the tempting brace-wrapped "fix" (`.tap((v) => { effect(v); })`) compiles but leaves the effect floating — fire-and-forget, never awaited, its `Err`/`Defect` unobserved.

Two changes, per the issue's proposed scope:

- **`docs/guide/choosing-a-combinator.md`** — a new `tap` vs `flatTap` entry in "The pairs that are easy to confuse", with a warning callout covering both shapes, the `flatTap` fix, and a note to mark deliberate fire-and-forgets with a comment (otherwise the same effect ends up `tap`ped at one call site and `flatTap`ped at another, and a reviewer has to guess which one is the bug).
- **`packages/core/src/types.ts`** — TSDoc on `tap`/`tapErr` (sync and async surfaces) now states the return value is ignored and points at `flatTap`/`flatTapErr` for failable effects.

Documentation only — no API or behaviour change, so no changeset (matching prior `docs(core)` commits).

Closes #78

## Checklist

- [x] The full gate passes locally: `pnpm format --check && pnpm lint && pnpm typecheck && pnpm knip && pnpm test && pnpm build` (plus `build:docs` typedoc-warning-free and the VitePress site build)
- [ ] Added/updated tests — N/A, docs only
- [ ] Added a changeset — N/A, docs only (matches prior `docs(core)` commits)
- [x] Updated TSDoc; `CLAUDE.md` unchanged (no surface or design-rule change)
- [x] Commits follow Conventional Commits