### PR TITLE
feat(prisma): @unthrown/prisma — a Prisma Client extension bridging queries into AsyncResult

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,7 +11,8 @@
       "@unthrown/neverthrow",
       "@unthrown/boxed",
       "@unthrown/oxlint",
-      "@unthrown/standard-schema"
+      "@unthrown/standard-schema",
+      "@unthrown/prisma"
     ]
   ],
   "linked": [],

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,8 +11,7 @@
       "@unthrown/neverthrow",
       "@unthrown/boxed",
       "@unthrown/oxlint",
-      "@unthrown/standard-schema",
-      "@unthrown/prisma"
+      "@unthrown/standard-schema"
     ]
   ],
   "linked": [],

--- a/.changeset/prisma-extension.md
+++ b/.changeset/prisma-extension.md
@@ -4,9 +4,12 @@
 
 Initial release of **@unthrown/prisma** — a Prisma Client extension that bridges
 Prisma queries into unthrown's `AsyncResult`. `$extends(unthrownPrisma)` adds
-`try`-prefixed variants of the model delegate operations (`tryFindMany`,
-`tryFindUnique`, `tryFindUniqueOrThrow`, `tryCount`, `tryCreate`, `tryUpdate`,
-`tryDelete`) alongside the raw promise ones: each returns an `AsyncResult` whose
+`try`-prefixed variants of **all seventeen** model delegate operations
+(`tryFindMany`, `tryFindUnique`, `tryFindUniqueOrThrow`, `tryFindFirst`,
+`tryFindFirstOrThrow`, `tryCount`, `tryAggregate`, `tryGroupBy`, `tryCreate`,
+`tryCreateMany`, `tryCreateManyAndReturn`, `tryUpsert`, `tryUpdate`,
+`tryUpdateMany`, `tryUpdateManyAndReturn`, `tryDelete`, `tryDeleteMany`)
+alongside the raw promise ones: each returns an `AsyncResult` whose
 error channel is exactly the set of P-codes that operation can produce, mapped to
 tagged errors (`UniqueConstraintViolation` / `ForeignKeyViolation` /
 `RecordNotFound` / `DriverError`) — with `select` / `include` payload inference

--- a/.changeset/prisma-extension.md
+++ b/.changeset/prisma-extension.md
@@ -1,0 +1,15 @@
+---
+"@unthrown/prisma": minor
+---
+
+Initial release of **@unthrown/prisma** — a Prisma Client extension that bridges
+Prisma queries into unthrown's `AsyncResult`. `$extends(unthrownPrisma)` adds
+`try`-prefixed variants of the model delegate operations (`tryFindMany`,
+`tryFindUnique`, `tryFindUniqueOrThrow`, `tryCount`, `tryCreate`, `tryUpdate`,
+`tryDelete`) alongside the raw promise ones: each returns an `AsyncResult` whose
+error channel is exactly the set of P-codes that operation can produce, mapped to
+tagged errors (`UniqueConstraintViolation` / `ForeignKeyViolation` /
+`RecordNotFound` / `DriverError`) — with `select` / `include` payload inference
+preserved. `$tryTransaction` runs an interactive transaction whose callback
+speaks `AsyncResult`: an `Err` triggers a rollback and comes out as the same
+typed `Err`; a defect also rolls back and stays a defect.

