### PR TITLE
feat(core): add OkAsync/ErrAsync pre-lifted async constructors

### DIFF
--- a/.changeset/okasync-errasync.md
+++ b/.changeset/okasync-errasync.md
@@ -4,7 +4,7 @@
 
 Add pre-lifted async constructors `OkAsync` / `ErrAsync` (and the companion
 aliases `AsyncResult.Ok` / `AsyncResult.Err`) for building an `AsyncResult`
-directly from a value — sparing the repeated `Ok(value).toAsync()` /
+directly from a value or error — sparing the repeated `Ok(value).toAsync()` /
 `Err(error).toAsync()` on the synchronous branch of an `AsyncResult`-returning
 function. They carry the `Async` suffix the other async free functions use
 (`allAsync`), which the companion drops (`AsyncResult.Ok`). Closes #75.

--- a/.changeset/okasync-errasync.md
+++ b/.changeset/okasync-errasync.md
@@ -1,0 +1,10 @@
+---
+"unthrown": minor
+---
+
+Add pre-lifted async constructors `OkAsync` / `ErrAsync` (and the companion
+aliases `AsyncResult.Ok` / `AsyncResult.Err`) for building an `AsyncResult`
+directly from a value — sparing the repeated `Ok(value).toAsync()` /
+`Err(error).toAsync()` on the synchronous branch of an `AsyncResult`-returning
+function. They carry the `Async` suffix the other async free functions use
+(`allAsync`), which the companion drops (`AsyncResult.Ok`). Closes #75.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,12 @@ async work re-enters via `fromPromise` / `fromSafePromise` and composes with
   unqualified rejection.
 - constructors: `Ok`, `Err` (there is **no** `Defect` constructor — a defect-state
   `Result` arises only at boundaries; the qualify-time `defect` marker helper is
-  injected, not exported)
+  injected, not exported), plus the **pre-lifted async** constructors `OkAsync` /
+  `ErrAsync` — `Ok(v).toAsync()` / `Err(e).toAsync()` without the boilerplate, for
+  the synchronous branch of an `AsyncResult`-returning function. They carry the
+  `Async` **suffix** the async free functions use (`allAsync`); the `AsyncResult`
+  companion aliases them as `AsyncResult.Ok` / `AsyncResult.Err` (suffix dropped,
+  same rule as `AsyncResult.all`)
 - interop: `fromNullable`, `fromThrowable`, `fromPromise`, `fromSafePromise`
 - aggregate: `all` / `allAsync` take a **tuple/array** (a fixed tuple keeps
   positional types; a dynamic `Result<T, E>[]` / `AsyncResult<T, E>[]` collapses
@@ -167,8 +172,9 @@ async work re-enters via `fromPromise` / `fromSafePromise` and composes with
   the `Result`-producing ones
   (`Result.Ok`/`Err`/`Do`/`fromNullable`/`fromThrowable`/`all`/`allFromDict`/`is*`);
   `AsyncResult.*` holds the `AsyncResult`-producing ones
-  (`AsyncResult.fromPromise`/`fromSafePromise`/`all`/`allFromDict` — the
-  aggregates drop the `Async` suffix the free functions carry, since the
+  (`AsyncResult.Ok`/`Err`/`fromPromise`/`fromSafePromise`/`all`/`allFromDict` — the
+  pre-lifted constructors and aggregates drop the `Async` suffix the free functions
+  carry (`OkAsync`→`AsyncResult.Ok`, `allAsync`→`AsyncResult.all`), since the
   namespace already says async). Both are value+type companions (the value and
   the `Result<T,E>` / `AsyncResult<T,E>` type share one name). The free functions
   remain the primary, tree-shakeable API; the companions are opt-in sugar (only

--- a/docs/guide/async-results.md
+++ b/docs/guide/async-results.md
@@ -5,7 +5,7 @@ the **same method surface**, and `await`-ing it collapses it to a `Result`.
 
 You get one from a qualified boundary ([`fromPromise`](./boundaries),
 `fromSafePromise`), by lifting a sync `Result` with `.toAsync()`, or — for a pure
-value — directly with `OkAsync` / `ErrAsync`.
+value or error — directly with `OkAsync` / `ErrAsync`.
 
 ```ts
 import { fromSafePromise } from "unthrown";

--- a/docs/guide/async-results.md
+++ b/docs/guide/async-results.md
@@ -4,7 +4,8 @@ An `AsyncResult<T, E>` is the asynchronous counterpart of `Result<T, E>`. It has
 the **same method surface**, and `await`-ing it collapses it to a `Result`.
 
 You get one from a qualified boundary ([`fromPromise`](./boundaries),
-`fromSafePromise`) or by lifting a sync `Result` with `.toAsync()`.
+`fromSafePromise`), by lifting a sync `Result` with `.toAsync()`, or — for a pure
+value — directly with `OkAsync` / `ErrAsync`.
 
 ```ts
 import { fromSafePromise } from "unthrown";
@@ -12,6 +13,23 @@ import { fromSafePromise } from "unthrown";
 const result = await fromSafePromise(Promise.resolve(1)).map((n) => n + 1);
 result.unwrap(); // => 2
 ```
+
+`OkAsync(value)` / `ErrAsync(error)` are the pre-lifted constructors — exactly
+`Ok(value).toAsync()` / `Err(error).toAsync()`, minus the boilerplate. Reach for
+them on the synchronous or early-return branch of an `AsyncResult`-returning
+function, so both branches share one return type:
+
+```ts
+import { OkAsync, type AsyncResult } from "unthrown";
+
+function loadItems(ids: string[]): AsyncResult<Item[], never> {
+  if (ids.length === 0) return OkAsync([]); // no trailing .toAsync()
+  return itemRepository.load(ids);
+}
+```
+
+They carry the `Async` suffix the async free functions use (`allAsync`); the
+`AsyncResult` companion aliases them as `AsyncResult.Ok` / `AsyncResult.Err`.
 
 ## Awaitable, not a Promise
 

--- a/docs/guide/choosing-a-combinator.md
+++ b/docs/guide/choosing-a-combinator.md
@@ -93,6 +93,7 @@ Use this table to move between the two:
 
 | I have… and want to…                    | use                                                   |
 | --------------------------------------- | ----------------------------------------------------- |
+| build an `AsyncResult` from a value     | `OkAsync(v)` / `ErrAsync(e)` (no `Ok(v).toAsync()`)   |
 | lift a sync `Result` into async         | `result.toAsync()` → `AsyncResult`                    |
 | collapse an `AsyncResult` to a `Result` | `await asyncResult`                                   |
 | add an **async** step mid-chain         | `.flatMap((v) => fromPromise(work(v), qualify))`      |

--- a/docs/guide/choosing-a-combinator.md
+++ b/docs/guide/choosing-a-combinator.md
@@ -91,14 +91,14 @@ exactly three ways:
 
 Use this table to move between the two:
 
-| I have… and want to…                    | use                                                   |
-| --------------------------------------- | ----------------------------------------------------- |
-| build an `AsyncResult` from a value     | `OkAsync(v)` / `ErrAsync(e)` (no `Ok(v).toAsync()`)   |
-| lift a sync `Result` into async         | `result.toAsync()` → `AsyncResult`                    |
-| collapse an `AsyncResult` to a `Result` | `await asyncResult`                                   |
-| add an **async** step mid-chain         | `.flatMap((v) => fromPromise(work(v), qualify))`      |
-| add a **sync** step to an async chain   | `.flatMap((v) => Ok(v + 1))` — a `Result` is accepted |
-| combine async results                   | `allAsync` / `allFromDictAsync`                       |
+| I have… and want to…                      | use                                                   |
+| ----------------------------------------- | ----------------------------------------------------- |
+| build an `AsyncResult` from a value/error | `OkAsync(v)` / `ErrAsync(e)` (no `Ok(v).toAsync()`)   |
+| lift a sync `Result` into async           | `result.toAsync()` → `AsyncResult`                    |
+| collapse an `AsyncResult` to a `Result`   | `await asyncResult`                                   |
+| add an **async** step mid-chain           | `.flatMap((v) => fromPromise(work(v), qualify))`      |
+| add a **sync** step to an async chain     | `.flatMap((v) => Ok(v + 1))` — a `Result` is accepted |
+| combine async results                     | `allAsync` / `allFromDictAsync`                       |
 
 ```ts
 // A chain that crosses an async boundary stays an AsyncResult to the end.

--- a/packages/core/src/constructors.spec.ts
+++ b/packages/core/src/constructors.spec.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it } from "vitest";
 
-import { Err, isDefect, isErr, isOk, isResult, Ok, type Result, UnwrapError } from "./index.js";
+import {
+  AsyncResult,
+  Err,
+  ErrAsync,
+  isDefect,
+  isErr,
+  isOk,
+  isResult,
+  Ok,
+  OkAsync,
+  type Result,
+  UnwrapError,
+} from "./index.js";
 
 const boom = new Error("boom");
 const defectOf = (cause: unknown): Result<number, never> =>
@@ -40,6 +52,30 @@ describe("constructors", () => {
     if (nested.isOk()) {
       expect(nested.value.tag).toBe("Err");
     }
+  });
+});
+
+describe("pre-lifted async constructors (OkAsync / ErrAsync)", () => {
+  it("OkAsync lifts a value into a success AsyncResult — no Ok(x).toAsync()", async () => {
+    const r = await OkAsync(42);
+    expect(r.isOk()).toBe(true);
+    expect(r.unwrap()).toBe(42);
+  });
+
+  it("ErrAsync lifts an error into a failed AsyncResult", async () => {
+    const r = await ErrAsync("nope");
+    expect(r.isErr()).toBe(true);
+    expect(r.unwrapErr()).toBe("nope");
+  });
+
+  it("await-ing never throws and yields the same outcome as Ok(x).toAsync()", async () => {
+    expect(await OkAsync(1)).toStrictEqual(await Ok(1).toAsync());
+    expect(await ErrAsync("e")).toStrictEqual(await Err("e").toAsync());
+  });
+
+  it("the AsyncResult companion aliases them (suffix dropped inside the namespace)", () => {
+    expect(AsyncResult.Ok).toBe(OkAsync);
+    expect(AsyncResult.Err).toBe(ErrAsync);
   });
 });
 