--- a/.changeset/prisma-extension.md
+++ b/.changeset/prisma-extension.md
@@ -13,3 +13,9 @@ tagged errors (`UniqueConstraintViolation` / `ForeignKeyViolation` /
 preserved. `$tryTransaction` runs an interactive transaction whose callback
 speaks `AsyncResult`: an `Err` triggers a rollback and comes out as the same
 typed `Err`; a defect also rolls back and stays a defect.
+
+`tryPaginate(query).withCursor({ limit, after, before, getCursor, parseCursor })`
+provides cursor pagination in the style of `prisma-extension-pagination` (same
+option names, same `[results, meta]` shape), with one fix folded in: a cursor
+pointing at a record that no longer matches the query filter does not skip the
+first element of the page.

--- a/.changeset/prisma-extension.md
+++ b/.changeset/prisma-extension.md
@@ -15,7 +15,8 @@ tagged errors (`UniqueConstraintViolation` / `ForeignKeyViolation` /
 `RecordNotFound` / `DriverError`) — with `select` / `include` payload inference
 preserved. `$tryTransaction` runs an interactive transaction whose callback
 speaks `AsyncResult`: an `Err` triggers a rollback and comes out as the same
-typed `Err`; a defect also rolls back and stays a defect.
+typed `Err`; a defect also rolls back and stays a defect (a callback that throws
+outright included — a bug is never downgraded to a modeled `DriverError`).
 
 `tryPaginate(query).withCursor({ limit, after, before, getCursor, parseCursor })`
 provides cursor pagination in the style of `prisma-extension-pagination` (same

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "ignorePatterns": ["**/*.test-d.ts"],
+  "ignorePatterns": ["**/*.test-d.ts", "**/generated/**"],
   "rules": {
     "@typescript-eslint/no-explicit-any": "error",
     "typescript/consistent-type-definitions": ["error", "type"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,18 +294,20 @@ library can be "done".
   on unthrown's `Result`. No TypeDoc API page; documented in the Linting guide.
   Tested with oxlint's `RuleTester` from `oxlint/plugins-dev`.)
 - `packages/prisma` → `@unthrown/prisma` (peerDep `@prisma/client` ^7; a Prisma
-  Client **extension** — `$extends(unthrownPrisma)` adds `try*` variants of the
-  model delegate operations alongside the raw promise ones, each an
-  `AsyncResult` whose error channel is exactly the P-codes that operation can
-  raise: `UniqueConstraintViolation` P2002, `ForeignKeyViolation` P2003,
-  `RecordNotFound` P2025, everything else `DriverError` with the cause
-  preserved. Also `$tryTransaction` (an interactive transaction whose callback
+  Client **extension** — `$extends(unthrownPrisma)` adds `try*` variants of
+  **all seventeen** model delegate operations alongside the raw promise ones,
+  each an `AsyncResult` whose error channel is exactly the P-codes that
+  operation can raise: `UniqueConstraintViolation` P2002, `ForeignKeyViolation`
+  P2003, `RecordNotFound` P2025, everything else `DriverError` with the cause
+  preserved — `upsert` and the `*Many` batch mutations never carry P2025 (an
+  upsert miss creates; zero batch matches is `Ok({ count: 0 })`). Also
+  `$tryTransaction` (an interactive transaction whose callback
   speaks `AsyncResult` — an `Err` rolls back and re-surfaces typed; a defect
   rolls back and stays a defect) and `tryPaginate(...).withCursor(...)` (the
   `prisma-extension-pagination` cursor API with its unmerged #35 fix folded
   in). Qualification happens once inside the extension via the exported
   `qualifyPrismaError`; the raw methods stay as the escape hatch for batch
-  `$transaction([...])` and the not-yet-wrapped operations. Tested against a
+  `$transaction([...])` and raw SQL. Tested against a
   real in-memory SQLite client (`@prisma/adapter-better-sqlite3`) with a
   generated, gitignored test client; **deliberately outside the fixed version
   group** — its majors track `@prisma/client`'s cadence, not the family's.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,7 +303,8 @@ library can be "done".
   upsert miss creates; zero batch matches is `Ok({ count: 0 })`). Also
   `$tryTransaction` (an interactive transaction whose callback
   speaks `AsyncResult` — an `Err` rolls back and re-surfaces typed; a defect
-  rolls back and stays a defect) and `tryPaginate(...).withCursor(...)` (the
+  rolls back and stays a defect, a throwing callback included) and
+  `tryPaginate(...).withCursor(...)` (the
   `prisma-extension-pagination` cursor API with its unmerged #35 fix folded
   in). Qualification happens once inside the extension via the exported
   `qualifyPrismaError`; the raw methods stay as the escape hatch for batch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,6 +293,24 @@ library can be "done".
   AST rules that resolve the import source via scope analysis so they only fire
   on unthrown's `Result`. No TypeDoc API page; documented in the Linting guide.
   Tested with oxlint's `RuleTester` from `oxlint/plugins-dev`.)
+- `packages/prisma` → `@unthrown/prisma` (peerDep `@prisma/client` ^7; a Prisma
+  Client **extension** — `$extends(unthrownPrisma)` adds `try*` variants of the
+  model delegate operations alongside the raw promise ones, each an
+  `AsyncResult` whose error channel is exactly the P-codes that operation can
+  raise: `UniqueConstraintViolation` P2002, `ForeignKeyViolation` P2003,
+  `RecordNotFound` P2025, everything else `DriverError` with the cause
+  preserved. Also `$tryTransaction` (an interactive transaction whose callback
+  speaks `AsyncResult` — an `Err` rolls back and re-surfaces typed; a defect
+  rolls back and stays a defect) and `tryPaginate(...).withCursor(...)` (the
+  `prisma-extension-pagination` cursor API with its unmerged #35 fix folded
+  in). Qualification happens once inside the extension via the exported
+  `qualifyPrismaError`; the raw methods stay as the escape hatch for batch
+  `$transaction([...])` and the not-yet-wrapped operations. Tested against a
+  real in-memory SQLite client (`@prisma/adapter-better-sqlite3`) with a
+  generated, gitignored test client; **deliberately outside the fixed version
+  group** — its majors track `@prisma/client`'s cadence, not the family's.
+  `engines: { node: ">=20.19" }` (Prisma 7's floor), the one exception to the
+  family's `>=20`. Documented in the Prisma guide page.)
 - `tools/tsconfig`, `tools/typedoc` → private shared config (`@unthrown/tsconfig`,
   `@unthrown/typedoc`)
 - `docs` → `@unthrown/docs`, the VitePress site (guide + TypeDoc-generated API
@@ -304,7 +322,8 @@ Never pull `ts-pattern`, `vitest`, or any interop peer (`effect`, `neverthrow`,
 Every satellite package depends on core via `workspace:^` (an exact pin would
 create a dual-copy hazard with the `instanceof`-based `isResult`); for the same
 reason, `@unthrown/vitest` takes core as a **peerDependency**, not a regular
-dependency. Every published package carries `engines: { node: ">=20" }`, ships
+dependency. Every published package carries `engines: { node: ">=20" }`
+(`@unthrown/prisma` alone raises it to `>=20.19`, Prisma 7's floor), ships
 its own `LICENSE`, and sets `files: ["dist"]`.
 
 ### Interop packages (`packages/effect`, `packages/neverthrow`, `packages/boxed`)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ defect, so the edge of your program needs a single `match` and no `try`/`catch`.
 | [`@unthrown/effect`](./packages/effect)         | Effect interop: `Result ↔ Exit` (bijection), `Either`, `Effect`.                               |
 | [`@unthrown/neverthrow`](./packages/neverthrow) | neverthrow interop: `Result ↔ Result`, `AsyncResult ↔ ResultAsync`.                            |
 | [`@unthrown/boxed`](./packages/boxed)           | Boxed interop: `Result ↔ Result`, `AsyncResult ↔ Future<Result>`.                              |
+| [`@unthrown/prisma`](./packages/prisma)         | Prisma Client extension: `try*` query methods returning `AsyncResult`, per-operation errors.   |
 
 ## Contributing
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -129,6 +129,7 @@ export default defineConfig({
             { text: "@unthrown/neverthrow", link: "/api/neverthrow/" },
             { text: "@unthrown/boxed", link: "/api/boxed/" },
             { text: "@unthrown/standard-schema", link: "/api/standard-schema/" },
+            { text: "@unthrown/prisma", link: "/api/prisma/" },
           ],
         },
       ],

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -108,6 +108,7 @@ export default defineConfig({
           items: [
             { text: "Testing", link: "/guide/testing" },
             { text: "Pattern Matching", link: "/guide/pattern-matching" },
+            { text: "Prisma", link: "/guide/prisma" },
             { text: "Linting", link: "/guide/linting" },
             { text: "Interop", link: "/guide/interop" },
             {

--- a/docs/guide/prisma.md
+++ b/docs/guide/prisma.md
@@ -33,14 +33,21 @@ error channel is only what that operation can actually raise**. A read cannot
 fail with a `UniqueConstraintViolation` _in the type_, so you never write a
 handler for a case that can't happen.
 
-| Method                                       | Error channel                                                                       |
-| -------------------------------------------- | ----------------------------------------------------------------------------------- |
-| `tryFindMany` / `tryFindUnique` / `tryCount` | `DriverError`                                                                       |
-| `tryFindUniqueOrThrow`                       | `RecordNotFound \| DriverError`                                                     |
-| `tryCreate`                                  | `UniqueConstraintViolation \| ForeignKeyViolation \| DriverError`                   |
-| `tryUpdate`                                  | `RecordNotFound \| UniqueConstraintViolation \| ForeignKeyViolation \| DriverError` |
-| `tryDelete`                                  | `RecordNotFound \| ForeignKeyViolation \| DriverError`                              |
-| `tryPaginate(...).withCursor(...)`           | `DriverError`                                                                       |
+| Method                                                                                        | Error channel                                                                       |
+| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `tryFindMany` / `tryFindUnique` / `tryFindFirst` / `tryCount` / `tryAggregate` / `tryGroupBy` | `DriverError`                                                                       |
+| `tryFindUniqueOrThrow` / `tryFindFirstOrThrow`                                                | `RecordNotFound \| DriverError`                                                     |
+| `tryCreate` / `tryCreateMany` / `tryCreateManyAndReturn`                                      | `UniqueConstraintViolation \| ForeignKeyViolation \| DriverError`                   |
+| `tryUpsert`                                                                                   | `UniqueConstraintViolation \| ForeignKeyViolation \| DriverError`                   |
+| `tryUpdate`                                                                                   | `RecordNotFound \| UniqueConstraintViolation \| ForeignKeyViolation \| DriverError` |
+| `tryUpdateMany` / `tryUpdateManyAndReturn`                                                    | `UniqueConstraintViolation \| ForeignKeyViolation \| DriverError`                   |
+| `tryDelete`                                                                                   | `RecordNotFound \| ForeignKeyViolation \| DriverError`                              |
+| `tryDeleteMany`                                                                               | `ForeignKeyViolation \| DriverError`                                                |
+| `tryPaginate(...).withCursor(...)`                                                            | `DriverError`                                                                       |
+
+Note where `RecordNotFound` does **not** appear: `tryUpsert` (a miss _creates_)
+and the batch mutations (`*Many` — zero matches is `Ok({ count: 0 })`, not an
+error). The union tells you exactly which outcomes are worth a branch.
 
 The tagged errors map to Prisma's P-codes: `UniqueConstraintViolation` is `P2002`
 (and carries the offending `fields`), `ForeignKeyViolation` is `P2003`, and
@@ -141,19 +148,18 @@ Three deliberate differences from upstream:
 ## The raw methods stay on purpose
 
 The bridge is additive: `db.user.findMany(...)` (the raw promise) is still there.
-That's the escape hatch for anything the extension doesn't wrap — batch
-`$transaction([...])` (which needs unexecuted `PrismaPromise`s), and operations
-without a `try*` variant yet (`findFirst`, `upsert`, `createMany`, `aggregate`,
-`groupBy`, …). Qualify those yourself at the boundary with
-[`fromPromise`](./boundaries):
+Every model delegate operation has a `try*` variant, so the raw methods remain
+for exactly two things — batch `$transaction([...])` (which needs unexecuted
+`PrismaPromise`s) and raw SQL (`$queryRaw` / `$executeRaw`). Qualify those
+yourself at the boundary with [`fromPromise`](./boundaries):
 
 ```ts
 import { fromPromise } from "unthrown";
 import { qualifyPrismaError } from "@unthrown/prisma";
 
 // qualifyPrismaError is exported — reuse the same P-code triage for a raw call.
-const first = fromPromise(db.user.findFirst({ where: { active: true } }), qualifyPrismaError);
-//    ^? AsyncResult<User | null, UniqueConstraintViolation | ForeignKeyViolation | RecordNotFound | DriverError>
+const rows = fromPromise(db.$queryRaw`SELECT 1`, qualifyPrismaError);
+//    ^? AsyncResult<unknown, UniqueConstraintViolation | ForeignKeyViolation | RecordNotFound | DriverError>
 ```
 
 See the [API reference](/api/prisma/) for every method's exact signature.

--- a/docs/guide/prisma.md
+++ b/docs/guide/prisma.md
@@ -104,7 +104,8 @@ const moved = await db.$tryTransaction((tx) =>
 
 - An `Err` from the callback rolls back and re-surfaces as that same modeled
   error.
-- A [`Defect`](./the-defect-channel) also rolls back and **stays a defect** — a
+- A [`Defect`](./the-defect-channel) also rolls back and **stays a defect** —
+  including a callback that _throws_ instead of returning an `AsyncResult`. A
   bug is never quietly downgraded into your error channel.
 - Nesting is a compile error: `tx` has no `$tryTransaction`. For a batch of
   independent writes, use the raw `$transaction([...])` with the raw (unexecuted)

--- a/docs/guide/prisma.md
+++ b/docs/guide/prisma.md
@@ -141,10 +141,11 @@ Three deliberate differences from upstream:
   [deptyped/prisma-extension-pagination#35](https://github.com/deptyped/prisma-extension-pagination/issues/35)).
 - **`before` + `limit: null` is a compile error** — Prisma's negative `take`
   can't express "everything before the cursor, unbounded."
-- **The default cursor preserves the id's type** — all-digit cursors parse back
-  to numbers (autoincrement ids), anything else stays a string (uuid / cuid).
-  Provide `getCursor` / `parseCursor` for composite keys or a selection without
-  `id`.
+- **The default cursor preserves the id's type** — an all-digit cursor parses
+  back to a number (autoincrement ids), promoted to a `bigint` beyond
+  `Number.MAX_SAFE_INTEGER` so a `BigInt` id never loses precision; anything
+  else stays a string (uuid / cuid). Provide `getCursor` / `parseCursor` for
+  composite keys or a selection without `id`.
 
 ## The raw methods stay on purpose
 

--- a/docs/guide/prisma.md
+++ b/docs/guide/prisma.md
@@ -1,0 +1,159 @@
+# Prisma
+
+[`@unthrown/prisma`](/api/prisma/) is a [Prisma](https://www.prisma.io) Client
+extension that bridges queries into unthrown's [`AsyncResult`](./async-results).
+Applying it with `$extends` adds `try`-prefixed variants of the model delegate
+operations **alongside** the raw promise ones — each returns an `AsyncResult`
+whose error channel is exactly the set of failures _that operation_ can produce,
+mapped to [tagged errors](./tagged-errors).
+
+```sh
+pnpm add @unthrown/prisma unthrown
+```
+
+```ts
+import { unthrownPrisma } from "@unthrown/prisma";
+import { PrismaClient } from "./generated/prisma/client.ts";
+
+const db = new PrismaClient({ adapter }).$extends(unthrownPrisma);
+
+const users = db.user.tryFindMany({ select: { id: true } });
+//    ^? AsyncResult<{ id: number }[], DriverError>
+```
+
+Qualification happens **once, inside the extension** ([Boundaries](./boundaries)):
+no raw `Promise` — and so no un-triaged rejection — ever reaches your code.
+`select` / `include` payload inference survives the wrap, so the success type is
+still narrowed by your query.
+
+## Per-operation error unions
+
+The point of the bridge isn't one flat error type — it's that **each operation's
+error channel is only what that operation can actually raise**. A read cannot
+fail with a `UniqueConstraintViolation` _in the type_, so you never write a
+handler for a case that can't happen.
+
+| Method                                       | Error channel                                                                       |
+| -------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `tryFindMany` / `tryFindUnique` / `tryCount` | `DriverError`                                                                       |
+| `tryFindUniqueOrThrow`                       | `RecordNotFound \| DriverError`                                                     |
+| `tryCreate`                                  | `UniqueConstraintViolation \| ForeignKeyViolation \| DriverError`                   |
+| `tryUpdate`                                  | `RecordNotFound \| UniqueConstraintViolation \| ForeignKeyViolation \| DriverError` |
+| `tryDelete`                                  | `RecordNotFound \| ForeignKeyViolation \| DriverError`                              |
+| `tryPaginate(...).withCursor(...)`           | `DriverError`                                                                       |
+
+The tagged errors map to Prisma's P-codes: `UniqueConstraintViolation` is `P2002`
+(and carries the offending `fields`), `ForeignKeyViolation` is `P2003`, and
+`RecordNotFound` is `P2025`. Everything else — connection drops, timeouts,
+unmapped codes, non-Prisma causes — folds into `DriverError` with the original
+`cause` preserved.
+
+::: tip Absence is not an error
+`tryFindUnique` returns `Ok(null)` for a miss — a missing row is an anticipated
+value, not a failure. Reach for `tryFindUniqueOrThrow` when the absence _is_ the
+error you want to model (`RecordNotFound`).
+:::
+
+## Handling the errors
+
+Because the errors are [tagged](./tagged-errors), `matchTags` gives you an
+exhaustive fold — the compiler lists exactly the cases the operation can hit:
+
+```ts
+import { matchTags } from "unthrown";
+
+const created = await db.user.tryCreate({ data: { email, name } });
+
+return matchTags(created, {
+  Ok: (user) => resp.created(user),
+  UniqueConstraintViolation: (e) => resp.conflict(`taken: ${e.fields.join(", ")}`),
+  ForeignKeyViolation: () => resp.badRequest("unknown reference"),
+  Defect: (cause) => resp.serverError(cause),
+});
+// No RecordNotFound arm — a create can't raise it, and the type knows.
+```
+
+Or handle it inline with `.match({ ok, err, defect })` when you don't need
+per-tag branches — one call at the HTTP edge, no `try`/`catch`.
+
+## Transactions
+
+`$tryTransaction` runs an interactive transaction whose callback speaks
+`AsyncResult`. An `Err` anywhere in the chain triggers a **ROLLBACK** and comes
+back out as the same typed error; the `try*` methods are available on the
+transaction client `tx`:
+
+```ts
+const moved = await db.$tryTransaction((tx) =>
+  tx.account
+    .tryUpdate({ where: { id: from }, data: { balance: { decrement: amount } } })
+    .flatMap(() =>
+      tx.account.tryUpdate({ where: { id: to }, data: { balance: { increment: amount } } }),
+    ),
+);
+//    ^? AsyncResult<Account, RecordNotFound | UniqueConstraintViolation | ForeignKeyViolation | DriverError>
+// Any Err → both updates rolled back, and the Err is in `moved`.
+```
+
+- An `Err` from the callback rolls back and re-surfaces as that same modeled
+  error.
+- A [`Defect`](./the-defect-channel) also rolls back and **stays a defect** — a
+  bug is never quietly downgraded into your error channel.
+- Nesting is a compile error: `tx` has no `$tryTransaction`. For a batch of
+  independent writes, use the raw `$transaction([...])` with the raw (unexecuted)
+  promise methods.
+
+## Cursor pagination
+
+`tryPaginate(query).withCursor(...)` follows the
+[`prisma-extension-pagination`](https://github.com/deptyped/prisma-extension-pagination)
+cursor API — same option names, same `[results, meta]` shape:
+
+```ts
+const page = await db.user
+  .tryPaginate({ where: { active: true }, orderBy: { id: "asc" } })
+  .withCursor({ limit: 20, after: req.query.cursor });
+//    ^? AsyncResult<[User[], CursorPaginationMeta], DriverError>
+
+page.match({
+  ok: ([users, meta]) => json({ users, nextCursor: meta.endCursor, hasMore: meta.hasNextPage }),
+  err: (e) => serverError(e),
+  defect: serverError,
+});
+```
+
+`meta` carries `hasPreviousPage` / `hasNextPage` / `startCursor` / `endCursor`.
+The query args exclude `cursor` / `take` / `skip` (pagination owns them), and
+payload inference still flows through `select` / `include`.
+
+Three deliberate differences from upstream:
+
+- **A cursor pointing at a now-filtered-out row doesn't skip the first element**
+  of the page (folds in the fix for
+  [deptyped/prisma-extension-pagination#35](https://github.com/deptyped/prisma-extension-pagination/issues/35)).
+- **`before` + `limit: null` is a compile error** — Prisma's negative `take`
+  can't express "everything before the cursor, unbounded."
+- **The default cursor preserves the id's type** — all-digit cursors parse back
+  to numbers (autoincrement ids), anything else stays a string (uuid / cuid).
+  Provide `getCursor` / `parseCursor` for composite keys or a selection without
+  `id`.
+
+## The raw methods stay on purpose
+
+The bridge is additive: `db.user.findMany(...)` (the raw promise) is still there.
+That's the escape hatch for anything the extension doesn't wrap — batch
+`$transaction([...])` (which needs unexecuted `PrismaPromise`s), and operations
+without a `try*` variant yet (`findFirst`, `upsert`, `createMany`, `aggregate`,
+`groupBy`, …). Qualify those yourself at the boundary with
+[`fromPromise`](./boundaries):
+
+```ts
+import { fromPromise } from "unthrown";
+import { qualifyPrismaError } from "@unthrown/prisma";
+
+// qualifyPrismaError is exported — reuse the same P-code triage for a raw call.
+const first = fromPromise(db.user.findFirst({ where: { active: true } }), qualifyPrismaError);
+//    ^? AsyncResult<User | null, UniqueConstraintViolation | ForeignKeyViolation | RecordNotFound | DriverError>
+```
+
+See the [API reference](/api/prisma/) for every method's exact signature.

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,6 +15,7 @@
     "@unthrown/effect": "workspace:*",
     "@unthrown/neverthrow": "workspace:*",
     "@unthrown/pattern": "workspace:*",
+    "@unthrown/prisma": "workspace:*",
     "@unthrown/standard-schema": "workspace:*",
     "@unthrown/vitest": "workspace:*",
     "unthrown": "workspace:*"

--- a/docs/scripts/copy-docs.ts
+++ b/docs/scripts/copy-docs.ts
@@ -11,6 +11,7 @@ import "@unthrown/effect";
 import "@unthrown/neverthrow";
 import "@unthrown/boxed";
 import "@unthrown/standard-schema";
+import "@unthrown/prisma";
 
 import { cp, mkdir, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
@@ -28,6 +29,7 @@ const packages: ReadonlyArray<{ readonly pkg: string; readonly out: string }> = 
   { pkg: "@unthrown/neverthrow", out: "neverthrow" },
   { pkg: "@unthrown/boxed", out: "boxed" },
   { pkg: "@unthrown/standard-schema", out: "standard-schema" },
+  { pkg: "@unthrown/prisma", out: "prisma" },
 ];
 
 await mkdir(apiDir, { recursive: true });

--- a/knip.json
+++ b/knip.json
@@ -6,6 +6,9 @@
     "packages/*": {
       "project": ["src/**/*.ts"]
     },
+    "packages/prisma": {
+      "project": ["src/**/*.ts", "!src/generated/**"]
+    },
     "docs": {
       "entry": ["scripts/*.ts"],
       "project": ["scripts/**/*.ts"]

--- a/packages/prisma/.gitignore
+++ b/packages/prisma/.gitignore
@@ -1,0 +1,3 @@
+# Prisma's generated test client — regenerated from prisma/schema.prisma by the
+# test/typecheck scripts (`prisma generate`). Not committed, never published.
+src/generated/

--- a/packages/prisma/LICENSE
+++ b/packages/prisma/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Benoit Travers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -1,0 +1,66 @@
+# @unthrown/prisma
+
+> A [Prisma](https://www.prisma.io) Client extension for
+> [unthrown](https://github.com/btravstack/unthrown)'s `Result`: `try`-prefixed
+> query methods returning `AsyncResult`, with per-operation tagged errors.
+
+📖 **[Documentation](https://btravstack.github.io/unthrown/guide/interop)** ·
+[API Reference](https://btravstack.github.io/unthrown/api/prisma/)
+
+```sh
+pnpm add @unthrown/prisma unthrown
+```
+
+`$extends(unthrownPrisma)` adds `try*` variants of the model delegate operations
+**alongside** the raw promise ones. Each returns an `AsyncResult` whose error
+channel is exactly the set of P-codes that operation can produce, mapped to
+tagged errors — a read cannot fail with `UniqueConstraintViolation` _in the
+type_. Qualification happens once, inside the extension: no raw Promise ever
+reaches your code.
+
+```ts
+import { unthrownPrisma } from "@unthrown/prisma";
+import { PrismaClient } from "./generated/prisma/client.ts";
+
+const db = new PrismaClient({ adapter }).$extends(unthrownPrisma);
+
+const users = db.user.tryFindMany({ select: { id: true } });
+//    ^? AsyncResult<{ id: number }[], DriverError>
+//       `select` / `include` payload inference survives the wrap.
+
+await db.user.tryCreate({ data }).match({
+  ok: (user) => created(user),
+  err: (e) => (e._tag === "UniqueConstraintViolation" ? conflict(e.fields) : serverError(e)),
+  defect: serverError,
+});
+```
+
+- **Per-operation errors** — reads (`tryFindMany` / `tryFindUnique` / `tryCount`)
+  fail only with `DriverError`; writes add `UniqueConstraintViolation` (P2002)
+  and `ForeignKeyViolation` (P2003); `tryFindUniqueOrThrow` / `tryUpdate` /
+  `tryDelete` add `RecordNotFound` (P2025). Everything else folds into
+  `DriverError` with the cause preserved.
+- **`$tryTransaction`** — an interactive transaction whose callback speaks
+  `AsyncResult`: an `Err` triggers a ROLLBACK and comes out as the same typed
+  `Err`; a defect also rolls back and stays a defect. The `try*` methods are
+  available on `tx`, and nesting is a compile error.
+
+```ts
+const moved = db.$tryTransaction((tx) =>
+  tx.account
+    .tryUpdate({ where: { id: from }, data: { balance: { decrement: amount } } })
+    .flatMap(() =>
+      tx.account.tryUpdate({ where: { id: to }, data: { balance: { increment: amount } } }),
+    ),
+);
+// Err anywhere → both updates rolled back, and the Err is in `moved`.
+```
+
+The raw promise methods stay available on purpose: they are the escape hatch for
+batch `$transaction([...])`, which needs unexecuted `PrismaPromise`s.
+
+`@prisma/client` (v7+) is a peer dependency.
+
+## License
+
+[MIT](https://github.com/btravstack/unthrown/blob/main/LICENSE) © Benoit TRAVERS

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -56,6 +56,31 @@ const moved = db.$tryTransaction((tx) =>
 // Err anywhere → both updates rolled back, and the Err is in `moved`.
 ```
 
+- **`tryPaginate`** — cursor pagination in the style of
+  [`prisma-extension-pagination`](https://github.com/deptyped/prisma-extension-pagination)
+  (same option names, same `[results, meta]` shape), with one fix folded in: a
+  cursor pointing at a record that no longer matches the query filter does not
+  skip the first element of the page
+  ([deptyped/prisma-extension-pagination#35](https://github.com/deptyped/prisma-extension-pagination/issues/35)).
+
+```ts
+const page = await db.user
+  .tryPaginate({ where: { active: true }, orderBy: { id: "asc" } })
+  .withCursor({ limit: 20, after: req.query.cursor });
+// Ok([users, { hasPreviousPage, hasNextPage, startCursor, endCursor }])
+// | Err(DriverError) — a malformed cursor included.
+
+// Custom serialization (composite keys, non-id cursors):
+.withCursor({
+  limit: 20,
+  getCursor: ({ postId, userId }) => `${postId}:${userId}`,
+  parseCursor: (cursor) => {
+    const [postId, userId] = cursor.split(":");
+    return { userId_postId: { postId: Number(postId), userId: Number(userId) } };
+  },
+});
+```
+
 The raw promise methods stay available on purpose: they are the escape hatch for
 batch `$transaction([...])`, which needs unexecuted `PrismaPromise`s.
 

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -4,7 +4,7 @@
 > [unthrown](https://github.com/btravstack/unthrown)'s `Result`: `try`-prefixed
 > query methods returning `AsyncResult`, with per-operation tagged errors.
 
-📖 **[Documentation](https://btravstack.github.io/unthrown/guide/interop)** ·
+📖 **[Documentation](https://btravstack.github.io/unthrown/guide/prisma)** ·
 [API Reference](https://btravstack.github.io/unthrown/api/prisma/)
 
 ```sh

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -35,11 +35,16 @@ await db.user.tryCreate({ data }).match({
 });
 ```
 
-- **Per-operation errors** — reads (`tryFindMany` / `tryFindUnique` / `tryCount`)
-  fail only with `DriverError`; writes add `UniqueConstraintViolation` (P2002)
-  and `ForeignKeyViolation` (P2003); `tryFindUniqueOrThrow` / `tryUpdate` /
-  `tryDelete` add `RecordNotFound` (P2025). Everything else folds into
-  `DriverError` with the cause preserved.
+- **Per-operation errors** — reads (`tryFindMany` / `tryFindUnique` /
+  `tryFindFirst` / `tryCount` / `tryAggregate` / `tryGroupBy`) fail only with
+  `DriverError`; writes (`tryCreate` / `tryCreateMany` / `tryCreateManyAndReturn`
+  / `tryUpsert` / `tryUpdateMany` / `tryUpdateManyAndReturn`) add
+  `UniqueConstraintViolation` (P2002) and `ForeignKeyViolation` (P2003);
+  `tryFindUniqueOrThrow` / `tryFindFirstOrThrow` / `tryUpdate` / `tryDelete` add
+  `RecordNotFound` (P2025) — the batch mutations and `tryUpsert` never carry it
+  (zero matches is `Ok({ count: 0 })`; an upsert miss creates). `tryDeleteMany`
+  models only `ForeignKeyViolation`. Everything else folds into `DriverError`
+  with the cause preserved.
 - **`$tryTransaction`** — an interactive transaction whose callback speaks
   `AsyncResult`: an `Err` triggers a ROLLBACK and comes out as the same typed
   `Err`; a defect also rolls back and stays a defect. The `try*` methods are

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -76,7 +76,7 @@ const page = await db.user
 // | Err(DriverError) — a malformed cursor included.
 
 // Custom serialization (composite keys, non-id cursors):
-.withCursor({
+const liked = await db.like.tryPaginate({ orderBy: { postId: "asc" } }).withCursor({
   limit: 20,
   getCursor: ({ postId, userId }) => `${postId}:${userId}`,
   parseCursor: (cursor) => {

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -1,0 +1,80 @@
+{
+  "name": "@unthrown/prisma",
+  "version": "4.0.0",
+  "description": "Prisma Client extension for unthrown: try-prefixed query methods returning AsyncResult, with per-operation tagged errors",
+  "keywords": [
+    "database",
+    "errors-as-values",
+    "orm",
+    "prisma",
+    "prisma-extension",
+    "result",
+    "typescript",
+    "unthrown"
+  ],
+  "homepage": "https://github.com/btravstack/unthrown#readme",
+  "bugs": {
+    "url": "https://github.com/btravstack/unthrown/issues"
+  },
+  "license": "MIT",
+  "author": "Benoit TRAVERS <benoit.travers.fr@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/btravstack/unthrown.git",
+    "directory": "packages/prisma"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.cts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsdown src/index.ts --format cjs,esm --dts --clean",
+    "build:docs": "typedoc",
+    "dev": "tsdown src/index.ts --format cjs,esm --dts --watch",
+    "generate": "prisma generate",
+    "test": "prisma generate && vitest run",
+    "typecheck": "prisma generate && tsc --noEmit"
+  },
+  "dependencies": {
+    "unthrown": "workspace:^"
+  },
+  "devDependencies": {
+    "@prisma/adapter-better-sqlite3": "catalog:",
+    "@prisma/client": "catalog:",
+    "@types/node": "catalog:",
+    "@unthrown/tsconfig": "workspace:*",
+    "@unthrown/typedoc": "workspace:*",
+    "@unthrown/vitest": "workspace:*",
+    "@vitest/coverage-v8": "catalog:",
+    "better-sqlite3": "catalog:",
+    "prisma": "catalog:",
+    "tsdown": "catalog:",
+    "typedoc": "catalog:",
+    "typedoc-plugin-markdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "@prisma/client": "^7"
+  },
+  "engines": {
+    "node": ">=20.19"
+  }
+}

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unthrown/prisma",
-  "version": "4.0.0",
+  "version": "0.0.0",
   "description": "Prisma Client extension for unthrown: try-prefixed query methods returning AsyncResult, with per-operation tagged errors",
   "keywords": [
     "database",

--- a/packages/prisma/prisma.config.ts
+++ b/packages/prisma/prisma.config.ts
@@ -1,0 +1,10 @@
+// Prisma 7 config for the TEST schema only. The package itself is schema-agnostic
+// (it ships a client extension); this schema exists so the test suite has a concrete
+// generated client (with a unique constraint and a relation) to exercise the bridge
+// against an in-memory SQLite database.
+
+import { defineConfig } from "prisma/config";
+
+export default defineConfig({
+  schema: "prisma/schema.prisma",
+});

--- a/packages/prisma/prisma/schema.prisma
+++ b/packages/prisma/prisma/schema.prisma
@@ -1,0 +1,27 @@
+// Test-only schema — the smallest shape that can provoke every mapped P-code:
+// `User.email @unique` for P2002, the `Post → User` relation for P2003, and any
+// update/delete of a missing row for P2025. Generated into src/generated
+// (gitignored) by the test/typecheck scripts.
+
+generator client {
+  provider = "prisma-client"
+  output   = "../src/generated/prisma"
+}
+
+datasource db {
+  provider = "sqlite"
+}
+
+model User {
+  id    Int    @id @default(autoincrement())
+  email String @unique
+  name  String?
+  posts Post[]
+}
+
+model Post {
+  id       Int    @id @default(autoincrement())
+  title    String
+  author   User   @relation(fields: [authorId], references: [id])
+  authorId Int
+}

--- a/packages/prisma/src/index.spec.ts
+++ b/packages/prisma/src/index.spec.ts
@@ -9,7 +9,7 @@ import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
 import { PrismaClientKnownRequestError } from "@prisma/client/runtime/client";
 import "@unthrown/vitest";
 import { Err, fromSafePromise, TaggedError } from "unthrown";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 
 import { PrismaClient } from "./generated/prisma/client.ts";
 import { qualifyPrismaError, unthrownPrisma } from "./index.js";
@@ -24,23 +24,37 @@ const DDL = [
   `CREATE TABLE "Post" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "title" TEXT NOT NULL, "authorId" INTEGER NOT NULL, CONSTRAINT "Post_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User" ("id"))`,
 ];
 
-const open: Array<{ $disconnect: () => Promise<void> }> = [];
+const makeClient = () =>
+  new PrismaClient({ adapter: new PrismaBetterSqlite3({ url: ":memory:" }) }).$extends(
+    unthrownPrisma,
+  );
 
-const makeDb = async () => {
-  const adapter = new PrismaBetterSqlite3({ url: ":memory:" });
-  const db = new PrismaClient({ adapter }).$extends(unthrownPrisma);
-  open.push(db);
-  for (const stmt of DDL) await db.$executeRawUnsafe(stmt);
-  return db;
-};
-
-afterEach(async () => {
-  await Promise.all(open.splice(0).map((db) => db.$disconnect()));
+// Test-context fixtures (lazy — a test only pays for what it destructures):
+// `db` is a fresh extended client over its own in-memory database, disconnected
+// on teardown; `seededDb` layers six users on top, ids 1..6 — `name` is the
+// filter knob: flipping one row to "banned" makes its cursor stop matching a
+// `where: { name: "member" }`.
+const it = test.extend<{
+  db: ReturnType<typeof makeClient>;
+  seededDb: ReturnType<typeof makeClient>;
+}>({
+  // oxlint-disable-next-line no-empty-pattern -- Vitest fixtures require a destructuring pattern; `db` depends on no other fixture
+  db: async ({}, use) => {
+    const db = makeClient();
+    for (const stmt of DDL) await db.$executeRawUnsafe(stmt);
+    await use(db);
+    await db.$disconnect();
+  },
+  seededDb: async ({ db }, use) => {
+    await db.user.createMany({
+      data: [1, 2, 3, 4, 5, 6].map((n) => ({ email: `u${n}@example.com`, name: "member" })),
+    });
+    await use(db);
+  },
 });
 
 describe("try* model methods", () => {
-  it("wraps a successful create and read in Ok", async () => {
-    const db = await makeDb();
+  it("wraps a successful create and read in Ok", async ({ db }) => {
     await expect(db.user.tryCreate({ data: { email: "ada@example.com", name: "Ada" } })).toBeOkWith(
       expect.objectContaining({ email: "ada@example.com", name: "Ada" }),
     );
@@ -49,21 +63,18 @@ describe("try* model methods", () => {
     ]);
   });
 
-  it("applies a select at runtime (the narrowed payload is real)", async () => {
-    const db = await makeDb();
+  it("applies a select at runtime (the narrowed payload is real)", async ({ db }) => {
     await db.user.tryCreate({ data: { email: "ada@example.com", name: "Ada" } });
     await expect(db.user.tryFindMany({ select: { email: true } })).toBeOkWith([
       { email: "ada@example.com" },
     ]);
   });
 
-  it("returns Ok(null) for a findUnique miss (absence is not an error)", async () => {
-    const db = await makeDb();
+  it("returns Ok(null) for a findUnique miss (absence is not an error)", async ({ db }) => {
     await expect(db.user.tryFindUnique({ where: { id: 999 } })).toBeOkWith(null);
   });
 
-  it("maps a duplicate key to UniqueConstraintViolation (P2002)", async () => {
-    const db = await makeDb();
+  it("maps a duplicate key to UniqueConstraintViolation (P2002)", async ({ db }) => {
     await db.user.tryCreate({ data: { email: "dup@example.com" } });
     await expect(db.user.tryCreate({ data: { email: "dup@example.com" } })).toBeErrTagged(
       "UniqueConstraintViolation",
@@ -71,15 +82,15 @@ describe("try* model methods", () => {
     );
   });
 
-  it("maps a dangling relation to ForeignKeyViolation (P2003)", async () => {
-    const db = await makeDb();
+  it("maps a dangling relation to ForeignKeyViolation (P2003)", async ({ db }) => {
     await expect(db.post.tryCreate({ data: { title: "orphan", authorId: 999 } })).toBeErrTagged(
       "ForeignKeyViolation",
     );
   });
 
-  it("maps a missing row to RecordNotFound (P2025) on findUniqueOrThrow, update, and delete", async () => {
-    const db = await makeDb();
+  it("maps a missing row to RecordNotFound (P2025) on findUniqueOrThrow, update, and delete", async ({
+    db,
+  }) => {
     await expect(db.user.tryFindUniqueOrThrow({ where: { id: 999 } })).toBeErrTagged(
       "RecordNotFound",
     );
@@ -89,8 +100,7 @@ describe("try* model methods", () => {
     await expect(db.user.tryDelete({ where: { id: 999 } })).toBeErrTagged("RecordNotFound");
   });
 
-  it("updates, deletes, and counts through the bridge", async () => {
-    const db = await makeDb();
+  it("updates, deletes, and counts through the bridge", async ({ db }) => {
     await db.user.tryCreate({ data: { email: "ada@example.com" } });
     await expect(
       db.user.tryUpdate({ where: { email: "ada@example.com" }, data: { name: "Countess" } }),
@@ -103,17 +113,15 @@ describe("try* model methods", () => {
 });
 
 describe("$tryTransaction", () => {
-  it("commits when the callback returns Ok", async () => {
-    const db = await makeDb();
+  it("commits when the callback returns Ok", async ({ db }) => {
     await expect(
       db.$tryTransaction((tx) => tx.user.tryCreate({ data: { email: "tx@example.com" } })),
     ).toBeOkWith(expect.objectContaining({ email: "tx@example.com" }));
     await expect(db.user.tryCount()).toBeOkWith(1);
   });
 
-  it("rolls back on Err and re-surfaces the callback's typed error", async () => {
+  it("rolls back on Err and re-surfaces the callback's typed error", async ({ db }) => {
     class Nope extends TaggedError("Nope") {}
-    const db = await makeDb();
     await expect(
       db.$tryTransaction((tx) =>
         tx.user.tryCreate({ data: { email: "gone@example.com" } }).flatMap(() => Err(new Nope())),
@@ -122,8 +130,7 @@ describe("$tryTransaction", () => {
     await expect(db.user.tryCount()).toBeOkWith(0);
   });
 
-  it("rolls back on a defect and the defect stays a defect", async () => {
-    const db = await makeDb();
+  it("rolls back on a defect and the defect stays a defect", async ({ db }) => {
     await expect(
       db.$tryTransaction((tx) =>
         tx.user.tryCreate({ data: { email: "boom@example.com" } }).map(() => {
@@ -134,16 +141,16 @@ describe("$tryTransaction", () => {
     await expect(db.user.tryCount()).toBeOkWith(0);
   });
 
-  it("surfaces a query failure inside the transaction as its tagged error", async () => {
-    const db = await makeDb();
+  it("surfaces a query failure inside the transaction as its tagged error", async ({ db }) => {
     await db.user.tryCreate({ data: { email: "dup@example.com" } });
     await expect(
       db.$tryTransaction((tx) => tx.user.tryCreate({ data: { email: "dup@example.com" } })),
     ).toBeErrTagged("UniqueConstraintViolation");
   });
 
-  it("qualifies a transaction-level failure (commit after timeout) as DriverError", async () => {
-    const db = await makeDb();
+  it("qualifies a transaction-level failure (commit after timeout) as DriverError", async ({
+    db,
+  }) => {
     // The callback outlives the transaction timeout WITHOUT touching `tx`, so the
     // rejection comes from Prisma's commit — not through the sentinel.
     await expect(
@@ -156,18 +163,9 @@ describe("$tryTransaction", () => {
 });
 
 describe("tryPaginate / withCursor", () => {
-  // Six users, ids 1..6. `name` is the filter knob: flipping one row to
-  // "banned" makes its cursor stop matching a `where: { name: "member" }`.
-  const seed = async (db: Awaited<ReturnType<typeof makeDb>>) => {
-    await db.user.createMany({
-      data: [1, 2, 3, 4, 5, 6].map((n) => ({ email: `u${n}@example.com`, name: "member" })),
-    });
-  };
   const ids = (rows: ReadonlyArray<{ id: number }>) => rows.map((r) => r.id);
 
-  it("serves the first page with default cursors", async () => {
-    const db = await makeDb();
-    await seed(db);
+  it("serves the first page with default cursors", async ({ seededDb: db }) => {
     const page = await db.user.tryPaginate({ orderBy: { id: "asc" } }).withCursor({ limit: 2 });
     expect(page.isOk() && [ids(page.value[0]), page.value[1]]).toEqual([
       [1, 2],
@@ -175,9 +173,7 @@ describe("tryPaginate / withCursor", () => {
     ]);
   });
 
-  it("pages forward with after (exclusive) and reports both flags", async () => {
-    const db = await makeDb();
-    await seed(db);
+  it("pages forward with after (exclusive) and reports both flags", async ({ seededDb: db }) => {
     const page = await db.user
       .tryPaginate({ orderBy: { id: "asc" } })
       .withCursor({ limit: 2, after: "2" });
@@ -187,9 +183,7 @@ describe("tryPaginate / withCursor", () => {
     ]);
   });
 
-  it("reaches the last page with hasNextPage false", async () => {
-    const db = await makeDb();
-    await seed(db);
+  it("reaches the last page with hasNextPage false", async ({ seededDb: db }) => {
     const page = await db.user
       .tryPaginate({ orderBy: { id: "asc" } })
       .withCursor({ limit: 2, after: "5" });
@@ -199,9 +193,7 @@ describe("tryPaginate / withCursor", () => {
     ]);
   });
 
-  it("pages backward with before (exclusive)", async () => {
-    const db = await makeDb();
-    await seed(db);
+  it("pages backward with before (exclusive)", async ({ seededDb: db }) => {
     const page = await db.user
       .tryPaginate({ orderBy: { id: "asc" } })
       .withCursor({ limit: 2, before: "4" });
@@ -211,9 +203,7 @@ describe("tryPaginate / withCursor", () => {
     ]);
   });
 
-  it("serves an empty page past the end with null cursors", async () => {
-    const db = await makeDb();
-    await seed(db);
+  it("serves an empty page past the end with null cursors", async ({ seededDb: db }) => {
     const page = await db.user
       .tryPaginate({ orderBy: { id: "asc" } })
       .withCursor({ limit: 2, after: "6" });
@@ -223,9 +213,9 @@ describe("tryPaginate / withCursor", () => {
     ]);
   });
 
-  it("returns everything with limit null, from the after cursor when given", async () => {
-    const db = await makeDb();
-    await seed(db);
+  it("returns everything with limit null, from the after cursor when given", async ({
+    seededDb: db,
+  }) => {
     const all = await db.user.tryPaginate({ orderBy: { id: "asc" } }).withCursor({ limit: null });
     expect(all.isOk() && [ids(all.value[0]), all.value[1].hasNextPage]).toEqual([
       [1, 2, 3, 4, 5, 6],
@@ -243,9 +233,9 @@ describe("tryPaginate / withCursor", () => {
   // The fix carried over from deptyped/prisma-extension-pagination#36 (#35):
   // when the AFTER cursor row was mutated and no longer matches the filter, the
   // first element of the page must NOT be skipped.
-  it("does not skip the first element when the after cursor no longer matches the filter", async () => {
-    const db = await makeDb();
-    await seed(db);
+  it("does not skip the first element when the after cursor no longer matches the filter", async ({
+    seededDb: db,
+  }) => {
     await db.user.update({ where: { id: 3 }, data: { name: "banned" } });
     const query = { where: { name: "member" }, orderBy: { id: "asc" } } as const;
     const wide = await db.user.tryPaginate(query).withCursor({ limit: 2, after: "3" });
@@ -261,9 +251,9 @@ describe("tryPaginate / withCursor", () => {
     ]);
   });
 
-  it("does not skip the last element when the before cursor no longer matches the filter", async () => {
-    const db = await makeDb();
-    await seed(db);
+  it("does not skip the last element when the before cursor no longer matches the filter", async ({
+    seededDb: db,
+  }) => {
     await db.user.update({ where: { id: 4 }, data: { name: "banned" } });
     const query = { where: { name: "member" }, orderBy: { id: "asc" } } as const;
     const wide = await db.user.tryPaginate(query).withCursor({ limit: 2, before: "4" });
@@ -279,9 +269,7 @@ describe("tryPaginate / withCursor", () => {
     ]);
   });
 
-  it("supports a custom cursor serialization (email)", async () => {
-    const db = await makeDb();
-    await seed(db);
+  it("supports a custom cursor serialization (email)", async ({ seededDb: db }) => {
     const page = await db.user.tryPaginate({ orderBy: { id: "asc" } }).withCursor({
       limit: 2,
       after: "u2@example.com",
@@ -294,9 +282,7 @@ describe("tryPaginate / withCursor", () => {
     ]);
   });
 
-  it("paginates a narrowed selection", async () => {
-    const db = await makeDb();
-    await seed(db);
+  it("paginates a narrowed selection", async ({ seededDb: db }) => {
     await expect(
       db.user
         .tryPaginate({ select: { id: true }, orderBy: { id: "asc" } })
@@ -307,17 +293,15 @@ describe("tryPaginate / withCursor", () => {
     ]);
   });
 
-  it("surfaces a default cursor over a selection without id as DriverError", async () => {
-    const db = await makeDb();
-    await seed(db);
+  it("surfaces a default cursor over a selection without id as DriverError", async ({
+    seededDb: db,
+  }) => {
     await expect(
       db.user.tryPaginate({ select: { email: true } }).withCursor({ limit: 2 }),
     ).toBeErrTagged("DriverError");
   });
 
-  it("surfaces a malformed cursor as DriverError", async () => {
-    const db = await makeDb();
-    await seed(db);
+  it("surfaces a malformed cursor as DriverError", async ({ seededDb: db }) => {
     // Default parseCursor keeps a non-numeric cursor as a string — invalid for
     // this model's Int id, so Prisma rejects it.
     await expect(

--- a/packages/prisma/src/index.spec.ts
+++ b/packages/prisma/src/index.spec.ts
@@ -329,6 +329,88 @@ describe("tryPaginate / withCursor", () => {
       /default cursor reads the `id` field/,
     );
   });
+
+  it("compares cursors structurally — bigint ids survive the round-trip", async () => {
+    // JSON.stringify-based comparison would throw on bigint cursor values.
+    const model = {
+      findMany: (args: object) =>
+        Promise.resolve(
+          (args as { take?: number }).take === -1
+            ? [{ id: 1n }]
+            : [{ id: 1n }, { id: 2n }, { id: 3n }],
+        ),
+    };
+    await expect(
+      paginateWithCursor(model, undefined, {
+        limit: 2,
+        after: "1",
+        getCursor: (row: { id: bigint }) => String(row.id),
+        parseCursor: (cursor) => ({ id: BigInt(cursor) }),
+      }),
+    ).resolves.toEqual([
+      [{ id: 2n }, { id: 3n }],
+      { hasPreviousPage: true, hasNextPage: false, startCursor: "2", endCursor: "3" },
+    ]);
+  });
+
+  it("compares cursors structurally — Date and array values round-trip", async () => {
+    // A composite cursor carrying a DateTime and a (contrived) array: both
+    // compare by value, not by reference.
+    const rows = [
+      { at: new Date(1000), tags: ["a", "b"] },
+      { at: new Date(2000), tags: ["c"] },
+    ];
+    const model = {
+      findMany: (args: object) =>
+        Promise.resolve((args as { take?: number }).take === -1 ? [rows[0]] : [...rows]),
+    };
+    const cursorOf = (row: { at: Date; tags: string[] }) =>
+      `${row.at.getTime()}|${row.tags.join(",")}`;
+    await expect(
+      paginateWithCursor(model, undefined, {
+        limit: 2,
+        after: cursorOf(rows[0]!),
+        getCursor: cursorOf,
+        parseCursor: (cursor) => {
+          const [at = "", tags = ""] = cursor.split("|");
+          return { at: new Date(Number(at)), tags: tags.split(",") };
+        },
+      }),
+    ).resolves.toEqual([
+      [rows[1]],
+      { hasPreviousPage: true, hasNextPage: false, startCursor: "2000|c", endCursor: "2000|c" },
+    ]);
+  });
+
+  it("compares cursors structurally — key order does not matter", async () => {
+    // The request cursor and the boundary row's cursor are parsed by separate
+    // calls; a parseCursor emitting keys in a different order each time must
+    // still round-trip (JSON.stringify comparison would false-negative and
+    // leave the cursor row in the page).
+    let flip = false;
+    const rows = [
+      { userId: 1, postId: 2 },
+      { userId: 3, postId: 4 },
+    ];
+    const model = {
+      findMany: (args: object) =>
+        Promise.resolve((args as { take?: number }).take === -1 ? [rows[0]] : [...rows]),
+    };
+    await expect(
+      paginateWithCursor(model, undefined, {
+        limit: 2,
+        after: "1:2",
+        getCursor: (row: { userId: number; postId: number }) => `${row.userId}:${row.postId}`,
+        parseCursor: () => {
+          flip = !flip;
+          return flip ? { userId: 1, postId: 2 } : { postId: 2, userId: 1 };
+        },
+      }),
+    ).resolves.toEqual([
+      [{ userId: 3, postId: 4 }],
+      { hasPreviousPage: true, hasNextPage: false, startCursor: "3:4", endCursor: "3:4" },
+    ]);
+  });
 });
 
 describe("qualifyPrismaError", () => {

--- a/packages/prisma/src/index.spec.ts
+++ b/packages/prisma/src/index.spec.ts
@@ -110,6 +110,97 @@ describe("try* model methods", () => {
     );
     await expect(db.user.tryCount()).toBeOkWith(0);
   });
+
+  it("finds the first match — Ok(row) on hit, Ok(null) on miss, RecordNotFound only for OrThrow", async ({
+    db,
+  }) => {
+    await db.user.tryCreate({ data: { email: "bee@example.com", name: "Bee" } });
+    await expect(db.user.tryFindFirst({ where: { name: "Bee" } })).toBeOkWith(
+      expect.objectContaining({ email: "bee@example.com" }),
+    );
+    await expect(db.user.tryFindFirst({ where: { name: "nobody" } })).toBeOkWith(null);
+    await expect(db.user.tryFindFirstOrThrow({ where: { name: "Bee" } })).toBeOkWith(
+      expect.objectContaining({ email: "bee@example.com" }),
+    );
+    await expect(db.user.tryFindFirstOrThrow({ where: { name: "nobody" } })).toBeErrTagged(
+      "RecordNotFound",
+    );
+  });
+
+  it("creates many — the count, the AndReturn rows, and P2002 for a duplicate in the batch", async ({
+    db,
+  }) => {
+    await expect(
+      db.user.tryCreateMany({ data: [{ email: "a@x.com" }, { email: "b@x.com" }] }),
+    ).toBeOkWith({ count: 2 });
+    await expect(
+      db.user.tryCreateManyAndReturn({ data: [{ email: "c@x.com" }], select: { email: true } }),
+    ).toBeOkWith([{ email: "c@x.com" }]);
+    await expect(db.user.tryCreateMany({ data: [{ email: "a@x.com" }] })).toBeErrTagged(
+      "UniqueConstraintViolation",
+    );
+  });
+
+  it("upserts — creates on miss (never P2025), updates on hit, and models a unique collision", async ({
+    db,
+  }) => {
+    const upsert = (update: { name?: string; email?: string }) =>
+      db.user.tryUpsert({
+        where: { email: "up@x.com" },
+        create: { email: "up@x.com", name: "created" },
+        update,
+      });
+    await expect(upsert({ name: "updated" })).toBeOkWith(
+      expect.objectContaining({ name: "created" }),
+    );
+    await expect(upsert({ name: "updated" })).toBeOkWith(
+      expect.objectContaining({ name: "updated" }),
+    );
+    await db.user.tryCreate({ data: { email: "taken@x.com" } });
+    await expect(upsert({ email: "taken@x.com" })).toBeErrTagged("UniqueConstraintViolation");
+  });
+
+  it("updates many — the count, Ok(0) on zero matches (never P2025), P2002 on a collision", async ({
+    seededDb: db,
+  }) => {
+    await expect(
+      db.user.tryUpdateMany({ where: { name: "member" }, data: { name: "crew" } }),
+    ).toBeOkWith({ count: 6 });
+    await expect(
+      db.user.tryUpdateMany({ where: { name: "nobody" }, data: { name: "x" } }),
+    ).toBeOkWith({ count: 0 });
+    await expect(
+      db.user.tryUpdateMany({ where: { id: 1 }, data: { email: "u2@example.com" } }),
+    ).toBeErrTagged("UniqueConstraintViolation");
+    await expect(
+      db.user.tryUpdateManyAndReturn({
+        where: { id: 1 },
+        data: { name: "solo" },
+        select: { name: true },
+      }),
+    ).toBeOkWith([{ name: "solo" }]);
+  });
+
+  it("deletes many — a referenced parent is P2003; the count otherwise (zero matches is Ok)", async ({
+    db,
+  }) => {
+    await db.user.tryCreate({ data: { email: "parent@x.com" } });
+    await db.post.tryCreate({ data: { title: "t", authorId: 1 } });
+    await expect(db.user.tryDeleteMany({ where: { id: 1 } })).toBeErrTagged("ForeignKeyViolation");
+    await expect(db.post.tryDeleteMany()).toBeOkWith({ count: 1 });
+    await expect(db.user.tryDeleteMany()).toBeOkWith({ count: 1 });
+    await expect(db.user.tryDeleteMany()).toBeOkWith({ count: 0 });
+  });
+
+  it("aggregates and groups through the bridge", async ({ seededDb: db }) => {
+    await expect(db.user.tryAggregate({ _count: true, _max: { id: true } })).toBeOkWith({
+      _count: 6,
+      _max: { id: 6 },
+    });
+    await expect(db.user.tryGroupBy({ by: ["name"], _count: true })).toBeOkWith([
+      { name: "member", _count: 6 },
+    ]);
+  });
 });
 
 describe("$tryTransaction", () => {

--- a/packages/prisma/src/index.spec.ts
+++ b/packages/prisma/src/index.spec.ts
@@ -13,6 +13,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { PrismaClient } from "./generated/prisma/client.ts";
 import { qualifyPrismaError, unthrownPrisma } from "./index.js";
+import { paginateWithCursor } from "./pagination.js";
 
 // The test schema's tables, created by hand (no Migrate): an in-memory database
 // is born empty, and DDL-by-hand keeps the suite free of any migration engine.
@@ -151,6 +152,198 @@ describe("$tryTransaction", () => {
         { timeout: 10 },
       ),
     ).toBeErrTagged("DriverError");
+  });
+});
+
+describe("tryPaginate / withCursor", () => {
+  // Six users, ids 1..6. `name` is the filter knob: flipping one row to
+  // "banned" makes its cursor stop matching a `where: { name: "member" }`.
+  const seed = async (db: Awaited<ReturnType<typeof makeDb>>) => {
+    await db.user.createMany({
+      data: [1, 2, 3, 4, 5, 6].map((n) => ({ email: `u${n}@example.com`, name: "member" })),
+    });
+  };
+  const ids = (rows: ReadonlyArray<{ id: number }>) => rows.map((r) => r.id);
+
+  it("serves the first page with default cursors", async () => {
+    const db = await makeDb();
+    await seed(db);
+    const page = await db.user.tryPaginate({ orderBy: { id: "asc" } }).withCursor({ limit: 2 });
+    expect(page.isOk() && [ids(page.value[0]), page.value[1]]).toEqual([
+      [1, 2],
+      { hasPreviousPage: false, hasNextPage: true, startCursor: "1", endCursor: "2" },
+    ]);
+  });
+
+  it("pages forward with after (exclusive) and reports both flags", async () => {
+    const db = await makeDb();
+    await seed(db);
+    const page = await db.user
+      .tryPaginate({ orderBy: { id: "asc" } })
+      .withCursor({ limit: 2, after: "2" });
+    expect(page.isOk() && [ids(page.value[0]), page.value[1]]).toEqual([
+      [3, 4],
+      { hasPreviousPage: true, hasNextPage: true, startCursor: "3", endCursor: "4" },
+    ]);
+  });
+
+  it("reaches the last page with hasNextPage false", async () => {
+    const db = await makeDb();
+    await seed(db);
+    const page = await db.user
+      .tryPaginate({ orderBy: { id: "asc" } })
+      .withCursor({ limit: 2, after: "5" });
+    expect(page.isOk() && [ids(page.value[0]), page.value[1]]).toEqual([
+      [6],
+      { hasPreviousPage: true, hasNextPage: false, startCursor: "6", endCursor: "6" },
+    ]);
+  });
+
+  it("pages backward with before (exclusive)", async () => {
+    const db = await makeDb();
+    await seed(db);
+    const page = await db.user
+      .tryPaginate({ orderBy: { id: "asc" } })
+      .withCursor({ limit: 2, before: "4" });
+    expect(page.isOk() && [ids(page.value[0]), page.value[1]]).toEqual([
+      [2, 3],
+      { hasPreviousPage: true, hasNextPage: true, startCursor: "2", endCursor: "3" },
+    ]);
+  });
+
+  it("serves an empty page past the end with null cursors", async () => {
+    const db = await makeDb();
+    await seed(db);
+    const page = await db.user
+      .tryPaginate({ orderBy: { id: "asc" } })
+      .withCursor({ limit: 2, after: "6" });
+    expect(page.isOk() && [ids(page.value[0]), page.value[1]]).toEqual([
+      [],
+      { hasPreviousPage: true, hasNextPage: false, startCursor: null, endCursor: null },
+    ]);
+  });
+
+  it("returns everything with limit null, from the after cursor when given", async () => {
+    const db = await makeDb();
+    await seed(db);
+    const all = await db.user.tryPaginate({ orderBy: { id: "asc" } }).withCursor({ limit: null });
+    expect(all.isOk() && [ids(all.value[0]), all.value[1].hasNextPage]).toEqual([
+      [1, 2, 3, 4, 5, 6],
+      false,
+    ]);
+    const rest = await db.user
+      .tryPaginate({ orderBy: { id: "asc" } })
+      .withCursor({ limit: null, after: "4" });
+    expect(rest.isOk() && [ids(rest.value[0]), rest.value[1].hasPreviousPage]).toEqual([
+      [5, 6],
+      true,
+    ]);
+  });
+
+  // The fix carried over from deptyped/prisma-extension-pagination#36 (#35):
+  // when the AFTER cursor row was mutated and no longer matches the filter, the
+  // first element of the page must NOT be skipped.
+  it("does not skip the first element when the after cursor no longer matches the filter", async () => {
+    const db = await makeDb();
+    await seed(db);
+    await db.user.update({ where: { id: 3 }, data: { name: "banned" } });
+    const query = { where: { name: "member" }, orderBy: { id: "asc" } } as const;
+    const wide = await db.user.tryPaginate(query).withCursor({ limit: 2, after: "3" });
+    expect(wide.isOk() && [ids(wide.value[0]), wide.value[1]]).toEqual([
+      [4, 5],
+      { hasPreviousPage: true, hasNextPage: true, startCursor: "4", endCursor: "5" },
+    ]);
+    // limit 1 exercises the fully-over-fetched trim (limit + 2 rows come back).
+    const narrow = await db.user.tryPaginate(query).withCursor({ limit: 1, after: "3" });
+    expect(narrow.isOk() && [ids(narrow.value[0]), narrow.value[1].hasNextPage]).toEqual([
+      [4],
+      true,
+    ]);
+  });
+
+  it("does not skip the last element when the before cursor no longer matches the filter", async () => {
+    const db = await makeDb();
+    await seed(db);
+    await db.user.update({ where: { id: 4 }, data: { name: "banned" } });
+    const query = { where: { name: "member" }, orderBy: { id: "asc" } } as const;
+    const wide = await db.user.tryPaginate(query).withCursor({ limit: 2, before: "4" });
+    expect(wide.isOk() && [ids(wide.value[0]), wide.value[1]]).toEqual([
+      [2, 3],
+      { hasPreviousPage: true, hasNextPage: true, startCursor: "2", endCursor: "3" },
+    ]);
+    // limit 1 exercises the fully-over-fetched trim on the backward side.
+    const narrow = await db.user.tryPaginate(query).withCursor({ limit: 1, before: "4" });
+    expect(narrow.isOk() && [ids(narrow.value[0]), narrow.value[1].hasPreviousPage]).toEqual([
+      [3],
+      true,
+    ]);
+  });
+
+  it("supports a custom cursor serialization (email)", async () => {
+    const db = await makeDb();
+    await seed(db);
+    const page = await db.user.tryPaginate({ orderBy: { id: "asc" } }).withCursor({
+      limit: 2,
+      after: "u2@example.com",
+      getCursor: (row) => row.email,
+      parseCursor: (cursor) => ({ email: cursor }),
+    });
+    expect(page.isOk() && [ids(page.value[0]), page.value[1].endCursor]).toEqual([
+      [3, 4],
+      "u4@example.com",
+    ]);
+  });
+
+  it("paginates a narrowed selection", async () => {
+    const db = await makeDb();
+    await seed(db);
+    await expect(
+      db.user
+        .tryPaginate({ select: { id: true }, orderBy: { id: "asc" } })
+        .withCursor({ limit: 2 }),
+    ).toBeOkWith([
+      [{ id: 1 }, { id: 2 }],
+      { hasPreviousPage: false, hasNextPage: true, startCursor: "1", endCursor: "2" },
+    ]);
+  });
+
+  it("surfaces a default cursor over a selection without id as DriverError", async () => {
+    const db = await makeDb();
+    await seed(db);
+    await expect(
+      db.user.tryPaginate({ select: { email: true } }).withCursor({ limit: 2 }),
+    ).toBeErrTagged("DriverError");
+  });
+
+  it("surfaces a malformed cursor as DriverError", async () => {
+    const db = await makeDb();
+    await seed(db);
+    // Default parseCursor keeps a non-numeric cursor as a string — invalid for
+    // this model's Int id, so Prisma rejects it.
+    await expect(
+      db.user.tryPaginate({ orderBy: { id: "asc" } }).withCursor({ limit: 2, after: "not-an-id" }),
+    ).toBeErrTagged("DriverError");
+  });
+
+  // The `before` + `limit: null` combination is typed away at the public
+  // surface (Prisma's negative take cannot express it); untyped callers get
+  // the upstream library's behavior. Runtime-only, via the engine directly.
+  it("keeps upstream parity for an untyped limit:null + before", async () => {
+    const rows = () => [{ id: 1 }, { id: 2 }];
+    const model = { findMany: () => Promise.resolve(rows()) };
+    await expect(
+      paginateWithCursor(model, undefined, { limit: null, before: "9" }),
+    ).resolves.toEqual([
+      [{ id: 1 }, { id: 2 }],
+      { hasPreviousPage: false, hasNextPage: true, startCursor: "1", endCursor: "2" },
+    ]);
+  });
+
+  it("rejects when the default cursor meets a null id", async () => {
+    const model = { findMany: () => Promise.resolve([{ id: null }]) };
+    await expect(paginateWithCursor(model, undefined, { limit: 2 })).rejects.toThrow(
+      /default cursor reads the `id` field/,
+    );
   });
 });
 

--- a/packages/prisma/src/index.spec.ts
+++ b/packages/prisma/src/index.spec.ts
@@ -232,6 +232,20 @@ describe("$tryTransaction", () => {
     await expect(db.user.tryCount()).toBeOkWith(0);
   });
 
+  it("a callback that THROWS (instead of returning an AsyncResult) is a defect, not a DriverError", async ({
+    db,
+  }) => {
+    // The throw bypasses every combinator (no AsyncResult exists yet), so it
+    // reaches the transaction boundary raw. A bug must stay a defect — never
+    // be downgraded to a modeled DriverError.
+    await expect(
+      db.$tryTransaction(() => {
+        throw new Error("sync callback bug");
+      }),
+    ).toBeDefect();
+    await expect(db.user.tryCount()).toBeOkWith(0);
+  });
+
   it("surfaces a query failure inside the transaction as its tagged error", async ({ db }) => {
     await db.user.tryCreate({ data: { email: "dup@example.com" } });
     await expect(

--- a/packages/prisma/src/index.spec.ts
+++ b/packages/prisma/src/index.spec.ts
@@ -435,6 +435,35 @@ describe("tryPaginate / withCursor", () => {
     );
   });
 
+  it("the DEFAULT parser preserves a BigInt id beyond Number.MAX_SAFE_INTEGER", async () => {
+    // 2^53 + 1 is not representable as a number; a Number(...) default would
+    // silently address the wrong row. The default parser must emit a bigint —
+    // and still emit a plain number for safe-range ids.
+    const big = 9007199254740993n; // 2^53 + 1
+    const seen: unknown[] = [];
+    const model = {
+      findMany: (args: object) => {
+        seen.push((args as { cursor?: unknown }).cursor);
+        return Promise.resolve(
+          (args as { take?: number }).take === -1 ? [{ id: big }] : [{ id: big }, { id: big + 1n }],
+        );
+      },
+    };
+    await expect(
+      paginateWithCursor(model, undefined, { limit: 2, after: String(big) }),
+    ).resolves.toEqual([
+      [{ id: big + 1n }],
+      {
+        hasPreviousPage: true,
+        hasNextPage: false,
+        startCursor: "9007199254740994",
+        endCursor: "9007199254740994",
+      },
+    ]);
+    // The cursor Prisma received is the EXACT bigint, not a lossy number.
+    expect(seen[0]).toEqual({ id: big });
+  });
+
   it("compares cursors structurally — bigint ids survive the round-trip", async () => {
     // JSON.stringify-based comparison would throw on bigint cursor values.
     const model = {

--- a/packages/prisma/src/index.spec.ts
+++ b/packages/prisma/src/index.spec.ts
@@ -1,0 +1,225 @@
+// Integration tests against a REAL Prisma client over in-memory SQLite
+// (`@prisma/adapter-better-sqlite3`): every mapped P-code is provoked for real —
+// a duplicate email for P2002, a dangling relation for P2003, a missing row for
+// P2025 — and `$tryTransaction` is exercised end-to-end (commit, rollback on
+// `Err`, rollback on defect, `try*` methods available on the itx client). The
+// pure P-code mapping gets its own unit block.
+
+import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime/client";
+import "@unthrown/vitest";
+import { Err, fromSafePromise, TaggedError } from "unthrown";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { PrismaClient } from "./generated/prisma/client.ts";
+import { qualifyPrismaError, unthrownPrisma } from "./index.js";
+
+// The test schema's tables, created by hand (no Migrate): an in-memory database
+// is born empty, and DDL-by-hand keeps the suite free of any migration engine.
+const DDL = [
+  `PRAGMA foreign_keys = ON`,
+  `CREATE TABLE "User" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "email" TEXT NOT NULL, "name" TEXT)`,
+  `CREATE UNIQUE INDEX "User_email_key" ON "User"("email")`,
+  `CREATE TABLE "Post" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "title" TEXT NOT NULL, "authorId" INTEGER NOT NULL, CONSTRAINT "Post_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User" ("id"))`,
+];
+
+const open: Array<{ $disconnect: () => Promise<void> }> = [];
+
+const makeDb = async () => {
+  const adapter = new PrismaBetterSqlite3({ url: ":memory:" });
+  const db = new PrismaClient({ adapter }).$extends(unthrownPrisma);
+  open.push(db);
+  for (const stmt of DDL) await db.$executeRawUnsafe(stmt);
+  return db;
+};
+
+afterEach(async () => {
+  await Promise.all(open.splice(0).map((db) => db.$disconnect()));
+});
+
+describe("try* model methods", () => {
+  it("wraps a successful create and read in Ok", async () => {
+    const db = await makeDb();
+    await expect(db.user.tryCreate({ data: { email: "ada@example.com", name: "Ada" } })).toBeOkWith(
+      expect.objectContaining({ email: "ada@example.com", name: "Ada" }),
+    );
+    await expect(db.user.tryFindMany()).toBeOkWith([
+      expect.objectContaining({ email: "ada@example.com" }),
+    ]);
+  });
+
+  it("applies a select at runtime (the narrowed payload is real)", async () => {
+    const db = await makeDb();
+    await db.user.tryCreate({ data: { email: "ada@example.com", name: "Ada" } });
+    await expect(db.user.tryFindMany({ select: { email: true } })).toBeOkWith([
+      { email: "ada@example.com" },
+    ]);
+  });
+
+  it("returns Ok(null) for a findUnique miss (absence is not an error)", async () => {
+    const db = await makeDb();
+    await expect(db.user.tryFindUnique({ where: { id: 999 } })).toBeOkWith(null);
+  });
+
+  it("maps a duplicate key to UniqueConstraintViolation (P2002)", async () => {
+    const db = await makeDb();
+    await db.user.tryCreate({ data: { email: "dup@example.com" } });
+    await expect(db.user.tryCreate({ data: { email: "dup@example.com" } })).toBeErrTagged(
+      "UniqueConstraintViolation",
+      expect.objectContaining({ fields: ["email"] }),
+    );
+  });
+
+  it("maps a dangling relation to ForeignKeyViolation (P2003)", async () => {
+    const db = await makeDb();
+    await expect(db.post.tryCreate({ data: { title: "orphan", authorId: 999 } })).toBeErrTagged(
+      "ForeignKeyViolation",
+    );
+  });
+
+  it("maps a missing row to RecordNotFound (P2025) on findUniqueOrThrow, update, and delete", async () => {
+    const db = await makeDb();
+    await expect(db.user.tryFindUniqueOrThrow({ where: { id: 999 } })).toBeErrTagged(
+      "RecordNotFound",
+    );
+    await expect(db.user.tryUpdate({ where: { id: 999 }, data: { name: "x" } })).toBeErrTagged(
+      "RecordNotFound",
+    );
+    await expect(db.user.tryDelete({ where: { id: 999 } })).toBeErrTagged("RecordNotFound");
+  });
+
+  it("updates, deletes, and counts through the bridge", async () => {
+    const db = await makeDb();
+    await db.user.tryCreate({ data: { email: "ada@example.com" } });
+    await expect(
+      db.user.tryUpdate({ where: { email: "ada@example.com" }, data: { name: "Countess" } }),
+    ).toBeOkWith(expect.objectContaining({ name: "Countess" }));
+    await expect(db.user.tryDelete({ where: { email: "ada@example.com" } })).toBeOkWith(
+      expect.objectContaining({ email: "ada@example.com" }),
+    );
+    await expect(db.user.tryCount()).toBeOkWith(0);
+  });
+});
+
+describe("$tryTransaction", () => {
+  it("commits when the callback returns Ok", async () => {
+    const db = await makeDb();
+    await expect(
+      db.$tryTransaction((tx) => tx.user.tryCreate({ data: { email: "tx@example.com" } })),
+    ).toBeOkWith(expect.objectContaining({ email: "tx@example.com" }));
+    await expect(db.user.tryCount()).toBeOkWith(1);
+  });
+
+  it("rolls back on Err and re-surfaces the callback's typed error", async () => {
+    class Nope extends TaggedError("Nope") {}
+    const db = await makeDb();
+    await expect(
+      db.$tryTransaction((tx) =>
+        tx.user.tryCreate({ data: { email: "gone@example.com" } }).flatMap(() => Err(new Nope())),
+      ),
+    ).toBeErrTagged("Nope");
+    await expect(db.user.tryCount()).toBeOkWith(0);
+  });
+
+  it("rolls back on a defect and the defect stays a defect", async () => {
+    const db = await makeDb();
+    await expect(
+      db.$tryTransaction((tx) =>
+        tx.user.tryCreate({ data: { email: "boom@example.com" } }).map(() => {
+          throw new Error("boom");
+        }),
+      ),
+    ).toBeDefect();
+    await expect(db.user.tryCount()).toBeOkWith(0);
+  });
+
+  it("surfaces a query failure inside the transaction as its tagged error", async () => {
+    const db = await makeDb();
+    await db.user.tryCreate({ data: { email: "dup@example.com" } });
+    await expect(
+      db.$tryTransaction((tx) => tx.user.tryCreate({ data: { email: "dup@example.com" } })),
+    ).toBeErrTagged("UniqueConstraintViolation");
+  });
+
+  it("qualifies a transaction-level failure (commit after timeout) as DriverError", async () => {
+    const db = await makeDb();
+    // The callback outlives the transaction timeout WITHOUT touching `tx`, so the
+    // rejection comes from Prisma's commit — not through the sentinel.
+    await expect(
+      db.$tryTransaction(
+        () => fromSafePromise(new Promise((resolve) => setTimeout(resolve, 100))).map(() => "ok"),
+        { timeout: 10 },
+      ),
+    ).toBeErrTagged("DriverError");
+  });
+});
+
+describe("qualifyPrismaError", () => {
+  const known = (code: string, meta?: Record<string, unknown>) =>
+    new PrismaClientKnownRequestError("boom", {
+      code,
+      clientVersion: "7.0.0",
+      ...(meta ? { meta } : {}),
+    });
+
+  it("maps P2002 to UniqueConstraintViolation with the offending fields", () => {
+    const cause = known("P2002", { target: ["email"] });
+    expect(qualifyPrismaError(cause)).toEqual(
+      expect.objectContaining({ _tag: "UniqueConstraintViolation", fields: ["email"], cause }),
+    );
+  });
+
+  it("maps P2002 in the driver-adapter shape (fields nested under driverAdapterError)", () => {
+    const cause = known("P2002", {
+      driverAdapterError: { cause: { constraint: { fields: ["email"] } } },
+    });
+    expect(qualifyPrismaError(cause)).toEqual(
+      expect.objectContaining({ _tag: "UniqueConstraintViolation", fields: ["email"], cause }),
+    );
+  });
+
+  it("maps P2002 without a target to an empty field list", () => {
+    expect(qualifyPrismaError(known("P2002"))).toEqual(
+      expect.objectContaining({ _tag: "UniqueConstraintViolation", fields: [] }),
+    );
+  });
+
+  it.each([
+    { driverAdapterError: "junk" },
+    { driverAdapterError: { cause: "junk" } },
+    { driverAdapterError: { cause: { constraint: "junk" } } },
+    { driverAdapterError: { cause: { constraint: { fields: "email" } } } },
+  ])("maps P2002 with a malformed meta (%j) to an empty field list", (meta) => {
+    expect(qualifyPrismaError(known("P2002", meta))).toEqual(
+      expect.objectContaining({ _tag: "UniqueConstraintViolation", fields: [] }),
+    );
+  });
+
+  it("maps P2003 to ForeignKeyViolation", () => {
+    const cause = known("P2003");
+    expect(qualifyPrismaError(cause)).toEqual(
+      expect.objectContaining({ _tag: "ForeignKeyViolation", cause }),
+    );
+  });
+
+  it("maps P2025 to RecordNotFound", () => {
+    const cause = known("P2025");
+    expect(qualifyPrismaError(cause)).toEqual(
+      expect.objectContaining({ _tag: "RecordNotFound", cause }),
+    );
+  });
+
+  it("maps an unhandled P-code to DriverError", () => {
+    const cause = known("P2024");
+    expect(qualifyPrismaError(cause)).toEqual(
+      expect.objectContaining({ _tag: "DriverError", cause }),
+    );
+  });
+
+  it("maps a non-Prisma rejection to DriverError, preserving the cause", () => {
+    const cause = new Error("socket hang up");
+    expect(qualifyPrismaError(cause)).toEqual(
+      expect.objectContaining({ _tag: "DriverError", cause }),
+    );
+  });
+});

--- a/packages/prisma/src/index.ts
+++ b/packages/prisma/src/index.ts
@@ -155,8 +155,11 @@ type DeleteManyError = ForeignKeyViolation | DriverError;
 type UntypedDelegate = Record<string, (args?: unknown) => Promise<unknown>>;
 
 const query = (self: unknown, op: string, args?: unknown): AsyncResult<unknown, PrismaQueryError> =>
+  // Passed as a THUNK: a delegate that throws synchronously (e.g. a validation
+  // error out of untyped args) is absorbed by the boundary instead of escaping
+  // the AsyncResult as a raw throw.
   fromPromise(
-    (Prisma.getExtensionContext(self) as unknown as UntypedDelegate)[op]!(args),
+    () => (Prisma.getExtensionContext(self) as unknown as UntypedDelegate)[op]!(args),
     qualifyPrismaError,
   );
 
@@ -536,23 +539,27 @@ export const unthrownPrisma = Prisma.defineExtension({
       const client = Prisma.getExtensionContext(this) as unknown as {
         $transaction: <R>(f: (tx: unknown) => Promise<R>, opts?: unknown) => Promise<R>;
       };
+      // Passed as a THUNK so even a synchronous throw out of `$transaction`
+      // itself (e.g. invalid options from untyped code) stays inside the
+      // boundary instead of escaping as a raw throw.
       return fromPromise(
-        client.$transaction(async (tx) => {
-          let result: Result<T, E>;
-          try {
-            result = await fn(tx as Omit<C, TxDenyList>);
-          } catch (cause) {
-            // A callback that throws (instead of returning an AsyncResult) is a
-            // bug — roll back and keep it a DEFECT. Only rejections outside
-            // this catch (Prisma's own BEGIN/COMMIT/timeout machinery) qualify
-            // as query failures below.
-            throw new Rollback(cause, true);
-          }
-          if (result.isOk()) return result.value;
-          throw result.isErr()
-            ? new Rollback(result.error, false)
-            : new Rollback(result.cause, true);
-        }, options),
+        () =>
+          client.$transaction(async (tx) => {
+            let result: Result<T, E>;
+            try {
+              result = await fn(tx as Omit<C, TxDenyList>);
+            } catch (cause) {
+              // A callback that throws (instead of returning an AsyncResult) is a
+              // bug — roll back and keep it a DEFECT. Only rejections outside
+              // this catch (Prisma's own BEGIN/COMMIT/timeout machinery) qualify
+              // as query failures below.
+              throw new Rollback(cause, true);
+            }
+            if (result.isOk()) return result.value;
+            throw result.isErr()
+              ? new Rollback(result.error, false)
+              : new Rollback(result.cause, true);
+          }, options),
         (cause, defect) =>
           cause instanceof Rollback
             ? cause.wasDefect

--- a/packages/prisma/src/index.ts
+++ b/packages/prisma/src/index.ts
@@ -17,7 +17,6 @@
 // for batch `$transaction([...])`, which needs unexecuted `PrismaPromise`s.
 
 import { Prisma } from "@prisma/client/extension";
-import { PrismaClientKnownRequestError } from "@prisma/client/runtime/client";
 import { type AsyncResult, fromPromise, TaggedError } from "unthrown";
 
 import {
@@ -78,6 +77,18 @@ export type PrismaQueryError =
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
 
+// Recognized structurally rather than with `instanceof` against a class
+// imported from a Prisma runtime entry: the runtime module path varies across
+// Prisma versions (`runtime/library` in v4–v6, `runtime/client` in v7), and an
+// `instanceof` against the wrong copy would silently fail. The `name` +
+// string-`code` shape is stable across all of them.
+type KnownRequestError = Error & { code: string; meta?: unknown };
+
+const isKnownRequestError = (cause: unknown): cause is KnownRequestError =>
+  cause instanceof Error &&
+  cause.name === "PrismaClientKnownRequestError" &&
+  typeof (cause as { code?: unknown }).code === "string";
+
 // The offending column set of a P2002, wherever this Prisma version put it:
 // `meta.target` (the classic engine shape) or
 // `meta.driverAdapterError.cause.constraint.fields` (the driver-adapter shape).
@@ -108,7 +119,7 @@ const constraintFields = (meta: unknown): readonly string[] => {
  * @param cause - the rejected value from a Prisma query.
  */
 export const qualifyPrismaError = (cause: unknown): PrismaQueryError => {
-  if (cause instanceof PrismaClientKnownRequestError) {
+  if (isKnownRequestError(cause)) {
     switch (cause.code) {
       case "P2002":
         return new UniqueConstraintViolation({ fields: constraintFields(cause.meta), cause });
@@ -155,6 +166,23 @@ class Rollback extends Error {
     super("transaction rolled back");
   }
 }
+
+/**
+ * The isolation levels Prisma accepts across databases, as a closed union.
+ *
+ * @remarks
+ * The schema-derived `Prisma.TransactionIsolationLevel` of a generated client
+ * is narrower (it lists only what YOUR database supports), but a shareable
+ * extension cannot name a generated type — this union at least rejects typos
+ * at compile time; a level your database does not support still fails at
+ * runtime as a {@link DriverError}.
+ */
+export type TransactionIsolationLevel =
+  | "ReadUncommitted"
+  | "ReadCommitted"
+  | "RepeatableRead"
+  | "Snapshot"
+  | "Serializable";
 
 /**
  * What `tryPaginate` returns: a builder holding the query, consumed by
@@ -367,7 +395,7 @@ export const unthrownPrisma = Prisma.defineExtension({
       options?: {
         maxWait?: number;
         timeout?: number;
-        isolationLevel?: string;
+        isolationLevel?: TransactionIsolationLevel;
       },
     ): AsyncResult<T, E | PrismaQueryError> {
       const client = Prisma.getExtensionContext(this) as unknown as {

--- a/packages/prisma/src/index.ts
+++ b/packages/prisma/src/index.ts
@@ -20,6 +20,15 @@ import { Prisma } from "@prisma/client/extension";
 import { PrismaClientKnownRequestError } from "@prisma/client/runtime/client";
 import { type AsyncResult, fromPromise, TaggedError } from "unthrown";
 
+import {
+  type CursorPaginationMeta,
+  type CursorPaginationOptions,
+  type PaginationDelegate,
+  paginateWithCursor,
+} from "./pagination.js";
+
+export type { CursorPaginationMeta, CursorPaginationOptions } from "./pagination.js";
+
 /**
  * A unique constraint was violated (Prisma error `P2002`).
  *
@@ -147,6 +156,23 @@ class Rollback extends Error {
   }
 }
 
+/**
+ * What `tryPaginate` returns: a builder holding the query, consumed by
+ * `withCursor`.
+ *
+ * @typeParam Results - the (selection-narrowed) `findMany` payload.
+ * @typeParam Cursor - the model's `cursor` input (its unique-where shape).
+ */
+export type CursorPaginator<Results extends readonly unknown[], Cursor> = {
+  /**
+   * Run the paginated query: the page and its metadata, or a
+   * {@link DriverError}.
+   */
+  readonly withCursor: (
+    options: CursorPaginationOptions<Results[number], Cursor>,
+  ) => AsyncResult<[Results, CursorPaginationMeta], DriverError>;
+};
+
 // Mirrors Prisma's `ITXClientDenyList` — what an interactive-transaction client
 // cannot do — plus `$tryTransaction` itself: nested transactions are not a
 // thing, and the itx client has no `$transaction` for the bridge to delegate to.
@@ -266,6 +292,47 @@ export const unthrownPrisma = Prisma.defineExtension({
         return query(this, "delete", args) as AsyncResult<
           Prisma.Result<T, A, "delete">,
           DeleteError
+        >;
+      },
+
+      /**
+       * Cursor pagination, in the style of `prisma-extension-pagination`:
+       * `tryPaginate(query).withCursor({ limit, after, before })` runs the
+       * `findMany` and answers with `[results, meta]`, where `meta` carries
+       * `hasPreviousPage` / `hasNextPage` / `startCursor` / `endCursor`.
+       *
+       * @remarks
+       * `args` is the `findMany` query WITHOUT `cursor` / `take` / `skip` —
+       * pagination owns those. A cursor pointing at a record that no longer
+       * matches the query filter is handled correctly (the first element of
+       * the page is not skipped). A throwing `parseCursor` — e.g. a malformed
+       * cursor from an API client — surfaces as a {@link DriverError}.
+       *
+       * @example
+       * ```ts
+       * const page = await db.user
+       *   .tryPaginate({ where: { active: true }, orderBy: { id: "asc" } })
+       *   .withCursor({ limit: 20, after: req.query.cursor });
+       * // Ok([users, { hasNextPage, endCursor, ... }]) | Err(DriverError)
+       * ```
+       */
+      tryPaginate<T, A>(
+        this: T,
+        args?: Prisma.Exact<A, Omit<Prisma.Args<T, "findMany">, "cursor" | "take" | "skip">>,
+      ): CursorPaginator<
+        Prisma.Result<T, A, "findMany">,
+        NonNullable<Prisma.Args<T, "findMany">["cursor"]>
+      > {
+        const delegate = Prisma.getExtensionContext(this) as unknown as PaginationDelegate;
+        return {
+          withCursor: (options: Parameters<typeof paginateWithCursor>[2]) =>
+            fromPromise(
+              paginateWithCursor(delegate, args as object | undefined, options),
+              qualifyPrismaError,
+            ),
+        } as unknown as CursorPaginator<
+          Prisma.Result<T, A, "findMany">,
+          NonNullable<Prisma.Args<T, "findMany">["cursor"]>
         >;
       },
     },

--- a/packages/prisma/src/index.ts
+++ b/packages/prisma/src/index.ts
@@ -1,0 +1,326 @@
+// @unthrown/prisma — a Prisma Client extension that bridges Prisma queries into
+// unthrown's `AsyncResult`.
+//
+// `$extends(unthrownPrisma)` adds `try`-prefixed variants of the model delegate
+// operations ALONGSIDE the raw promise ones: each returns an `AsyncResult` whose
+// error channel is the set of P-codes THAT operation can produce, mapped to
+// tagged errors — a read cannot fail with `UniqueConstraintViolation` in the
+// type. Qualification happens once, inside the extension (Thesis #3): no raw
+// Promise ever crosses into a combinator.
+//
+//   const db = new PrismaClient({ adapter }).$extends(unthrownPrisma);
+//
+//   await db.user.tryCreate({ data }).match({ ok, err, defect });
+//   // err is UniqueConstraintViolation | ForeignKeyViolation | DriverError
+//
+// The raw promise methods stay available on purpose: they are the escape hatch
+// for batch `$transaction([...])`, which needs unexecuted `PrismaPromise`s.
+
+import { Prisma } from "@prisma/client/extension";
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime/client";
+import { type AsyncResult, fromPromise, TaggedError } from "unthrown";
+
+/**
+ * A unique constraint was violated (Prisma error `P2002`).
+ *
+ * @remarks
+ * `fields` carries the offending column set from the error's `meta.target`
+ * (empty when the driver does not report it).
+ */
+export class UniqueConstraintViolation extends TaggedError("UniqueConstraintViolation")<{
+  fields: readonly string[];
+  cause: unknown;
+}> {}
+
+/** A foreign key constraint was violated (Prisma error `P2003`). */
+export class ForeignKeyViolation extends TaggedError("ForeignKeyViolation")<{ cause: unknown }> {}
+
+/**
+ * A record required by the operation does not exist (Prisma error `P2025`) —
+ * the missing row of a `findUniqueOrThrow`, `update`, or `delete`.
+ */
+export class RecordNotFound extends TaggedError("RecordNotFound")<{ cause: unknown }> {}
+
+/**
+ * Any other query failure: connection drops, timeouts, unmapped P-codes,
+ * driver-level errors.
+ *
+ * @remarks
+ * Prisma validation errors land here too. Arguably a malformed query is a
+ * programmer bug rather than an anticipated outcome; triage it further at the
+ * call site if the distinction matters to you.
+ */
+export class DriverError extends TaggedError("DriverError")<{ cause: unknown }> {}
+
+/**
+ * The full union of tagged errors a Prisma query can surface.
+ *
+ * @remarks
+ * This is the RUNTIME-side union: {@link qualifyPrismaError} maps into it. Each
+ * `try*` method narrows the static type to the codes its operation can
+ * actually hit (a read is typed `DriverError` only).
+ */
+export type PrismaQueryError =
+  | UniqueConstraintViolation
+  | ForeignKeyViolation
+  | RecordNotFound
+  | DriverError;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+// The offending column set of a P2002, wherever this Prisma version put it:
+// `meta.target` (the classic engine shape) or
+// `meta.driverAdapterError.cause.constraint.fields` (the driver-adapter shape).
+const constraintFields = (meta: unknown): readonly string[] => {
+  if (!isRecord(meta)) return [];
+  const target = meta["target"];
+  if (Array.isArray(target)) return target.map(String);
+  const adapterError = meta["driverAdapterError"];
+  if (!isRecord(adapterError)) return [];
+  const cause = adapterError["cause"];
+  if (!isRecord(cause)) return [];
+  const constraint = cause["constraint"];
+  if (!isRecord(constraint)) return [];
+  const fields = constraint["fields"];
+  return Array.isArray(fields) ? fields.map(String) : [];
+};
+
+/**
+ * Qualify a Prisma rejection into a tagged error — the runtime half of the
+ * bridge.
+ *
+ * @remarks
+ * Recognized P-codes map to their dedicated errors (`P2002` →
+ * {@link UniqueConstraintViolation}, `P2003` → {@link ForeignKeyViolation},
+ * `P2025` → {@link RecordNotFound}); everything else — including non-Prisma
+ * causes — folds into {@link DriverError} with the cause preserved.
+ *
+ * @param cause - the rejected value from a Prisma query.
+ */
+export const qualifyPrismaError = (cause: unknown): PrismaQueryError => {
+  if (cause instanceof PrismaClientKnownRequestError) {
+    switch (cause.code) {
+      case "P2002":
+        return new UniqueConstraintViolation({ fields: constraintFields(cause.meta), cause });
+      case "P2003":
+        return new ForeignKeyViolation({ cause });
+      case "P2025":
+        return new RecordNotFound({ cause });
+      default:
+        break;
+    }
+  }
+  return new DriverError({ cause });
+};
+
+// Per-operation error unions — the static half. Reads can only fail in the
+// driver; writes add the constraint violations their SQL can raise; `*OrThrow`
+// and mutations of a specific record add P2025.
+type ReadError = DriverError;
+type CreateError = UniqueConstraintViolation | ForeignKeyViolation | DriverError;
+type UpdateError = RecordNotFound | UniqueConstraintViolation | ForeignKeyViolation | DriverError;
+type DeleteError = RecordNotFound | ForeignKeyViolation | DriverError;
+
+// The untyped runtime call under the typed surface: `getExtensionContext`
+// resolves the concrete delegate and the promise is qualified at the boundary,
+// so a raw Promise never escapes. Each public method casts the result down to
+// its per-operation payload and error union (the `$allModels` implementation
+// side is untyped by design; the declared signatures carry the safety).
+type UntypedDelegate = Record<string, (args?: unknown) => Promise<unknown>>;
+
+const query = (self: unknown, op: string, args?: unknown): AsyncResult<unknown, PrismaQueryError> =>
+  fromPromise(
+    (Prisma.getExtensionContext(self) as unknown as UntypedDelegate)[op]!(args),
+    qualifyPrismaError,
+  );
+
+// The rollback sentinel: an `Err` (or defect) inside `$tryTransaction`'s
+// callback is thrown so Prisma aborts the transaction, then unwrapped back out
+// on the other side.
+class Rollback extends Error {
+  constructor(
+    readonly carried: unknown,
+    readonly wasDefect: boolean,
+  ) {
+    super("transaction rolled back");
+  }
+}
+
+// Mirrors Prisma's `ITXClientDenyList` — what an interactive-transaction client
+// cannot do — plus `$tryTransaction` itself: nested transactions are not a
+// thing, and the itx client has no `$transaction` for the bridge to delegate to.
+type TxDenyList =
+  | "$connect"
+  | "$disconnect"
+  | "$on"
+  | "$transaction"
+  | "$use"
+  | "$extends"
+  | "$tryTransaction";
+
+/**
+ * The Prisma Client extension. Apply it with `$extends` to add the `try*`
+ * methods to every model delegate, and `$tryTransaction` to the client.
+ *
+ * @remarks
+ * Typing follows Prisma's documented `$allModels` pattern: `this: T` binds the
+ * concrete delegate, `Prisma.Exact` checks args, and `Prisma.Result` computes
+ * the payload — so `select` / `include` inference survives the wrap.
+ *
+ * @example
+ * ```ts
+ * import { PrismaClient } from "./generated/prisma/client.ts";
+ * import { unthrownPrisma } from "@unthrown/prisma";
+ *
+ * const db = new PrismaClient({ adapter }).$extends(unthrownPrisma);
+ *
+ * const users = db.user.tryFindMany({ select: { id: true } });
+ * //    ^? AsyncResult<{ id: number }[], DriverError>
+ * ```
+ */
+export const unthrownPrisma = Prisma.defineExtension({
+  name: "@unthrown/prisma",
+  model: {
+    $allModels: {
+      /** `findMany`, qualified: the list, or a {@link DriverError}. */
+      tryFindMany<T, A = Record<string, never>>(
+        this: T,
+        args?: Prisma.Exact<A, Prisma.Args<T, "findMany">>,
+      ): AsyncResult<Prisma.Result<T, A, "findMany">, ReadError> {
+        return query(this, "findMany", args) as AsyncResult<
+          Prisma.Result<T, A, "findMany">,
+          ReadError
+        >;
+      },
+
+      /** `findUnique`, qualified: the row or `null`, or a {@link DriverError}. */
+      tryFindUnique<T, A>(
+        this: T,
+        args: Prisma.Exact<A, Prisma.Args<T, "findUnique">>,
+      ): AsyncResult<Prisma.Result<T, A, "findUnique">, ReadError> {
+        return query(this, "findUnique", args) as AsyncResult<
+          Prisma.Result<T, A, "findUnique">,
+          ReadError
+        >;
+      },
+
+      /**
+       * `findUniqueOrThrow`, qualified: the missing row is a modeled
+       * {@link RecordNotFound}, not a throw.
+       */
+      tryFindUniqueOrThrow<T, A>(
+        this: T,
+        args: Prisma.Exact<A, Prisma.Args<T, "findUniqueOrThrow">>,
+      ): AsyncResult<Prisma.Result<T, A, "findUniqueOrThrow">, RecordNotFound | DriverError> {
+        return query(this, "findUniqueOrThrow", args) as AsyncResult<
+          Prisma.Result<T, A, "findUniqueOrThrow">,
+          RecordNotFound | DriverError
+        >;
+      },
+
+      /** `count`, qualified. */
+      tryCount<T, A = Record<string, never>>(
+        this: T,
+        args?: Prisma.Exact<A, Prisma.Args<T, "count">>,
+      ): AsyncResult<Prisma.Result<T, A, "count">, ReadError> {
+        return query(this, "count", args) as AsyncResult<Prisma.Result<T, A, "count">, ReadError>;
+      },
+
+      /**
+       * `create`, qualified: constraint violations are modeled —
+       * {@link UniqueConstraintViolation} and {@link ForeignKeyViolation}.
+       */
+      tryCreate<T, A>(
+        this: T,
+        args: Prisma.Exact<A, Prisma.Args<T, "create">>,
+      ): AsyncResult<Prisma.Result<T, A, "create">, CreateError> {
+        return query(this, "create", args) as AsyncResult<
+          Prisma.Result<T, A, "create">,
+          CreateError
+        >;
+      },
+
+      /**
+       * `update`, qualified: the missing row is a modeled
+       * {@link RecordNotFound}; constraint violations are modeled too.
+       */
+      tryUpdate<T, A>(
+        this: T,
+        args: Prisma.Exact<A, Prisma.Args<T, "update">>,
+      ): AsyncResult<Prisma.Result<T, A, "update">, UpdateError> {
+        return query(this, "update", args) as AsyncResult<
+          Prisma.Result<T, A, "update">,
+          UpdateError
+        >;
+      },
+
+      /**
+       * `delete`, qualified: the missing row is a modeled
+       * {@link RecordNotFound}.
+       */
+      tryDelete<T, A>(
+        this: T,
+        args: Prisma.Exact<A, Prisma.Args<T, "delete">>,
+      ): AsyncResult<Prisma.Result<T, A, "delete">, DeleteError> {
+        return query(this, "delete", args) as AsyncResult<
+          Prisma.Result<T, A, "delete">,
+          DeleteError
+        >;
+      },
+    },
+  },
+  client: {
+    /**
+     * An interactive transaction whose callback speaks `AsyncResult`: an `Err`
+     * triggers a ROLLBACK and comes out as the same typed `Err`.
+     *
+     * @remarks
+     * The callback's `Err` is thrown internally as a sentinel so Prisma aborts
+     * the transaction, then unwrapped back into the typed error channel —
+     * `AsyncResult<T, E | PrismaQueryError>`. A defect inside the callback also
+     * rolls back and stays a defect. The `try*` methods are available on `tx`
+     * (extensions propagate into the interactive transaction); the deny list
+     * additionally removes `$tryTransaction` itself — no nesting.
+     *
+     * @example
+     * ```ts
+     * const moved = db.$tryTransaction((tx) =>
+     *   tx.account.tryUpdate({ where: { id: from }, data: { balance: { decrement: amount } } })
+     *     .flatMap(() =>
+     *       tx.account.tryUpdate({ where: { id: to }, data: { balance: { increment: amount } } }),
+     *     ),
+     * );
+     * // Err anywhere → both updates rolled back, and the Err is in `moved`.
+     * ```
+     */
+    $tryTransaction<C, T, E>(
+      this: C,
+      fn: (tx: Omit<C, TxDenyList>) => AsyncResult<T, E>,
+      options?: {
+        maxWait?: number;
+        timeout?: number;
+        isolationLevel?: string;
+      },
+    ): AsyncResult<T, E | PrismaQueryError> {
+      const client = Prisma.getExtensionContext(this) as unknown as {
+        $transaction: <R>(f: (tx: unknown) => Promise<R>, opts?: unknown) => Promise<R>;
+      };
+      return fromPromise(
+        client.$transaction(async (tx) => {
+          const result = await fn(tx as Omit<C, TxDenyList>);
+          if (result.isOk()) return result.value;
+          throw result.isErr()
+            ? new Rollback(result.error, false)
+            : new Rollback(result.cause, true);
+        }, options),
+        (cause, defect) =>
+          cause instanceof Rollback
+            ? cause.wasDefect
+              ? defect(cause.carried)
+              : (cause.carried as E | PrismaQueryError)
+            : qualifyPrismaError(cause),
+      );
+    },
+  },
+});

--- a/packages/prisma/src/index.ts
+++ b/packages/prisma/src/index.ts
@@ -17,7 +17,7 @@
 // for batch `$transaction([...])`, which needs unexecuted `PrismaPromise`s.
 
 import { Prisma } from "@prisma/client/extension";
-import { type AsyncResult, fromPromise, TaggedError } from "unthrown";
+import { type AsyncResult, fromPromise, type Result, TaggedError } from "unthrown";
 
 import {
   type CursorPaginationMeta,
@@ -507,7 +507,9 @@ export const unthrownPrisma = Prisma.defineExtension({
      * The callback's `Err` is thrown internally as a sentinel so Prisma aborts
      * the transaction, then unwrapped back into the typed error channel —
      * `AsyncResult<T, E | PrismaQueryError>`. A defect inside the callback also
-     * rolls back and stays a defect. The `try*` methods are available on `tx`
+     * rolls back and stays a defect — including a callback that *throws*
+     * instead of returning an `AsyncResult` (a bug, never downgraded to a
+     * modeled `DriverError`). The `try*` methods are available on `tx`
      * (extensions propagate into the interactive transaction); the deny list
      * additionally removes `$tryTransaction` itself — no nesting.
      *
@@ -536,7 +538,16 @@ export const unthrownPrisma = Prisma.defineExtension({
       };
       return fromPromise(
         client.$transaction(async (tx) => {
-          const result = await fn(tx as Omit<C, TxDenyList>);
+          let result: Result<T, E>;
+          try {
+            result = await fn(tx as Omit<C, TxDenyList>);
+          } catch (cause) {
+            // A callback that throws (instead of returning an AsyncResult) is a
+            // bug — roll back and keep it a DEFECT. Only rejections outside
+            // this catch (Prisma's own BEGIN/COMMIT/timeout machinery) qualify
+            // as query failures below.
+            throw new Rollback(cause, true);
+          }
           if (result.isOk()) return result.value;
           throw result.isErr()
             ? new Rollback(result.error, false)

--- a/packages/prisma/src/index.ts
+++ b/packages/prisma/src/index.ts
@@ -136,11 +136,16 @@ export const qualifyPrismaError = (cause: unknown): PrismaQueryError => {
 
 // Per-operation error unions — the static half. Reads can only fail in the
 // driver; writes add the constraint violations their SQL can raise; `*OrThrow`
-// and mutations of a specific record add P2025.
+// and mutations of a specific record add P2025. The batch mutations (`*Many`)
+// and `upsert` never raise P2025: zero matches is `Ok({ count: 0 })`, and an
+// upsert miss creates.
 type ReadError = DriverError;
 type CreateError = UniqueConstraintViolation | ForeignKeyViolation | DriverError;
 type UpdateError = RecordNotFound | UniqueConstraintViolation | ForeignKeyViolation | DriverError;
 type DeleteError = RecordNotFound | ForeignKeyViolation | DriverError;
+type UpsertError = UniqueConstraintViolation | ForeignKeyViolation | DriverError;
+type UpdateManyError = UniqueConstraintViolation | ForeignKeyViolation | DriverError;
+type DeleteManyError = ForeignKeyViolation | DriverError;
 
 // The untyped runtime call under the typed surface: `getExtensionContext`
 // resolves the concrete delegate and the promise is qualified at the boundary,
@@ -273,12 +278,59 @@ export const unthrownPrisma = Prisma.defineExtension({
         >;
       },
 
+      /** `findFirst`, qualified: the first match or `null`, or a {@link DriverError}. */
+      tryFindFirst<T, A = Record<string, never>>(
+        this: T,
+        args?: Prisma.Exact<A, Prisma.Args<T, "findFirst">>,
+      ): AsyncResult<Prisma.Result<T, A, "findFirst">, ReadError> {
+        return query(this, "findFirst", args) as AsyncResult<
+          Prisma.Result<T, A, "findFirst">,
+          ReadError
+        >;
+      },
+
+      /**
+       * `findFirstOrThrow`, qualified: no match is a modeled
+       * {@link RecordNotFound}, not a throw.
+       */
+      tryFindFirstOrThrow<T, A = Record<string, never>>(
+        this: T,
+        args?: Prisma.Exact<A, Prisma.Args<T, "findFirstOrThrow">>,
+      ): AsyncResult<Prisma.Result<T, A, "findFirstOrThrow">, RecordNotFound | DriverError> {
+        return query(this, "findFirstOrThrow", args) as AsyncResult<
+          Prisma.Result<T, A, "findFirstOrThrow">,
+          RecordNotFound | DriverError
+        >;
+      },
+
       /** `count`, qualified. */
       tryCount<T, A = Record<string, never>>(
         this: T,
         args?: Prisma.Exact<A, Prisma.Args<T, "count">>,
       ): AsyncResult<Prisma.Result<T, A, "count">, ReadError> {
         return query(this, "count", args) as AsyncResult<Prisma.Result<T, A, "count">, ReadError>;
+      },
+
+      /** `aggregate`, qualified. */
+      tryAggregate<T, A>(
+        this: T,
+        args: Prisma.Exact<A, Prisma.Args<T, "aggregate">>,
+      ): AsyncResult<Prisma.Result<T, A, "aggregate">, ReadError> {
+        return query(this, "aggregate", args) as AsyncResult<
+          Prisma.Result<T, A, "aggregate">,
+          ReadError
+        >;
+      },
+
+      /** `groupBy`, qualified. */
+      tryGroupBy<T, A>(
+        this: T,
+        args: Prisma.Exact<A, Prisma.Args<T, "groupBy">>,
+      ): AsyncResult<Prisma.Result<T, A, "groupBy">, ReadError> {
+        return query(this, "groupBy", args) as AsyncResult<
+          Prisma.Result<T, A, "groupBy">,
+          ReadError
+        >;
       },
 
       /**
@@ -291,6 +343,31 @@ export const unthrownPrisma = Prisma.defineExtension({
       ): AsyncResult<Prisma.Result<T, A, "create">, CreateError> {
         return query(this, "create", args) as AsyncResult<
           Prisma.Result<T, A, "create">,
+          CreateError
+        >;
+      },
+
+      /**
+       * `createMany`, qualified: the batch count, or the same modeled
+       * constraint violations as `tryCreate`.
+       */
+      tryCreateMany<T, A>(
+        this: T,
+        args: Prisma.Exact<A, Prisma.Args<T, "createMany">>,
+      ): AsyncResult<Prisma.Result<T, A, "createMany">, CreateError> {
+        return query(this, "createMany", args) as AsyncResult<
+          Prisma.Result<T, A, "createMany">,
+          CreateError
+        >;
+      },
+
+      /** `createManyAndReturn`, qualified: the created rows instead of a count. */
+      tryCreateManyAndReturn<T, A>(
+        this: T,
+        args: Prisma.Exact<A, Prisma.Args<T, "createManyAndReturn">>,
+      ): AsyncResult<Prisma.Result<T, A, "createManyAndReturn">, CreateError> {
+        return query(this, "createManyAndReturn", args) as AsyncResult<
+          Prisma.Result<T, A, "createManyAndReturn">,
           CreateError
         >;
       },
@@ -310,6 +387,47 @@ export const unthrownPrisma = Prisma.defineExtension({
       },
 
       /**
+       * `upsert`, qualified: no {@link RecordNotFound} in the union — a miss
+       * *creates* — but the write can still hit the modeled constraint
+       * violations.
+       */
+      tryUpsert<T, A>(
+        this: T,
+        args: Prisma.Exact<A, Prisma.Args<T, "upsert">>,
+      ): AsyncResult<Prisma.Result<T, A, "upsert">, UpsertError> {
+        return query(this, "upsert", args) as AsyncResult<
+          Prisma.Result<T, A, "upsert">,
+          UpsertError
+        >;
+      },
+
+      /**
+       * `updateMany`, qualified: the batch count. Zero matches is `Ok({ count:
+       * 0 })` — never {@link RecordNotFound} — but a constraint violation is
+       * still modeled.
+       */
+      tryUpdateMany<T, A>(
+        this: T,
+        args: Prisma.Exact<A, Prisma.Args<T, "updateMany">>,
+      ): AsyncResult<Prisma.Result<T, A, "updateMany">, UpdateManyError> {
+        return query(this, "updateMany", args) as AsyncResult<
+          Prisma.Result<T, A, "updateMany">,
+          UpdateManyError
+        >;
+      },
+
+      /** `updateManyAndReturn`, qualified: the updated rows instead of a count. */
+      tryUpdateManyAndReturn<T, A>(
+        this: T,
+        args: Prisma.Exact<A, Prisma.Args<T, "updateManyAndReturn">>,
+      ): AsyncResult<Prisma.Result<T, A, "updateManyAndReturn">, UpdateManyError> {
+        return query(this, "updateManyAndReturn", args) as AsyncResult<
+          Prisma.Result<T, A, "updateManyAndReturn">,
+          UpdateManyError
+        >;
+      },
+
+      /**
        * `delete`, qualified: the missing row is a modeled
        * {@link RecordNotFound}.
        */
@@ -320,6 +438,21 @@ export const unthrownPrisma = Prisma.defineExtension({
         return query(this, "delete", args) as AsyncResult<
           Prisma.Result<T, A, "delete">,
           DeleteError
+        >;
+      },
+
+      /**
+       * `deleteMany`, qualified: the batch count. Zero matches is `Ok({ count:
+       * 0 })` — never {@link RecordNotFound} — but deleting a still-referenced
+       * parent is a modeled {@link ForeignKeyViolation}.
+       */
+      tryDeleteMany<T, A = Record<string, never>>(
+        this: T,
+        args?: Prisma.Exact<A, Prisma.Args<T, "deleteMany">>,
+      ): AsyncResult<Prisma.Result<T, A, "deleteMany">, DeleteManyError> {
+        return query(this, "deleteMany", args) as AsyncResult<
+          Prisma.Result<T, A, "deleteMany">,
+          DeleteManyError
         >;
       },
 

--- a/packages/prisma/src/pagination.ts
+++ b/packages/prisma/src/pagination.ts
@@ -1,0 +1,166 @@
+// Cursor pagination — the runtime half of `tryPaginate(...).withCursor(...)`,
+// modeled on `prisma-extension-pagination` (same option names, same
+// `[results, meta]` shape) with one behavioral fix folded in
+// (deptyped/prisma-extension-pagination#35): a cursor pointing at a record that
+// NO LONGER matches the query filter must not swallow the first element of the
+// page. Instead of `skip: 1` past the cursor row — which skips a real result
+// when the cursor row itself is filtered out — the page is over-fetched by two
+// and the boundary row is dropped only when it IS the cursor row.
+
+export type CursorPaginationMeta = {
+  hasPreviousPage: boolean;
+  hasNextPage: boolean;
+  startCursor: string | null;
+  endCursor: string | null;
+};
+
+/**
+ * Options of `withCursor`, in the style of `prisma-extension-pagination`.
+ *
+ * @remarks
+ * `limit: null` returns everything (from the `after` cursor when given).
+ * Combining `limit: null` with `before` is a compile error — "everything
+ * before the cursor, backwards, unbounded" is not something Prisma's negative
+ * `take` can express.
+ *
+ * The default cursor is the record's `id` field, serialized with `String` and
+ * parsed back to a number when it is all digits (autoincrement ids) or kept as
+ * a string otherwise (uuid / cuid ids). Provide `getCursor` / `parseCursor`
+ * for composite keys, or when the selection omits `id`.
+ *
+ * @typeParam Row - the (selection-narrowed) result row type.
+ * @typeParam Cursor - the model's `cursor` input (its unique-where shape).
+ */
+export type CursorPaginationOptions<Row, Cursor> = {
+  /** An opaque cursor: results strictly AFTER this record. */
+  after?: string;
+  /** Serialize a row into an opaque cursor. Defaults to `String(row.id)`. */
+  getCursor?: (row: Row) => string;
+  /** Parse an opaque cursor back into the model's `cursor` input. */
+  parseCursor?: (cursor: string) => Cursor;
+} & (
+  | {
+      /** Page size. */
+      limit: number;
+      /** An opaque cursor: results strictly BEFORE this record. */
+      before?: string;
+    }
+  | {
+      /** `null` returns all results. Cannot be combined with `before`. */
+      limit: null;
+      before?: never;
+    }
+);
+
+// The one shape pagination needs from a delegate. The extension casts the
+// untyped `getExtensionContext` result into it.
+export type PaginationDelegate = {
+  findMany: (args: object) => Promise<unknown[]>;
+};
+
+// The probe queries only check for existence — drop the caller's selection so
+// they stay cheap and never fail on a selection that omits the cursor fields.
+const resetSelection = { select: undefined, include: undefined, omit: undefined };
+
+const defaultGetCursor = (row: unknown): string => {
+  const id = (row as { id?: unknown }).id;
+  if (id === undefined || id === null) {
+    throw new Error(
+      "@unthrown/prisma: the default cursor reads the `id` field — the row has none " +
+        "(composite key, or a selection omitting `id`?). Provide getCursor/parseCursor.",
+    );
+  }
+  return String(id);
+};
+
+// Preserve the id's type through the round-trip: an all-digits cursor parses
+// back to a number (autoincrement ids), anything else stays a string.
+const defaultParseCursor = (cursor: string): unknown => ({
+  id: /^\d+$/.test(cursor) ? Number(cursor) : cursor,
+});
+
+type RuntimeOptions = {
+  limit: number | null;
+  after?: string;
+  before?: string;
+  getCursor?: (row: never) => string;
+  parseCursor?: (cursor: string) => unknown;
+};
+
+/**
+ * The pagination engine. Exported for the typed `tryPaginate` surface (and its
+ * edge-case unit tests); use `db.model.tryPaginate(...).withCursor(...)`.
+ */
+export const paginateWithCursor = async (
+  model: PaginationDelegate,
+  query: object | undefined,
+  options: RuntimeOptions,
+): Promise<[unknown[], CursorPaginationMeta]> => {
+  const { limit, after, before } = options;
+  const getCursor = (options.getCursor ?? defaultGetCursor) as (row: unknown) => string;
+  const parseCursor = options.parseCursor ?? defaultParseCursor;
+
+  // Is this row the cursor row? Compared through the cursor round-trip, so it
+  // works for any serialization the caller chose.
+  const sameCursor = (row: unknown, cursor: unknown): boolean =>
+    JSON.stringify(parseCursor(getCursor(row))) === JSON.stringify(cursor);
+
+  let results: unknown[];
+  let hasPreviousPage = false;
+  let hasNextPage = false;
+
+  if (typeof before === "string") {
+    const cursor = parseCursor(before);
+    // Backwards from the cursor, over-fetched by two: one slot for the cursor
+    // row itself (present only when it still matches the filter), one to know
+    // whether a previous page exists. The forward probe answers hasNextPage —
+    // the cursor row (or its closest matching successor) is the next page.
+    const [rows, nextProbe] = await Promise.all([
+      model.findMany({ ...query, cursor, take: limit === null ? undefined : -limit - 2 }),
+      model.findMany({ ...query, ...resetSelection, cursor, take: 1 }),
+    ]);
+    results = rows;
+    if (results.length > 0 && sameCursor(results[results.length - 1]!, cursor)) {
+      results.pop(); // the cursor row itself — exclusive pagination
+    } else if (limit !== null && results.length === limit + 2) {
+      results.shift(); // cursor row filtered out: both extra slots hold real rows
+    }
+    if (limit !== null && results.length > limit) {
+      hasPreviousPage = Boolean(results.shift());
+    }
+    hasNextPage = nextProbe.length > 0;
+  } else if (typeof after === "string") {
+    const cursor = parseCursor(after);
+    // Forwards from the cursor, over-fetched by two (same slots as above,
+    // mirrored). The backward probe answers hasPreviousPage.
+    const [rows, previousProbe] = await Promise.all([
+      model.findMany({ ...query, cursor, take: limit === null ? undefined : limit + 2 }),
+      model.findMany({ ...query, ...resetSelection, cursor, take: -1 }),
+    ]);
+    results = rows;
+    if (results.length > 0 && sameCursor(results[0]!, cursor)) {
+      results.shift();
+    } else if (limit !== null && results.length === limit + 2) {
+      results.pop();
+    }
+    hasPreviousPage = previousProbe.length > 0;
+    if (limit !== null && results.length > limit) {
+      hasNextPage = Boolean(results.pop());
+    }
+  } else {
+    results = await model.findMany({ ...query, take: limit === null ? undefined : limit + 1 });
+    if (limit !== null && results.length > limit) {
+      hasNextPage = Boolean(results.pop());
+    }
+  }
+
+  return [
+    results,
+    {
+      hasPreviousPage,
+      hasNextPage,
+      startCursor: results.length > 0 ? getCursor(results[0]!) : null,
+      endCursor: results.length > 0 ? getCursor(results[results.length - 1]!) : null,
+    },
+  ];
+};

--- a/packages/prisma/src/pagination.ts
+++ b/packages/prisma/src/pagination.ts
@@ -32,9 +32,11 @@ export type CursorPaginationMeta = {
  * `take` can express.
  *
  * The default cursor is the record's `id` field, serialized with `String` and
- * parsed back to a number when it is all digits (autoincrement ids) or kept as
- * a string otherwise (uuid / cuid ids). Provide `getCursor` / `parseCursor`
- * for composite keys, or when the selection omits `id`.
+ * parsed back to a number when it is all digits (autoincrement ids) — a bigint
+ * once it exceeds `Number.MAX_SAFE_INTEGER`, so `BigInt` ids never lose
+ * precision — or kept as a string otherwise (uuid / cuid ids). Provide
+ * `getCursor` / `parseCursor` for composite keys, or when the selection omits
+ * `id`.
  *
  * @typeParam Row - the (selection-narrowed) result row type.
  * @typeParam Cursor - the model's `cursor` input (its unique-where shape).
@@ -82,10 +84,14 @@ const defaultGetCursor = (row: unknown): string => {
 };
 
 // Preserve the id's type through the round-trip: an all-digits cursor parses
-// back to a number (autoincrement ids), anything else stays a string.
-const defaultParseCursor = (cursor: string): unknown => ({
-  id: /^\d+$/.test(cursor) ? Number(cursor) : cursor,
-});
+// back to a number (autoincrement ids) — or a bigint once it exceeds
+// Number.MAX_SAFE_INTEGER, so a BigInt id never loses precision — and anything
+// else stays a string (uuid / cuid).
+const defaultParseCursor = (cursor: string): unknown => {
+  if (!/^\d+$/.test(cursor)) return { id: cursor };
+  const n = Number(cursor);
+  return { id: Number.isSafeInteger(n) ? n : BigInt(cursor) };
+};
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;

--- a/packages/prisma/src/pagination.ts
+++ b/packages/prisma/src/pagination.ts
@@ -7,12 +7,20 @@
 // when the cursor row itself is filtered out — the page is over-fetched by two
 // and the boundary row is dropped only when it IS the cursor row.
 
+/**
+ * The page metadata of `withCursor`.
+ *
+ * @remarks
+ * `startCursor` / `endCursor` are the cursors of the page's boundary rows, so
+ * they are `null` together exactly when the page is empty — checking one
+ * narrows the other. They are deliberately NOT coupled to the flags: the last
+ * page has `hasNextPage: false` with a non-null `endCursor`, and an empty page
+ * past the end has `hasPreviousPage: true` with a null `startCursor`.
+ */
 export type CursorPaginationMeta = {
   hasPreviousPage: boolean;
   hasNextPage: boolean;
-  startCursor: string | null;
-  endCursor: string | null;
-};
+} & ({ startCursor: string; endCursor: string } | { startCursor: null; endCursor: null });
 
 /**
  * Options of `withCursor`, in the style of `prisma-extension-pagination`.
@@ -79,6 +87,36 @@ const defaultParseCursor = (cursor: string): unknown => ({
   id: /^\d+$/.test(cursor) ? Number(cursor) : cursor,
 });
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+// Deep structural equality for parsed cursors: key-order independent, and safe
+// for every value a Prisma unique input can carry — `bigint` ids, `Date`
+// fields, nested composite-key records. (`JSON.stringify` would throw on
+// `bigint` and is sensitive to key order.)
+const cursorEquals = (a: unknown, b: unknown): boolean => {
+  if (a === b) return true;
+  if (a instanceof Date || b instanceof Date) {
+    return a instanceof Date && b instanceof Date && a.getTime() === b.getTime();
+  }
+  if (Array.isArray(a) || Array.isArray(b)) {
+    return (
+      Array.isArray(a) &&
+      Array.isArray(b) &&
+      a.length === b.length &&
+      a.every((value, i) => cursorEquals(value, b[i]))
+    );
+  }
+  if (isRecord(a) && isRecord(b)) {
+    const keys = Object.keys(a);
+    return (
+      keys.length === Object.keys(b).length &&
+      keys.every((key) => key in b && cursorEquals(a[key], b[key]))
+    );
+  }
+  return false;
+};
+
 type RuntimeOptions = {
   limit: number | null;
   after?: string;
@@ -103,7 +141,7 @@ export const paginateWithCursor = async (
   // Is this row the cursor row? Compared through the cursor round-trip, so it
   // works for any serialization the caller chose.
   const sameCursor = (row: unknown, cursor: unknown): boolean =>
-    JSON.stringify(parseCursor(getCursor(row))) === JSON.stringify(cursor);
+    cursorEquals(parseCursor(getCursor(row)), cursor);
 
   let results: unknown[];
   let hasPreviousPage = false;
@@ -154,13 +192,12 @@ export const paginateWithCursor = async (
     }
   }
 
-  return [
-    results,
-    {
-      hasPreviousPage,
-      hasNextPage,
-      startCursor: results.length > 0 ? getCursor(results[0]!) : null,
-      endCursor: results.length > 0 ? getCursor(results[results.length - 1]!) : null,
-    },
-  ];
+  // Boundary cursors travel together: both strings on a non-empty page, both
+  // null on an empty one (see the CursorPaginationMeta union).
+  const cursors =
+    results.length > 0
+      ? { startCursor: getCursor(results[0]!), endCursor: getCursor(results[results.length - 1]!) }
+      : { startCursor: null, endCursor: null };
+
+  return [results, { hasPreviousPage, hasNextPage, ...cursors }];
 };

--- a/packages/prisma/src/types.test-d.ts
+++ b/packages/prisma/src/types.test-d.ts
@@ -33,6 +33,23 @@ const created = db.user.tryCreate({ data: { email: "a@example.com" } });
 const fetched = db.user.tryFindUniqueOrThrow({ where: { id: 1 } });
 const maybe = db.user.tryFindUnique({ where: { id: 1 } });
 const counted = db.user.tryCount();
+const first = db.user.tryFindFirst({ select: { id: true } });
+const firstOrThrow = db.user.tryFindFirstOrThrow();
+const upserted = db.user.tryUpsert({
+  where: { id: 1 },
+  create: { email: "a@example.com" },
+  update: { name: "x" },
+});
+const createdMany = db.user.tryCreateMany({ data: [{ email: "a@example.com" }] });
+const createdRows = db.user.tryCreateManyAndReturn({
+  data: [{ email: "a@example.com" }],
+  select: { id: true },
+});
+const updatedMany = db.user.tryUpdateMany({ where: {}, data: { name: "x" } });
+const updatedRows = db.user.tryUpdateManyAndReturn({ data: { name: "x" }, select: { id: true } });
+const deletedMany = db.user.tryDeleteMany();
+const aggregated = db.user.tryAggregate({ _count: true });
+const grouped = db.user.tryGroupBy({ by: ["name"] });
 
 // @ts-expect-error — `email` was not selected; the payload narrowed to `{ id }`.
 selected.map((rows) => rows.map((r) => r.email));
@@ -105,6 +122,32 @@ export type _Assertions = [
     Equal<AsyncErrOf<typeof created>, UniqueConstraintViolation | ForeignKeyViolation | DriverError>
   >,
   Expect<Equal<AsyncErrOf<typeof fetched>, RecordNotFound | DriverError>>,
+  // findFirst: selection narrows, a miss is `null`, and only OrThrow adds P2025
+  Expect<Equal<AsyncOkOf<typeof first>, { id: number } | null>>,
+  Expect<Equal<AsyncErrOf<typeof first>, DriverError>>,
+  Expect<Equal<AsyncErrOf<typeof firstOrThrow>, RecordNotFound | DriverError>>,
+  // upsert never carries RecordNotFound — a miss creates
+  Expect<
+    Equal<
+      AsyncErrOf<typeof upserted>,
+      UniqueConstraintViolation | ForeignKeyViolation | DriverError
+    >
+  >,
+  // the batch mutations: counts / rows, and no P2025 in their unions
+  Expect<Equal<AsyncOkOf<typeof createdMany>["count"], number>>,
+  Expect<Equal<AsyncOkOf<typeof createdRows>, { id: number }[]>>,
+  Expect<
+    Equal<
+      AsyncErrOf<typeof updatedMany>,
+      UniqueConstraintViolation | ForeignKeyViolation | DriverError
+    >
+  >,
+  Expect<Equal<AsyncOkOf<typeof updatedRows>, { id: number }[]>>,
+  Expect<Equal<AsyncErrOf<typeof deletedMany>, ForeignKeyViolation | DriverError>>,
+  // the aggregations are reads: DriverError only
+  Expect<Equal<AsyncErrOf<typeof aggregated>, DriverError>>,
+  Expect<Equal<AsyncErrOf<typeof grouped>, DriverError>>,
+  Expect<Equal<AsyncOkOf<typeof aggregated>["_count"], number>>,
   // pagination: the payload is the narrowed page + meta; the error is read-only
   Expect<Equal<AsyncOkOf<typeof paged>[0][number]["email"], string>>,
   Expect<Equal<AsyncOkOf<typeof paged>[1], CursorPaginationMeta>>,

--- a/packages/prisma/src/types.test-d.ts
+++ b/packages/prisma/src/types.test-d.ts
@@ -10,6 +10,7 @@ import type { AsyncErrOf, AsyncOkOf } from "unthrown";
 
 import type { PrismaClient } from "./generated/prisma/client.ts";
 import type {
+  CursorPaginationMeta,
   DriverError,
   ForeignKeyViolation,
   RecordNotFound,
@@ -44,6 +45,27 @@ db.user.tryFindMany({ bogus: true });
 // @ts-expect-error — a read cannot fail with UniqueConstraintViolation.
 const _readNarrow: AsyncErrOf<typeof all> = null as unknown as UniqueConstraintViolation;
 
+// --- tryPaginate: query owns the filter, pagination owns the cursor ------------
+
+const paged = db.user.tryPaginate({ where: { name: "x" } }).withCursor({ limit: 2 });
+const pagedSelect = db.user.tryPaginate({ select: { id: true } }).withCursor({ limit: null });
+
+// @ts-expect-error — `take` belongs to pagination, not the query.
+db.user.tryPaginate({ take: 1 });
+// @ts-expect-error — `cursor` belongs to pagination, not the query.
+db.user.tryPaginate({ cursor: { id: 1 } });
+// @ts-expect-error — `limit: null` cannot be combined with `before`.
+db.user.tryPaginate().withCursor({ limit: null, before: "1" });
+
+db.user.tryPaginate({ select: { id: true } }).withCursor({
+  limit: 1,
+  // @ts-expect-error — `email` is not in the selection; getCursor sees the narrowed row.
+  getCursor: (row) => row.email,
+});
+
+// @ts-expect-error — parseCursor must return the model's unique-where input.
+db.user.tryPaginate().withCursor({ limit: 1, parseCursor: () => ({ bogus: 1 }) });
+
 // --- $tryTransaction: errors union, try-methods inside, no nesting -------------
 
 const tx = db.$tryTransaction((txc) => txc.user.tryCreate({ data: { email: "a@example.com" } }));
@@ -72,6 +94,11 @@ export type _Assertions = [
     Equal<AsyncErrOf<typeof created>, UniqueConstraintViolation | ForeignKeyViolation | DriverError>
   >,
   Expect<Equal<AsyncErrOf<typeof fetched>, RecordNotFound | DriverError>>,
+  // pagination: the payload is the narrowed page + meta; the error is read-only
+  Expect<Equal<AsyncOkOf<typeof paged>[0][number]["email"], string>>,
+  Expect<Equal<AsyncOkOf<typeof paged>[1], CursorPaginationMeta>>,
+  Expect<Equal<AsyncErrOf<typeof paged>, DriverError>>,
+  Expect<Equal<AsyncOkOf<typeof pagedSelect>[0], { id: number }[]>>,
   // the transaction unions the callback's errors with the transaction's own
   Expect<
     Equal<

--- a/packages/prisma/src/types.test-d.ts
+++ b/packages/prisma/src/types.test-d.ts
@@ -1,0 +1,83 @@
+// Type-level tests, checked by the package's regular `tsc --noEmit` (the file has
+// no runtime — nothing imports it). They guard the two claims the extension is
+// built on: payload inference (`select` / `include`) survives the wrap, and the
+// error channel is per-operation — a read cannot fail with a write's constraint
+// violations. Assertions accumulate in the exported `_Assertions` tuple (so
+// nothing is an unused local); `@ts-expect-error` guards the cases that must NOT
+// compile.
+
+import type { AsyncErrOf, AsyncOkOf } from "unthrown";
+
+import type { PrismaClient } from "./generated/prisma/client.ts";
+import type {
+  DriverError,
+  ForeignKeyViolation,
+  RecordNotFound,
+  UniqueConstraintViolation,
+} from "./index.js";
+import { unthrownPrisma } from "./index.js";
+
+type Equal<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+declare const base: PrismaClient;
+const db = base.$extends(unthrownPrisma);
+
+// --- payload inference survives the wrap --------------------------------------
+
+const all = db.user.tryFindMany();
+const selected = db.user.tryFindMany({ select: { id: true } });
+const created = db.user.tryCreate({ data: { email: "a@example.com" } });
+const fetched = db.user.tryFindUniqueOrThrow({ where: { id: 1 } });
+const maybe = db.user.tryFindUnique({ where: { id: 1 } });
+const counted = db.user.tryCount();
+
+// @ts-expect-error — `email` was not selected; the payload narrowed to `{ id }`.
+selected.map((rows) => rows.map((r) => r.email));
+
+// @ts-expect-error — an unknown arg key is rejected (`Prisma.Exact`).
+db.user.tryFindMany({ bogus: true });
+
+// --- the error channel is per-operation ----------------------------------------
+
+// @ts-expect-error — a read cannot fail with UniqueConstraintViolation.
+const _readNarrow: AsyncErrOf<typeof all> = null as unknown as UniqueConstraintViolation;
+
+// --- $tryTransaction: errors union, try-methods inside, no nesting -------------
+
+const tx = db.$tryTransaction((txc) => txc.user.tryCreate({ data: { email: "a@example.com" } }));
+
+db.$tryTransaction((txc) => {
+  // @ts-expect-error — no nested transactions inside the callback.
+  txc.$tryTransaction;
+  // @ts-expect-error — the raw `$transaction` is denied inside the callback too.
+  txc.$transaction;
+  return txc.user.tryFindMany();
+});
+
+export type _Assertions = [
+  // full read: default payload flows through
+  Expect<Equal<AsyncOkOf<typeof all>[number]["email"], string>>,
+  Expect<Equal<AsyncOkOf<typeof counted>, number>>,
+  // a findUnique miss is `null`, not an error
+  Expect<Equal<Extract<AsyncOkOf<typeof maybe>, null>, null>>,
+  // select narrowing is exact
+  Expect<Equal<AsyncOkOf<typeof selected>, { id: number }[]>>,
+  Expect<Equal<AsyncOkOf<typeof created>["email"], string>>,
+  // reads fail only in the driver; writes carry their constraint violations;
+  // `*OrThrow` adds P2025
+  Expect<Equal<AsyncErrOf<typeof all>, DriverError>>,
+  Expect<
+    Equal<AsyncErrOf<typeof created>, UniqueConstraintViolation | ForeignKeyViolation | DriverError>
+  >,
+  Expect<Equal<AsyncErrOf<typeof fetched>, RecordNotFound | DriverError>>,
+  // the transaction unions the callback's errors with the transaction's own
+  Expect<
+    Equal<
+      AsyncErrOf<typeof tx>,
+      UniqueConstraintViolation | ForeignKeyViolation | RecordNotFound | DriverError
+    >
+  >,
+  Expect<Equal<AsyncOkOf<typeof tx>["email"], string>>,
+];

--- a/packages/prisma/src/types.test-d.ts
+++ b/packages/prisma/src/types.test-d.ts
@@ -66,6 +66,17 @@ db.user.tryPaginate({ select: { id: true } }).withCursor({
 // @ts-expect-error — parseCursor must return the model's unique-where input.
 db.user.tryPaginate().withCursor({ limit: 1, parseCursor: () => ({ bogus: 1 }) });
 
+// The meta's boundary cursors travel together: non-null startCursor proves endCursor.
+declare const meta: CursorPaginationMeta;
+if (meta.startCursor !== null) {
+  meta.endCursor satisfies string;
+}
+
+// $tryTransaction accepts only known isolation levels.
+db.$tryTransaction((txc) => txc.user.tryFindMany(), { isolationLevel: "Serializable" });
+// @ts-expect-error — not a Prisma isolation level.
+db.$tryTransaction((txc) => txc.user.tryFindMany(), { isolationLevel: "Chaotic" });
+
 // --- $tryTransaction: errors union, try-methods inside, no nesting -------------
 
 const tx = db.$tryTransaction((txc) => txc.user.tryCreate({ data: { email: "a@example.com" } }));

--- a/packages/prisma/tsconfig.json
+++ b/packages/prisma/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@unthrown/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    // The generated test client (src/generated, gitignored) imports its own
+    // files with explicit `.ts` extensions; `noEmit` in the base config makes
+    // this legal.
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/generated"]
+}

--- a/packages/prisma/typedoc.json
+++ b/packages/prisma/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@unthrown/typedoc/base.json",
+  "entryPoints": ["src/index.ts"],
+  "out": "docs"
+}

--- a/packages/prisma/typedoc.json
+++ b/packages/prisma/typedoc.json
@@ -2,5 +2,13 @@
   "extends": "@unthrown/typedoc/base.json",
   "entryPoints": ["src/index.ts"],
   "out": "docs",
-  "intentionallyNotExported": ["CreateError", "UpdateError", "DeleteError", "TxDenyList"]
+  "intentionallyNotExported": [
+    "CreateError",
+    "UpdateError",
+    "DeleteError",
+    "UpsertError",
+    "UpdateManyError",
+    "DeleteManyError",
+    "TxDenyList"
+  ]
 }

--- a/packages/prisma/typedoc.json
+++ b/packages/prisma/typedoc.json
@@ -1,5 +1,6 @@
 {
   "extends": "@unthrown/typedoc/base.json",
   "entryPoints": ["src/index.ts"],
-  "out": "docs"
+  "out": "docs",
+  "intentionallyNotExported": ["CreateError", "UpdateError", "DeleteError", "TxDenyList"]
 }

--- a/packages/prisma/vitest.config.ts
+++ b/packages/prisma/vitest.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.spec.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**"],
+      // The generated test client is Prisma's output, not ours.
+      exclude: ["src/generated/**", "src/**/*.test-d.ts", "src/**/*.spec.ts"],
+      // The whole bridge is exercised against a real in-memory SQLite database:
+      // every mapped P-code is provoked for real, and `$tryTransaction` covers
+      // commit, rollback-on-Err, rollback-on-defect, and a transaction-level
+      // failure that bypasses the sentinel.
+      thresholds: {
+        statements: 100,
+        branches: 100,
+        functions: 100,
+        lines: 100,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,12 @@ catalogs:
     '@commitlint/config-conventional':
       specifier: 21.2.0
       version: 21.2.0
+    '@prisma/adapter-better-sqlite3':
+      specifier: 7.8.0
+      version: 7.8.0
+    '@prisma/client':
+      specifier: 7.8.0
+      version: 7.8.0
     '@standard-schema/spec':
       specifier: 1.1.0
       version: 1.1.0
@@ -30,6 +36,9 @@ catalogs:
     '@vitest/coverage-v8':
       specifier: 4.1.9
       version: 4.1.9
+    better-sqlite3:
+      specifier: 12.11.1
+      version: 12.11.1
     effect:
       specifier: 3.21.4
       version: 3.21.4
@@ -48,6 +57,9 @@ catalogs:
     oxlint:
       specifier: 1.72.0
       version: 1.72.0
+    prisma:
+      specifier: 7.8.0
+      version: 7.8.0
     ts-pattern:
       specifier: 5.9.0
       version: 5.9.0
@@ -119,6 +131,9 @@ importers:
       '@unthrown/pattern':
         specifier: workspace:*
         version: link:../packages/pattern
+      '@unthrown/prisma':
+        specifier: workspace:*
+        version: link:../packages/prisma
       '@unthrown/standard-schema':
         specifier: workspace:*
         version: link:../packages/standard-schema
@@ -332,6 +347,55 @@ importers:
       ts-pattern:
         specifier: 'catalog:'
         version: 5.9.0
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.3(oxc-resolver@11.21.3)(tsx@4.22.4)(typescript@6.0.3)
+      typedoc:
+        specifier: 'catalog:'
+        version: 0.28.19(typescript@6.0.3)
+      typedoc-plugin-markdown:
+        specifier: 'catalog:'
+        version: 4.12.0(typedoc@0.28.19(typescript@6.0.3))
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+
+  packages/prisma:
+    dependencies:
+      unthrown:
+        specifier: workspace:^
+        version: link:../core
+    devDependencies:
+      '@prisma/adapter-better-sqlite3':
+        specifier: 'catalog:'
+        version: 7.8.0
+      '@prisma/client':
+        specifier: 'catalog:'
+        version: 7.8.0(prisma@7.8.0(better-sqlite3@12.11.1)(magicast@0.5.3)(typescript@6.0.3))(typescript@6.0.3)
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.2
+      '@unthrown/tsconfig':
+        specifier: workspace:*
+        version: link:../../tools/tsconfig
+      '@unthrown/typedoc':
+        specifier: workspace:*
+        version: link:../../tools/typedoc
+      '@unthrown/vitest':
+        specifier: workspace:*
+        version: link:../vitest
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.9(vitest@4.1.9)
+      better-sqlite3:
+        specifier: 'catalog:'
+        version: 12.11.1
+      prisma:
+        specifier: 'catalog:'
+        version: 7.8.0(better-sqlite3@12.11.1)(magicast@0.5.3)(typescript@6.0.3)
       tsdown:
         specifier: 'catalog:'
         version: 0.22.3(oxc-resolver@11.21.3)(tsx@4.22.4)(typescript@6.0.3)
@@ -726,6 +790,20 @@ packages:
       search-insights:
         optional: true
 
+  '@electric-sql/pglite-socket@0.1.1':
+    resolution: {integrity: sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==}
+    hasBin: true
+    peerDependencies:
+      '@electric-sql/pglite': 0.4.1
+
+  '@electric-sql/pglite-tools@0.3.1':
+    resolution: {integrity: sha512-C+T3oivmy9bpQvSxVqXA1UDY8cB9Eb9vZHL9zxWwEUfDixbXv4G3r2LjoTdR33LD8aomR3O9ZXEO3XEwr/cUCA==}
+    peerDependencies:
+      '@electric-sql/pglite': 0.4.1
+
+  '@electric-sql/pglite@0.4.1':
+    resolution: {integrity: sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==}
+
   '@emnapi/core@1.11.0':
     resolution: {integrity: sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==}
 
@@ -1038,6 +1116,12 @@ packages:
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
 
+  '@hono/node-server@1.19.11':
+    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@iconify-json/simple-icons@1.2.87':
     resolution: {integrity: sha512-8YciStObhSji3OZFmWAWK6kBujyqO5bLCxeDwLxf3CR3F4PVelq7keC2LBvgTqviWzSTysj5/g4PCFLiAMVGsw==}
 
@@ -1065,6 +1149,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@kurkle/color@0.3.4':
+    resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -1574,8 +1661,145 @@ packages:
     resolution: {integrity: sha512-TF6+ruuIwUpT64deU2JvoDs78m1QjYuMB7IP9AZ2p05fkUesumy+3aqKERE5sYd1C8CmL+yt0swwfXlR3/YluQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@prisma/adapter-better-sqlite3@7.8.0':
+    resolution: {integrity: sha512-9p0HvQNaRoOaUForDcp1MPIjylmCamYQjQpEogpdesLr14g3NwAsYR3bHL9wFi8tn21TPDVQPzcZi+SxXEokSA==}
+
+  '@prisma/client-runtime-utils@7.8.0':
+    resolution: {integrity: sha512-5NQZztQ0oY/ADFkmd9gPuweH5A1/CCY8YQPorLLO0Mu6a87mY5gsnDkzmFmIHs9NFaLnZojzgddFVN4RpKYrdw==}
+
+  '@prisma/client@7.8.0':
+    resolution: {integrity: sha512-HFp3Dawv/3sU3JtlPha90IB+48lS7zHiH4LKZPjmcE8YH5P9DOXGPvo8dqOtO7MqLDd1p2hOWMcFlRT1DMblHw==}
+    engines: {node: ^20.19 || ^22.12 || >=24.0}
+    peerDependencies:
+      prisma: '*'
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      prisma:
+        optional: true
+      typescript:
+        optional: true
+
+  '@prisma/config@7.8.0':
+    resolution: {integrity: sha512-HFESzd9rx2ZQxlK+TL7tu1HPvCqrHiL6LCxYykI2c34mvaUuIVVl3lYuicJD/MNnzgPnyeBEMlK4WTomJCV5jw==}
+
+  '@prisma/debug@7.2.0':
+    resolution: {integrity: sha512-YSGTiSlBAVJPzX4ONZmMotL+ozJwQjRmZweQNIq/ER0tQJKJynNkRB3kyvt37eOfsbMCXk3gnLF6J9OJ4QWftw==}
+
+  '@prisma/debug@7.8.0':
+    resolution: {integrity: sha512-p+QZReysDUqXC+mk17q9a+Y/qzh4c2KYliDK30buYUyfrGeTGSyfmc0AIrJRhZJrLHhRiJa9Au/J72h3C+szvA==}
+
+  '@prisma/dev@0.24.3':
+    resolution: {integrity: sha512-ffHlQuKXZiaDt9Go0OnCTdJZrHxK0k7omJKNV86/VjpsXu5EIHZLK0T7JSWgvNlJwh56kW9JFu9v0qJciFzepg==}
+
+  '@prisma/driver-adapter-utils@7.8.0':
+    resolution: {integrity: sha512-/Q13o0ZT0rjc1Xk0Q9KhZYwuq2EW/vSbWUBKfgEKkaCuB/Sg6bqnjmTZqC5cD4d6y1vfFAEwBRzfzoSMIVJ55A==}
+
+  '@prisma/engines-version@7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a':
+    resolution: {integrity: sha512-fJPQxCkLgA5EayWaW8eArgCvjJ+N+Kz3VyeNKMEeYiQC4alNkxRKFVAGxv/ZUzuJISKqdw+zGeDbS6mn6RCPOA==}
+
+  '@prisma/engines@7.8.0':
+    resolution: {integrity: sha512-jx3rCnNNrt5uzbkKlegtQ2GZHxSlihMCzutgT/BP6UIDF1r9tDI39hV/0T/cHZgzJ3ELbuQPXlVZy+Y1n0pcgw==}
+
+  '@prisma/fetch-engine@7.8.0':
+    resolution: {integrity: sha512-gwB0Euiz/DDRyxFRpLXYlK3RfaZUj1c5dAYMuhZYfApg7arknJlcb9bIsOHDppJmbqYaVA+yBIiFMDBfprsNPQ==}
+
+  '@prisma/get-platform@7.2.0':
+    resolution: {integrity: sha512-k1V0l0Td1732EHpAfi2eySTezyllok9dXb6UQanajkJQzPUGi3vO2z7jdkz67SypFTdmbnyGYxvEvYZdZsMAVA==}
+
+  '@prisma/get-platform@7.8.0':
+    resolution: {integrity: sha512-WlxgRGnolL8VH2EmkH1R/DkKNr/mVdS3G2h42IZFFZ3eUrH9OT6t73kIOSlkkrv50wG123Iq8d96ufv5LlZktw==}
+
+  '@prisma/query-plan-executor@7.2.0':
+    resolution: {integrity: sha512-EOZmNzcV8uJ0mae3DhTsiHgoNCuu1J9mULQpGCh62zN3PxPTd+qI9tJvk5jOst8WHKQNwJWR3b39t0XvfBB0WQ==}
+
+  '@prisma/streams-local@0.1.2':
+    resolution: {integrity: sha512-l49yTxKKF2odFxaAXTmwmkBKL3+bVQ1tFOooGifu4xkdb9NMNLxHj27XAhTylWZod8I+ISGM5erU1xcl/oBCtg==}
+    engines: {bun: '>=1.3.6', node: '>=22.0.0'}
+
+  '@prisma/studio-core@0.27.3':
+    resolution: {integrity: sha512-AADjNFPdsrglxHQVTmHFqv6DuKQZ5WY4p5/gVFY017twvNrSwpLJ9lqUbYYxEu2W7nbvVxTZA8deJ8LseNALsw==}
+    engines: {node: ^20.19 || ^22.12 || >=24.0, pnpm: '8'}
+    peerDependencies:
+      '@types/react': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
+
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.10':
+    resolution: {integrity: sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@rolldown/binding-android-arm64@1.1.4':
     resolution: {integrity: sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==}
@@ -2120,19 +2344,39 @@ packages:
   ast-v8-to-istanbul@1.0.4:
     resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
 
+  aws-ssl-profiles@1.1.2:
+    resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
+    engines: {node: '>= 6.0.0'}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
+
+  better-result@2.9.2:
+    resolution: {integrity: sha512-WIFoBPCdnTOdk9inkE1ZRvCZ4P0CpSkAiLlchC65N7n9DcjZ3NhqkBOlafzpOVnO8ixyi37kicmSJ3ENhPZl7Q==}
+
+  better-sqlite3@12.11.1:
+    resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
   birpc@2.9.0:
     resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
 
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -2141,6 +2385,17 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  c12@3.3.4:
+    resolution: {integrity: sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==}
+    peerDependencies:
+      magicast: '*'
+    peerDependenciesMeta:
+      magicast:
+        optional: true
 
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
@@ -2166,12 +2421,26 @@ packages:
   chardet@2.2.0:
     resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
 
+  chart.js@4.5.1:
+    resolution: {integrity: sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==}
+    engines: {pnpm: '>=8'}
+
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
   cliui@9.0.1:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
     engines: {node: '>=20'}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  confbox@0.2.4:
+    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
 
   conventional-changelog-angular@9.2.0:
     resolution: {integrity: sha512-2EihZvM1KmbBGwuUow8lNXLe+ECRFsyOcV8X0197/WI7Rvvgfi55Oicfw0wxJTXGGIVXSfj+xBoNj+cxLlIiVw==}
@@ -2217,12 +2486,31 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
+  deepmerge-ts@7.1.5:
+    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
+    engines: {node: '>=16.0.0'}
+
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
+
+  destr@2.0.5:
+    resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
@@ -2239,6 +2527,10 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
+
   dts-resolver@3.0.0:
     resolution: {integrity: sha512-1T1f+z+4tl9XD+m+0HBgWoL/nm0bOIffyWaUuUSBlFg/86IWvfx+wjNaO/ybU0AJzG9/Mi5hBUgGV6zCmWEN7Q==}
     engines: {node: ^22.18.0 || >=24.0.0}
@@ -2247,6 +2539,9 @@ packages:
     peerDependenciesMeta:
       oxc-resolver:
         optional: true
+
+  effect@3.20.0:
+    resolution: {integrity: sha512-qMLfDJscrNG8p/aw+IkT9W7fgj50Z4wG5bLBy0Txsxz8iUHjDIkOgO3SV0WZfnQbNG2VJYb0b+rDLMrhM4+Krw==}
 
   effect@3.21.4:
     resolution: {integrity: sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ==}
@@ -2257,9 +2552,16 @@ packages:
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
+  empathic@2.0.0:
+    resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
+    engines: {node: '>=14'}
+
   empathic@2.0.1:
     resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
     engines: {node: '>=14'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
@@ -2276,6 +2578,10 @@ packages:
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
+
+  env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
@@ -2311,9 +2617,16 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
+
+  exsolve@1.1.0:
+    resolution: {integrity: sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==}
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
@@ -2347,6 +2660,9 @@ packages:
       picomatch:
         optional: true
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -2358,10 +2674,17 @@ packages:
   focus-trap@7.8.0:
     resolution: {integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   formatly@0.3.0:
     resolution: {integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==}
     engines: {node: '>=18.3.0'}
     hasBin: true
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -2376,6 +2699,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  generate-function@2.3.1:
+    resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -2384,6 +2710,9 @@ packages:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
 
+  get-port-please@3.2.0:
+    resolution: {integrity: sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==}
+
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
@@ -2391,11 +2720,18 @@ packages:
     resolution: {integrity: sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==}
     engines: {node: '>=20.20.0'}
 
+  giget@3.3.0:
+    resolution: {integrity: sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw==}
+    hasBin: true
+
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
     engines: {node: '>=18'}
     deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -2412,6 +2748,12 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  grammex@3.1.12:
+    resolution: {integrity: sha512-6ufJOsSA7LcQehIJNCO7HIBykfM7DXQual0Ny780/DEcJIpBlHRvcqEBWGPYd7hrXL2GJ3oJI1MIhaXjWmLQOQ==}
+
+  graphmatch@1.1.1:
+    resolution: {integrity: sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -2421,6 +2763,10 @@ packages:
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+    engines: {node: '>=16.9.0'}
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -2434,6 +2780,9 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  http-status-codes@2.3.0:
+    resolution: {integrity: sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==}
+
   human-id@4.2.0:
     resolution: {integrity: sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==}
     hasBin: true
@@ -2441,6 +2790,9 @@ packages:
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2453,6 +2805,12 @@ packages:
   import-without-cache@0.4.0:
     resolution: {integrity: sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ==}
     engines: {node: ^22.18.0 || >=24.0.0}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   ini@6.0.0:
     resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
@@ -2476,6 +2834,9 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-property@1.0.2:
+    resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
 
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
@@ -2686,6 +3047,13 @@ packages:
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  lru.min@1.1.4:
+    resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
+    engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
+
   lunr@2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
 
@@ -2743,9 +3111,16 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   minisearch@7.2.0:
     resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
@@ -2753,22 +3128,46 @@ packages:
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
 
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
+
+  mysql2@3.15.3:
+    resolution: {integrity: sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==}
+    engines: {node: '>= 8.0'}
+
+  named-placeholders@1.1.6:
+    resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
+    engines: {node: '>=8.0.0'}
 
   nanoid@3.3.15:
     resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   neverthrow@8.2.0:
     resolution: {integrity: sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ==}
     engines: {node: '>=18'}
 
+  node-abi@3.94.0:
+    resolution: {integrity: sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==}
+    engines: {node: '>=10'}
+
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
     engines: {node: '>=12.20.0'}
+
+  ohash@2.0.11:
+    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   oniguruma-to-es@3.1.1:
     resolution: {integrity: sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==}
@@ -2858,6 +3257,9 @@ packages:
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
+  perfect-debounce@2.1.0:
+    resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2873,20 +3275,52 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
+  pkg-types@2.3.1:
+    resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
+
   postcss@8.5.16:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postgres@3.4.7:
+    resolution: {integrity: sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==}
+    engines: {node: '>=12'}
+
   preact@10.29.2:
     resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
+
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
 
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  prisma@7.8.0:
+    resolution: {integrity: sha512-yfN4yrw7HV9kEJhoy1+jgah0jafEIQsf7uWouSsM8MvJtlubsk+kM7AIBWZ8+GJl74Yj3c+nbYqBkMOxtsZ3Lw==}
+    engines: {node: ^20.19 || ^22.12 || >=24.0}
+    hasBin: true
+    peerDependencies:
+      better-sqlite3: '>=9.0.0'
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      better-sqlite3:
+        optional: true
+      typescript:
+        optional: true
+
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
@@ -2904,9 +3338,24 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  rc9@3.0.1:
+    resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
 
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
@@ -2916,6 +3365,9 @@ packages:
 
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
+  remeda@2.33.4:
+    resolution: {integrity: sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ==}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -2931,6 +3383,10 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -2971,6 +3427,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -2978,6 +3437,9 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  seq-queue@0.0.5:
+    resolution: {integrity: sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2993,9 +3455,18 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -3022,8 +3493,15 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  sqlstring@2.3.3:
+    resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
+    engines: {node: '>= 0.6'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
@@ -3031,6 +3509,9 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -3047,6 +3528,10 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
   strip-json-comments@5.0.3:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
@@ -3061,6 +3546,13 @@ packages:
 
   tabbable@6.5.0:
     resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
+
+  tar-fs@2.1.5:
+    resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -3141,6 +3633,9 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
   turbo@2.10.2:
     resolution: {integrity: sha512-wTExrNrRjB8qzIcg+ZLm0A3GFNLDsWNwdS/RBXB0FPrBDyzk3i96Yx+TxWZC7a0k1SIreFB8ciUbxjmEqTH8IQ==}
     hasBin: true
@@ -3194,6 +3689,17 @@ packages:
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  valibot@1.2.0:
+    resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -3353,6 +3859,9 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -3369,6 +3878,9 @@ packages:
   yargs@18.0.0:
     resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  zeptomatch@2.1.0:
+    resolution: {integrity: sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -3824,6 +4336,16 @@ snapshots:
     transitivePeerDependencies:
       - '@algolia/client-search'
 
+  '@electric-sql/pglite-socket@0.1.1(@electric-sql/pglite@0.4.1)':
+    dependencies:
+      '@electric-sql/pglite': 0.4.1
+
+  '@electric-sql/pglite-tools@0.3.1(@electric-sql/pglite@0.4.1)':
+    dependencies:
+      '@electric-sql/pglite': 0.4.1
+
+  '@electric-sql/pglite@0.4.1': {}
+
   '@emnapi/core@1.11.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
@@ -4006,6 +4528,10 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
+  '@hono/node-server@1.19.11(hono@4.12.27)':
+    dependencies:
+      hono: 4.12.27
+
   '@iconify-json/simple-icons@1.2.87':
     dependencies:
       '@iconify/types': 2.0.0
@@ -4032,6 +4558,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@kurkle/color@0.3.4': {}
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -4320,9 +4848,130 @@ snapshots:
 
   '@oxlint/plugins@1.72.0': {}
 
+  '@prisma/adapter-better-sqlite3@7.8.0':
+    dependencies:
+      '@prisma/driver-adapter-utils': 7.8.0
+      better-sqlite3: 12.11.1
+
+  '@prisma/client-runtime-utils@7.8.0': {}
+
+  '@prisma/client@7.8.0(prisma@7.8.0(better-sqlite3@12.11.1)(magicast@0.5.3)(typescript@6.0.3))(typescript@6.0.3)':
+    dependencies:
+      '@prisma/client-runtime-utils': 7.8.0
+    optionalDependencies:
+      prisma: 7.8.0(better-sqlite3@12.11.1)(magicast@0.5.3)(typescript@6.0.3)
+      typescript: 6.0.3
+
+  '@prisma/config@7.8.0(magicast@0.5.3)':
+    dependencies:
+      c12: 3.3.4(magicast@0.5.3)
+      deepmerge-ts: 7.1.5
+      effect: 3.20.0
+      empathic: 2.0.0
+    transitivePeerDependencies:
+      - magicast
+
+  '@prisma/debug@7.2.0': {}
+
+  '@prisma/debug@7.8.0': {}
+
+  '@prisma/dev@0.24.3(typescript@6.0.3)':
+    dependencies:
+      '@electric-sql/pglite': 0.4.1
+      '@electric-sql/pglite-socket': 0.1.1(@electric-sql/pglite@0.4.1)
+      '@electric-sql/pglite-tools': 0.3.1(@electric-sql/pglite@0.4.1)
+      '@hono/node-server': 1.19.11(hono@4.12.27)
+      '@prisma/get-platform': 7.2.0
+      '@prisma/query-plan-executor': 7.2.0
+      '@prisma/streams-local': 0.1.2
+      foreground-child: 3.3.1
+      get-port-please: 3.2.0
+      hono: 4.12.27
+      http-status-codes: 2.3.0
+      pathe: 2.0.3
+      proper-lockfile: 4.1.2
+      remeda: 2.33.4
+      std-env: 3.10.0
+      valibot: 1.2.0(typescript@6.0.3)
+      zeptomatch: 2.1.0
+    transitivePeerDependencies:
+      - typescript
+
+  '@prisma/driver-adapter-utils@7.8.0':
+    dependencies:
+      '@prisma/debug': 7.8.0
+
+  '@prisma/engines-version@7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a': {}
+
+  '@prisma/engines@7.8.0':
+    dependencies:
+      '@prisma/debug': 7.8.0
+      '@prisma/engines-version': 7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a
+      '@prisma/fetch-engine': 7.8.0
+      '@prisma/get-platform': 7.8.0
+
+  '@prisma/fetch-engine@7.8.0':
+    dependencies:
+      '@prisma/debug': 7.8.0
+      '@prisma/engines-version': 7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a
+      '@prisma/get-platform': 7.8.0
+
+  '@prisma/get-platform@7.2.0':
+    dependencies:
+      '@prisma/debug': 7.2.0
+
+  '@prisma/get-platform@7.8.0':
+    dependencies:
+      '@prisma/debug': 7.8.0
+
+  '@prisma/query-plan-executor@7.2.0': {}
+
+  '@prisma/streams-local@0.1.2':
+    dependencies:
+      ajv: 8.20.0
+      better-result: 2.9.2
+      env-paths: 3.0.0
+      proper-lockfile: 4.1.2
+
+  '@prisma/studio-core@0.27.3':
+    dependencies:
+      '@radix-ui/react-toggle': 1.1.10
+      chart.js: 4.5.1
+    transitivePeerDependencies:
+      - '@types/react-dom'
+
   '@quansync/fs@1.0.0':
     dependencies:
       quansync: 1.0.0
+
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-compose-refs@1.1.2': {}
+
+  '@radix-ui/react-primitive@2.1.3':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3
+
+  '@radix-ui/react-slot@1.2.3':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2
+
+  '@radix-ui/react-toggle@1.1.10':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-primitive': 2.1.3
+      '@radix-ui/react-use-controllable-state': 1.2.2
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2
+      '@radix-ui/react-use-layout-effect': 1.1.1
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1
+
+  '@radix-ui/react-use-layout-effect@1.1.1': {}
 
   '@rolldown/binding-android-arm64@1.1.4':
     optional: true
@@ -4796,15 +5445,36 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
+  aws-ssl-profiles@1.1.2: {}
+
   balanced-match@4.0.4: {}
+
+  base64-js@1.5.1: {}
 
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
 
+  better-result@2.9.2: {}
+
+  better-sqlite3@12.11.1:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
   birpc@2.9.0: {}
 
   birpc@4.0.0: {}
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   brace-expansion@5.0.6:
     dependencies:
@@ -4813,6 +5483,28 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  c12@3.3.4(magicast@0.5.3):
+    dependencies:
+      chokidar: 5.0.0
+      confbox: 0.2.4
+      defu: 6.1.7
+      dotenv: 17.4.2
+      exsolve: 1.1.0
+      giget: 3.3.0
+      jiti: 2.7.0
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      pkg-types: 2.3.1
+      rc9: 3.0.1
+    optionalDependencies:
+      magicast: 0.5.3
 
   cac@7.0.0: {}
 
@@ -4828,6 +5520,16 @@ snapshots:
 
   chardet@2.2.0: {}
 
+  chart.js@4.5.1:
+    dependencies:
+      '@kurkle/color': 0.3.4
+
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
+  chownr@1.1.4: {}
+
   cliui@9.0.1:
     dependencies:
       string-width: 7.2.0
@@ -4835,6 +5537,8 @@ snapshots:
       wrap-ansi: 9.0.2
 
   comma-separated-tokens@2.0.3: {}
+
+  confbox@0.2.4: {}
 
   conventional-changelog-angular@9.2.0:
     dependencies:
@@ -4879,9 +5583,21 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
+  deep-extend@0.6.0: {}
+
+  deepmerge-ts@7.1.5: {}
+
   defu@6.1.7: {}
 
+  denque@2.1.0: {}
+
   dequal@2.0.3: {}
+
+  destr@2.0.5: {}
 
   detect-indent@6.1.0: {}
 
@@ -4895,9 +5611,16 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
+  dotenv@17.4.2: {}
+
   dts-resolver@3.0.0(oxc-resolver@11.21.3):
     optionalDependencies:
       oxc-resolver: 11.21.3
+
+  effect@3.20.0:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
 
   effect@3.21.4:
     dependencies:
@@ -4908,7 +5631,13 @@ snapshots:
 
   emoji-regex@10.6.0: {}
 
+  empathic@2.0.0: {}
+
   empathic@2.0.1: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enquirer@2.4.1:
     dependencies:
@@ -4920,6 +5649,8 @@ snapshots:
   entities@7.0.1: {}
 
   env-paths@2.2.1: {}
+
+  env-paths@3.0.0: {}
 
   error-ex@1.3.4:
     dependencies:
@@ -4994,7 +5725,11 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
 
+  expand-template@2.0.3: {}
+
   expect-type@1.4.0: {}
+
+  exsolve@1.1.0: {}
 
   extendable-error@0.1.7: {}
 
@@ -5026,6 +5761,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  file-uri-to-path@1.0.0: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -5039,9 +5776,16 @@ snapshots:
     dependencies:
       tabbable: 6.5.0
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   formatly@0.3.0:
     dependencies:
       fd-package-json: 2.0.0
+
+  fs-constants@1.0.0: {}
 
   fs-extra@7.0.1:
     dependencies:
@@ -5058,9 +5802,15 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  generate-function@2.3.1:
+    dependencies:
+      is-property: 1.0.2
+
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.6.0: {}
+
+  get-port-please@3.2.0: {}
 
   get-tsconfig@4.14.0:
     dependencies:
@@ -5070,6 +5820,8 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  giget@3.3.0: {}
+
   git-raw-commits@5.0.1:
     dependencies:
       '@conventional-changelog/git-client': 2.7.0
@@ -5077,6 +5829,8 @@ snapshots:
     transitivePeerDependencies:
       - conventional-commits-filter
       - conventional-commits-parser
+
+  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -5096,6 +5850,10 @@ snapshots:
       slash: 3.0.0
 
   graceful-fs@4.2.11: {}
+
+  grammex@3.1.12: {}
+
+  graphmatch@1.1.1: {}
 
   has-flag@4.0.0: {}
 
@@ -5117,6 +5875,8 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  hono@4.12.27: {}
+
   hookable@5.5.3: {}
 
   hookable@6.1.1: {}
@@ -5125,11 +5885,15 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  http-status-codes@2.3.0: {}
+
   human-id@4.2.0: {}
 
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
+
+  ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 
@@ -5139,6 +5903,10 @@ snapshots:
       resolve-from: 4.0.0
 
   import-without-cache@0.4.0: {}
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   ini@6.0.0: {}
 
@@ -5153,6 +5921,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-property@1.0.2: {}
 
   is-subdir@1.2.0:
     dependencies:
@@ -5324,6 +6094,10 @@ snapshots:
 
   lodash.startcase@4.4.0: {}
 
+  long@5.3.2: {}
+
+  lru.min@1.1.4: {}
+
   lunr@2.3.9: {}
 
   magic-string@0.30.21:
@@ -5393,23 +6167,57 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  mimic-response@3.1.0: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
+
+  minimist@1.2.8: {}
 
   minisearch@7.2.0: {}
 
   mitt@3.0.1: {}
 
+  mkdirp-classic@0.5.3: {}
+
   mri@1.2.0: {}
 
+  mysql2@3.15.3:
+    dependencies:
+      aws-ssl-profiles: 1.1.2
+      denque: 2.1.0
+      generate-function: 2.3.1
+      iconv-lite: 0.7.2
+      long: 5.3.2
+      lru.min: 1.1.4
+      named-placeholders: 1.1.6
+      seq-queue: 0.0.5
+      sqlstring: 2.3.3
+
+  named-placeholders@1.1.6:
+    dependencies:
+      lru.min: 1.1.4
+
   nanoid@3.3.15: {}
+
+  napi-build-utils@2.0.0: {}
 
   neverthrow@8.2.0:
     optionalDependencies:
       '@rollup/rollup-linux-x64-gnu': 4.62.2
 
+  node-abi@3.94.0:
+    dependencies:
+      semver: 7.8.5
+
   obug@2.1.3: {}
+
+  ohash@2.0.11: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   oniguruma-to-es@3.1.1:
     dependencies:
@@ -5553,6 +6361,8 @@ snapshots:
 
   perfect-debounce@1.0.0: {}
 
+  perfect-debounce@2.1.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -5561,17 +6371,69 @@ snapshots:
 
   pify@4.0.1: {}
 
+  pkg-types@2.3.1:
+    dependencies:
+      confbox: 0.2.4
+      exsolve: 1.1.0
+      pathe: 2.0.3
+
   postcss@8.5.16:
     dependencies:
       nanoid: 3.3.15
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postgres@3.4.7: {}
+
   preact@10.29.2: {}
+
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.94.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.5
+      tunnel-agent: 0.6.0
 
   prettier@2.8.8: {}
 
+  prisma@7.8.0(better-sqlite3@12.11.1)(magicast@0.5.3)(typescript@6.0.3):
+    dependencies:
+      '@prisma/config': 7.8.0(magicast@0.5.3)
+      '@prisma/dev': 0.24.3(typescript@6.0.3)
+      '@prisma/engines': 7.8.0
+      '@prisma/studio-core': 0.27.3
+      mysql2: 3.15.3
+      postgres: 3.4.7
+    optionalDependencies:
+      better-sqlite3: 12.11.1
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - magicast
+      - react
+      - react-dom
+
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
   property-information@7.2.0: {}
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
 
   punycode.js@2.3.1: {}
 
@@ -5583,12 +6445,32 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  rc9@3.0.1:
+    dependencies:
+      defu: 6.1.7
+      destr: 2.0.5
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
       js-yaml: 3.14.2
       pify: 4.0.1
       strip-bom: 3.0.0
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  readdirp@5.0.0: {}
 
   regex-recursion@6.0.2:
     dependencies:
@@ -5600,6 +6482,8 @@ snapshots:
     dependencies:
       regex-utilities: 2.3.0
 
+  remeda@2.33.4: {}
+
   require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
@@ -5607,6 +6491,8 @@ snapshots:
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  retry@0.12.0: {}
 
   reusify@1.1.0: {}
 
@@ -5684,9 +6570,13 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.2.1: {}
+
   safer-buffer@2.1.2: {}
 
   semver@7.8.5: {}
+
+  seq-queue@0.0.5: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -5707,7 +6597,17 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@3.0.7: {}
+
   signal-exit@4.1.0: {}
+
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
 
   slash@3.0.0: {}
 
@@ -5726,7 +6626,11 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  sqlstring@2.3.3: {}
+
   stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   std-env@4.1.0: {}
 
@@ -5735,6 +6639,10 @@ snapshots:
       emoji-regex: 10.6.0
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   stringify-entities@4.0.4:
     dependencies:
@@ -5751,6 +6659,8 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-json-comments@2.0.1: {}
+
   strip-json-comments@5.0.3: {}
 
   superjson@2.2.6:
@@ -5762,6 +6672,21 @@ snapshots:
       has-flag: 4.0.0
 
   tabbable@6.5.0: {}
+
+  tar-fs@2.1.5:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   term-size@2.2.1: {}
 
@@ -5823,6 +6748,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   turbo@2.10.2:
     optionalDependencies:
       '@turbo/darwin-64': 2.10.2
@@ -5882,6 +6811,12 @@ snapshots:
       unist-util-visit-parents: 6.0.2
 
   universalify@0.1.2: {}
+
+  util-deprecate@1.0.2: {}
+
+  valibot@1.2.0(typescript@6.0.3):
+    optionalDependencies:
+      typescript: 6.0.3
 
   vfile-message@4.0.3:
     dependencies:
@@ -6033,6 +6968,8 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
+  wrappy@1.0.2: {}
+
   y18n@5.0.8: {}
 
   yaml@2.9.0: {}
@@ -6047,6 +6984,11 @@ snapshots:
       string-width: 7.2.0
       y18n: 5.0.8
       yargs-parser: 22.0.0
+
+  zeptomatch@2.1.0:
+    dependencies:
+      grammex: 3.1.12
+      graphmatch: 1.1.1
 
   zod@4.4.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,11 +14,15 @@ catalog:
   "@commitlint/cli": 21.2.0
   "@bloodyowl/boxed": 3.4.0
   "@btravstack/theme": 1.5.0
+  "@prisma/adapter-better-sqlite3": 7.8.0
+  "@prisma/client": 7.8.0
   "@standard-schema/spec": 1.1.0
   "@commitlint/config-conventional": 21.2.0
   "@types/node": 24.13.2
   "@vitest/coverage-v8": 4.1.9
+  better-sqlite3: 12.11.1
   effect: 3.21.4
+  prisma: 7.8.0
   knip: 6.23.0
   lefthook: 2.1.9
   neverthrow: 8.2.0
@@ -38,10 +42,20 @@ peerDependencyRules:
   ignoreMissing:
     # Optional analytics peer of VitePress's bundled Algolia DocSearch.
     - search-insights
+    # React peers of `@prisma/studio-core`, pulled in transitively by the `prisma`
+    # CLI (v7 bundles Prisma Studio). We never run `prisma studio`; the CLI is a
+    # dev-only dependency of `@unthrown/prisma` (its test-client generation).
+    - react
+    - react-dom
 
 allowBuilds:
+  # Prisma 7 is engine-less (WASM query compiler); nothing to build or download.
+  "@prisma/engines": false
+  # Native SQLite bindings for `@unthrown/prisma`'s tests (prebuilt binaries).
+  better-sqlite3: true
   esbuild: true
   lefthook: true
+  prisma: true
 
 # Supply-chain maturity delay: don't adopt a freshly published version until it
 # has been on the registry for 7 days (10080 minutes). Strict mode also validates


### PR DESCRIPTION
## What

A new integration package, **`@unthrown/prisma`** (`packages/prisma`), following the `@unthrown/<peer>` convention: a shareable Prisma Client extension (`Prisma.defineExtension` from `@prisma/client/extension`) that adds `try`-prefixed variants of the model delegate operations **alongside** the raw promise ones.

```ts
const db = new PrismaClient({ adapter }).$extends(unthrownPrisma);

const users = db.user.tryFindMany({ select: { id: true } });
//    ^? AsyncResult<{ id: number }[], DriverError>
```

## Design

- **Per-operation error unions** — the key feature over one flat union: reads (`tryFindMany` / `tryFindUnique` / `tryCount`) can only fail with `DriverError`; writes add `UniqueConstraintViolation` (P2002) and `ForeignKeyViolation` (P2003); `tryFindUniqueOrThrow` / `tryUpdate` / `tryDelete` add `RecordNotFound` (P2025). Everything else folds into `DriverError` with the cause preserved.
- **Payload inference survives the wrap** — typed with the official `Prisma.Args` / `Prisma.Result` / `Prisma.Exact` utilities (the `$allModels` pattern); a naive mapped type over the client would destroy `select`/`include` narrowing.
- **Qualification once, at the boundary (Thesis #3)** — `fromPromise(…, qualifyPrismaError)` inside the extension; no raw Promise reaches the caller. P2002's offending `fields` are extracted from both the classic `meta.target` and the driver-adapter shape (`meta.driverAdapterError.cause.constraint.fields`).
- **`$tryTransaction`** — an interactive transaction whose callback speaks `AsyncResult`: an `Err` is thrown internally as a sentinel so Prisma rolls back, then re-surfaced as the same typed `Err`; a defect also rolls back and **stays a defect** (re-minted through `fromPromise`'s `defect` factory). The `try*` methods propagate onto `tx`; the deny list removes `$tryTransaction` itself, so nesting is a compile error.
- **The raw methods stay on purpose** — they are the escape hatch for batch `$transaction([...])`, which needs unexecuted `PrismaPromise`s.

## Verification

- **23 runtime tests against a real client** over in-memory SQLite (`@prisma/adapter-better-sqlite3`): every mapped P-code is provoked for real (duplicate email → P2002, dangling relation → P2003, missing row → P2025), and `$tryTransaction` covers commit, rollback-on-`Err`, rollback-on-defect, and a transaction-level failure that bypasses the sentinel. **100% statement / branch / function / line coverage**, enforced by thresholds.
- **Type-level tests** (`types.test-d.ts`, checked by the package's regular `tsc --noEmit`): exact `select` narrowing, per-operation error unions, `Prisma.Exact` arg rejection, transaction error-union and deny list.
- Dogfoods `@unthrown/vitest` (`toBeOkWith` / `toBeErrTagged` / `toBeDefect`).

## Housekeeping

- Catalog entries for `prisma` / `@prisma/client` / `@prisma/adapter-better-sqlite3` / `better-sqlite3` (all past the 7-day supply-chain gate); `allowBuilds` for better-sqlite3's native bindings, engines disabled (Prisma 7 is WASM); `react`/`react-dom` peer-ignore for the bundled Prisma Studio we never run.
- `@unthrown/prisma` versions **independently** (left the fixed group in a review round — its majors track `@prisma/client`'s cadence, not the family's); changeset included (minor, starts at 0.1.0).
- Registered in the docs pipeline (copy-docs, VitePress sidebar) and the root README package table.
- oxlint/knip exclude the generated test client (`src/generated`, gitignored, regenerated by the test/typecheck scripts — the published package is schema-agnostic and ships `dist` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Update: cursor pagination (`tryPaginate`)

Added \`tryPaginate(query).withCursor({ limit, after, before, getCursor, parseCursor })\` → \`AsyncResult<[results, meta], DriverError>\` — the [prisma-extension-pagination](https://github.com/deptyped/prisma-extension-pagination) cursor API (same option names, same \`[results, meta]\` shape), with three changes:

- **Folds in deptyped/prisma-extension-pagination#36** (fixing [#35](https://github.com/deptyped/prisma-extension-pagination/issues/35), never merged upstream): a cursor pointing at a record that no longer matches the query filter must not skip the first element of the page. Instead of \`skip: 1\`, the page is over-fetched by two and the boundary row is dropped only when it round-trips to the request cursor — now covered by the tests the upstream PR was missing, in both directions (\`after\` / \`before\`) and at both over-fetch depths.
- **\`before\` + \`limit: null\` is a compile error** — Prisma's negative \`take\` cannot express "everything before the cursor"; upstream silently pages the wrong way for this combination.
- **The default \`parseCursor\` preserves the id's type** — all-digits cursors parse back to numbers (autoincrement ids), anything else stays a string (uuid/cuid), where upstream hard-assumes numeric ids.

The query args exclude \`cursor\` / \`take\` / \`skip\` at the type level (pagination owns them), \`select\`/\`include\` payload inference flows through, and a throwing \`parseCursor\` (malformed cursor from an API client) surfaces as a modeled \`DriverError\`, never a raw throw. 37 tests, still 100% statement/branch/function/line coverage.