--- a/packages/core/src/constructors.ts
+++ b/packages/core/src/constructors.ts
@@ -1,7 +1,7 @@
 // Result constructors and the standalone narrowing guards.
 
 import { errRes, okRes } from "./core.js";
-import type { DefectView, ErrView, OkView, Result } from "./types.js";
+import type { AsyncResult, DefectView, ErrView, OkView, Result } from "./types.js";
 
 /**
  * Construct a successful {@link Result}.
@@ -41,6 +41,60 @@ export function Ok<T>(value: T): Result<T, never> {
  */
 export function Err<E>(error: E): Result<never, E> {
   return errRes(error);
+}
+
+/**
+ * Construct a successful {@link AsyncResult} from a pure value — the pre-lifted
+ * form of {@link Ok}, sparing you `Ok(value).toAsync()`.
+ *
+ * @remarks
+ * Reach for this on the synchronous/early branch of an `AsyncResult`-returning
+ * function, so both branches share one return type without a trailing
+ * `.toAsync()`. Named with the `Async` suffix the async free functions carry
+ * (`allAsync`, `allFromDictAsync`); the {@link AsyncResult} companion aliases it
+ * as `AsyncResult.Ok` (the namespace already says "async", so the suffix drops).
+ *
+ * @typeParam T - the success value type.
+ * @param value - the success value to wrap.
+ *
+ * @example
+ * ```ts
+ * import { OkAsync, type AsyncResult } from "unthrown";
+ *
+ * function loadItems(ids: string[]): AsyncResult<Item[], never> {
+ *   if (ids.length === 0) return OkAsync([]); // no more Ok([]).toAsync()
+ *   return itemRepository.load(ids);
+ * }
+ * ```
+ *
+ * @category Constructors
+ */
+export function OkAsync<T>(value: T): AsyncResult<T, never> {
+  return Ok(value).toAsync();
+}
+
+/**
+ * Construct a failed {@link AsyncResult} carrying a **modeled** error — the
+ * pre-lifted form of {@link Err}, sparing you `Err(error).toAsync()`.
+ *
+ * @remarks
+ * The error-channel mirror of {@link OkAsync}; see it for the naming and the
+ * `AsyncResult.Err` companion alias.
+ *
+ * @typeParam E - the modeled error type.
+ * @param error - the domain error to wrap.
+ *
+ * @example
+ * ```ts
+ * import { ErrAsync } from "unthrown";
+ *
+ * ErrAsync("not_found"); // AsyncResult<never, string>
+ * ```
+ *
+ * @category Constructors
+ */
+export function ErrAsync<E>(error: E): AsyncResult<never, E> {
+  return Err(error).toAsync();
 }
 
 /**

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -4,7 +4,7 @@
 // `Result` and the type `Result<T, E>` (types.ts) share a name — the
 // companion-object pattern. See CLAUDE.md → "Internal design".
 
-import { Err, isDefect, isErr, isOk, Ok } from "./constructors.js";
+import { Err, ErrAsync, isDefect, isErr, isOk, Ok, OkAsync } from "./constructors.js";
 import { isResult } from "./core.js";
 import { Do } from "./do.js";
 import {
@@ -79,18 +79,20 @@ export type Result<T, E> = ResultType<T, E>;
 
 /**
  * Companion object grouping the **`AsyncResult`-producing** entry points under
- * the matching namespace: {@link AsyncResult.fromPromise},
- * {@link AsyncResult.fromSafePromise}, {@link AsyncResult.all},
- * {@link AsyncResult.allFromDict}.
+ * the matching namespace: {@link AsyncResult.Ok}, {@link AsyncResult.Err},
+ * {@link AsyncResult.fromPromise}, {@link AsyncResult.fromSafePromise},
+ * {@link AsyncResult.all}, {@link AsyncResult.allFromDict}.
  *
  * @remarks
  * The async sibling of {@link Result}. Statics are grouped by what they
- * **return**, so `fromPromise`/`fromSafePromise` and the async aggregates sit
- * here rather than on {@link Result}; the namespace already conveys "async", so
- * the aggregates drop the `Async` suffix (`AsyncResult.all` is the free function
- * `allAsync`; `AsyncResult.allFromDict` is `allFromDictAsync`). Like
- * {@link Result}, the free functions remain the primary, tree-shakeable API; the
- * value `AsyncResult` and the type {@link AsyncResult} share one name.
+ * **return**, so the pre-lifted constructors, `fromPromise`/`fromSafePromise`,
+ * and the async aggregates sit here rather than on {@link Result}; the namespace
+ * already conveys "async", so the members drop the `Async` suffix their free
+ * functions carry (`AsyncResult.Ok` is `OkAsync`; `AsyncResult.Err` is
+ * `ErrAsync`; `AsyncResult.all` is `allAsync`; `AsyncResult.allFromDict` is
+ * `allFromDictAsync`). Like {@link Result}, the free functions remain the
+ * primary, tree-shakeable API; the value `AsyncResult` and the type
+ * {@link AsyncResult} share one name.
  *
  * @category Facade
  *
@@ -102,6 +104,8 @@ export type Result<T, E> = ResultType<T, E>;
  * ```
  */
 export const AsyncResult = {
+  Ok: OkAsync,
+  Err: ErrAsync,
   fromPromise,
   fromSafePromise,
   all: allAsync,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-export { Err, isDefect, isErr, isOk, Ok } from "./constructors.js";
+export { Err, ErrAsync, isDefect, isErr, isOk, Ok, OkAsync } from "./constructors.js";
 export { isResult, UnwrapError } from "./core.js";
 export { Do } from "./do.js";
 export { AsyncResult, Result } from "./facade.js";

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -17,6 +17,7 @@ import {
   Do,
   type ErrOf,
   Err,
+  ErrAsync,
   type ErrView,
   fromPromise,
   fromThrowable,
@@ -26,6 +27,7 @@ import {
   isResult,
   matchTags,
   Ok,
+  OkAsync,
   type OkOf,
   type Result,
   TaggedError,
@@ -45,6 +47,13 @@ type _ok = Expect<Equal<typeof okV, Result<number, never>>>;
 
 const errV = Err<string>("e");
 type _err = Expect<Equal<typeof errV, Result<never, string>>>;
+
+// pre-lifted async constructors mirror Ok/Err but produce an AsyncResult
+const okAsyncV = OkAsync(1);
+type _okAsync = Expect<Equal<typeof okAsyncV, AsyncResult<number, never>>>;
+
+const errAsyncV = ErrAsync<string>("e");
+type _errAsync = Expect<Equal<typeof errAsyncV, AsyncResult<never, string>>>;
 
 // --- aggregation: `all` keeps positional tuple types -------------------------
 


### PR DESCRIPTION
Closes #75.

## What

Add free functions **`OkAsync(value)`** / **`ErrAsync(error)`** and companion aliases **`AsyncResult.Ok`** / **`AsyncResult.Err`** for building an `AsyncResult` directly from a value — semantically identical to `Ok(value).toAsync()` / `Err(error).toAsync()`, minus the boilerplate.

```ts
function loadItems(ids: string[]): AsyncResult<Item[], never> {
  if (ids.length === 0) return OkAsync([]); // was: Ok([]).toAsync()
  return itemRepository.load(ids);
}
```

The issue reported this as the single most-repeated boilerplate when migrating a ~100-file codebase (`Ok(...).toAsync()` × 54, `Err(...).toAsync()` × 5).

## Naming

The issue floated neverthrow's `okAsync`/`errAsync`. Instead these follow unthrown's **own** async-free-function convention — the `Async` suffix (`allAsync`, `allFromDictAsync`), which the companion drops (`AsyncResult.all`). Applying that rule to the constructors gives `OkAsync → AsyncResult.Ok` for free and preserves the PascalCase constructor casing of `Ok`/`Err` (neverthrow's lowercase would have demoted a constructor and introduced a second async-naming style).

## Changes

- `constructors.ts` — `OkAsync`/`ErrAsync`, fully TSDoc'd.
- `index.ts` / `facade.ts` — exported the free functions and the `AsyncResult.Ok`/`Err` companion aliases.
- Tests — runtime + companion-alias identity (`constructors.spec.ts`); type-level assertions (`types.test-d.ts`).
- Docs — `async-results.md`, `choosing-a-combinator.md`, and `CLAUDE.md` (the spec) kept in sync.
- Changeset — `minor` bump.

## Gate

Typecheck (15/15), 198 tests, 100% line/function coverage, lint, build, and TypeDoc all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)