### PR TITLE
feat(core): add getOrThrow() eliminator

### DIFF
--- a/.changeset/get-or-throw.md
+++ b/.changeset/get-or-throw.md
@@ -1,0 +1,15 @@
+---
+"unthrown": minor
+---
+
+Add the `getOrThrow()` eliminator on `Result` / `AsyncResult`. It completes the
+`getOr…` family (`getOrNull` / `getOrUndefined` / `getOrThrow`): it extracts `T`
+from any `Result<T, E>` — not type-gated like `unwrap()` — and **throws the
+modeled error as-is** on `Err` (panicking on a `Defect`, like the rest of the
+family). On `AsyncResult` it returns a `Promise<T>` that rejects the same way.
+
+This is a deliberate escape hatch off the errors-as-values model: its purpose is
+to move a literal `throw` behind a method, so a `no-throw` lint rule can ban raw
+throws while this one sanctioned extraction remains — the faithful, lint-clean
+form of `.orElse((e) => { throw e }).unwrap()`. Prefer `match` / `recover` /
+`orElse` whenever the error can stay a value.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,14 @@ async work re-enters via `fromPromise` / `fromSafePromise` and composes with
   `unwrapOr<U>(fallback: U): T | U` — widening, not narrowed to `T`), `unwrapOrElse`
   (same `T | U` widening), `getOrNull`, `getOrUndefined` — the `unwrapOr…`/`getOr…`
   family extracts from a still-fallible `Result` with a fallback, since
-  `unwrap`/`unwrapErr` won't compile on it
+  `unwrap`/`unwrapErr` won't compile on it. `getOrThrow` completes the `getOr…`
+  family with a **deliberate escape hatch**: not type-gated, it extracts `T` from
+  any `Result<T, E>` and **throws the modeled `error` as-is** on `Err` (and
+  panics on a `Defect`, like the rest of the family). It exists so a `no-throw`
+  lint rule can ban raw `throw` while this one sanctioned extraction remains — the
+  faithful, lint-clean form of `.orElse((e) => { throw e }).unwrap()`; it is
+  **off the errors-as-values thesis** by design, so reach for `match` / `recover`
+  / `orElse` whenever the error can stay a value
 - guards: methods `isOk`/`isErr`/`isDefect` **and** standalone
   `isOk`/`isErr`/`isDefect` both narrow (to `OkView`/`ErrView`/`DefectView`) — the
   methods are `this is …` type predicates, so `if (r.isErr()) r.error` compiles.

--- a/docs/guide/choosing-a-combinator.md
+++ b/docs/guide/choosing-a-combinator.md
@@ -182,6 +182,11 @@ Reach for an eliminator once you're done chaining:
   needs `Result<never, E>`), and _panicking_ (rethrowing the cause) on a defect.
 - `unwrapOr` / `unwrapOrElse` / `getOrNull` / `getOrUndefined` — recover an `Err`
   to a fallback, but **re-throw a defect** (it's a bug, not an absent value).
+- `getOrThrow` — extract `T`, but **throw the modeled error as-is** on `Err`
+  (panicking on a defect). A deliberate escape hatch off errors-as-values: its
+  point is to move a literal `throw` behind a method so a `no-throw` lint rule can
+  ban raw throws. Prefer `match` / `recover` / `orElse` when the error can stay a
+  value.
 
 On an `AsyncResult` every eliminator returns a `Promise` — `await` it (an `Err` or
 `Defect` still throws/rejects, exactly as above).

--- a/packages/core/src/async-result.spec.ts
+++ b/packages/core/src/async-result.spec.ts
@@ -280,6 +280,11 @@ describe("AsyncResult eliminators", () => {
     await expect(asyncOk(2).getOrNull()).resolves.toBe(2);
   });
 
+  it("getOrThrow resolves the Ok value but rejects with the modeled error on Err", async () => {
+    await expect(asyncOk(2).getOrThrow()).resolves.toBe(2);
+    await expect(asyncErr("e").getOrThrow()).rejects.toBe("e");
+  });
+
   it("a Defect rejects the eliminators with the original cause", async () => {
     await expect(asyncDefect().unwrap()).rejects.toBe(boom);
     // Also type-unreachable (unwrapErr needs T = never; asyncDefect's declared
@@ -291,6 +296,7 @@ describe("AsyncResult eliminators", () => {
     await expect(asyncDefect().unwrapOrElse(() => 0)).rejects.toBe(boom);
     await expect(asyncDefect().getOrNull()).rejects.toBe(boom);
     await expect(asyncDefect().getOrUndefined()).rejects.toBe(boom);
+    await expect(asyncDefect().getOrThrow()).rejects.toBe(boom);
   });
 
   it("Promise.all adopts AsyncResults, settling to Results", async () => {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -283,6 +283,12 @@ class Res<T, E> {
     return undefined;
   }
 
+  getOrThrow(this: Result<T, E>): T {
+    if (this.tag === "Ok") return this.value;
+    if (this.tag === "Defect") throw this.cause;
+    throw this.error;
+  }
+
   isOk(this: Result<T, E>): this is OkView<T, E> {
     return this.tag === "Ok";
   }
@@ -678,5 +684,8 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
   }
   getOrUndefined(): Promise<T | undefined> {
     return this.promise.then((r) => r.getOrUndefined());
+  }
+  getOrThrow(): Promise<T> {
+    return this.promise.then((r) => r.getOrThrow());
   }
 }

--- a/packages/core/src/result.spec.ts
+++ b/packages/core/src/result.spec.ts
@@ -493,9 +493,16 @@ describe("Result eliminators on Ok / Err", () => {
   it("getOrThrow returns the Ok value, throws the modeled error as-is on Err, and panics on a Defect", () => {
     expect(Ok(3).getOrThrow()).toBe(3);
 
-    // Err throws the error value itself (faithful to `.orElse((e) => { throw e })`)
+    // Err throws the error value itself, BY REFERENCE (faithful to
+    // `.orElse((e) => { throw e })`). `toThrow(err)` only matches the message,
+    // so assert identity via try/catch instead.
     const err = new Error("modeled");
-    expect(() => Err(err).getOrThrow()).toThrow(err);
+    try {
+      Err(err).getOrThrow();
+      expect.unreachable();
+    } catch (thrown) {
+      expect(thrown).toBe(err); // same instance, not merely same message
+    }
     // even a non-Error error value is thrown as-is
     try {
       Err("plain").getOrThrow();

--- a/packages/core/src/result.spec.ts
+++ b/packages/core/src/result.spec.ts
@@ -489,6 +489,30 @@ describe("Result eliminators on Ok / Err", () => {
     expect(Ok(3).getOrUndefined()).toBe(3);
     expect(Err("e").getOrUndefined()).toBe(undefined);
   });
+
+  it("getOrThrow returns the Ok value, throws the modeled error as-is on Err, and panics on a Defect", () => {
+    expect(Ok(3).getOrThrow()).toBe(3);
+
+    // Err throws the error value itself (faithful to `.orElse((e) => { throw e })`)
+    const err = new Error("modeled");
+    expect(() => Err(err).getOrThrow()).toThrow(err);
+    // even a non-Error error value is thrown as-is
+    try {
+      Err("plain").getOrThrow();
+      expect.unreachable();
+    } catch (thrown) {
+      expect(thrown).toBe("plain");
+    }
+
+    // a Defect rethrows the ORIGINAL cause with its stack (a panic, like getOrNull)
+    try {
+      defectOf(boom).getOrThrow();
+      expect.unreachable();
+    } catch (thrown) {
+      expect(thrown).toBe(boom);
+      expect((thrown as Error).stack).toBe(boom.stack);
+    }
+  });
 });
 
 describe("Result.toAsync", () => {

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -239,6 +239,11 @@ arFallible.unwrap();
 // @ts-expect-error - async unwrapErr requires T = never
 arFallible.unwrapErr();
 
+// getOrThrow is NOT gated — it compiles on a fallible Result and returns T
+// (it throws the modeled error at runtime instead of eliminating it in the type)
+type _getOrThrow = Expect<Equal<ReturnType<typeof rFallible.getOrThrow>, number>>;
+type _getOrThrowAsync = Expect<Equal<ReturnType<typeof arFallible.getOrThrow>, Promise<number>>>;
+
 // --- extractor types ---------------------------------------------------------
 
 type _okOf = Expect<Equal<OkOf<Result<number, "e">>, number>>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -336,6 +336,24 @@ export type ResultMethods<T, E> = {
    * @throws Re-throws on a `Defect`.
    */
   getOrUndefined(): T | undefined;
+  /**
+   * The success value, or **throw** the modeled error on `Err`.
+   *
+   * @remarks
+   * A deliberate escape hatch off the errors-as-values model. Unlike
+   * {@link ResultMethods.unwrap | unwrap} (type-gated to an empty error
+   * channel), this compiles on any `Result<T, E>` and **throws the `Err` value
+   * as-is** at the call site. Its purpose is to move a literal `throw` behind a
+   * method, so a `no-throw` lint rule can ban raw throws while this one
+   * sanctioned extraction remains — _not_ to replace principled handling. When
+   * you can keep the error a value, prefer {@link ResultMethods.match | match} /
+   * {@link ResultMethods.recover | recover} / {@link ResultMethods.orElse | orElse}.
+   *
+   * @returns the `Ok` value.
+   * @throws the modeled `error` on `Err`; re-throws the original `cause` on a
+   * `Defect` (a panic, like the rest of the `getOr…` family).
+   */
+  getOrThrow(): T;
 
   /** Whether this result is `Ok` — narrows `this` to its {@link OkView} on `true`. */
   isOk(): this is OkView<T, E>;
@@ -623,6 +641,12 @@ export type AsyncResultMethods<T, E> = {
   getOrNull(): Promise<T | null>;
   /** Asynchronous {@link ResultMethods.getOrUndefined | getOrUndefined}. */
   getOrUndefined(): Promise<T | undefined>;
+  /**
+   * Asynchronous {@link ResultMethods.getOrThrow | getOrThrow} — the returned
+   * promise **rejects** with the modeled error on `Err` (or the original cause
+   * on a `Defect`), rather than throwing synchronously.
+   */
+  getOrThrow(): Promise<T>;
 };
 
 /**


### PR DESCRIPTION
## What

Adds **`getOrThrow()`** on `Result` and `AsyncResult`, completing the `getOr…` family:

| method | on `Err` | on `Defect` |
| --- | --- | --- |
| `getOrNull()` | → `null` | panics |
| `getOrUndefined()` | → `undefined` | panics |
| **`getOrThrow()`** | **throws the error as-is** | panics |

Unlike the type-gated `unwrap()` (which needs `Result<T, never>`), `getOrThrow()` compiles on **any** `Result<T, E>`, returns `T`, and throws the modeled `error` value directly on `Err`. On `AsyncResult` it returns `Promise<T>` that rejects the same way (like the async `unwrap`).

## Why

Migrating real codebases (temporal-contract / amqp-contract), the recurring escape hatch was `.orElse((e) => { throw e })` — which, because combinators catch throws, actually promotes `Err → Defect` and then relies on `unwrap()`. The goal is to **ban raw `throw` via a lint rule** while keeping one sanctioned, lint-clean extraction. `getOrThrow()` is exactly the faithful form of `.orElse((e) => { throw e }).unwrap()`, without a literal `throw` in user code.

This is a **deliberate escape hatch off the errors-as-values thesis** — documented as such in the TSDoc, `CLAUDE.md`, and the combinator guide, all pointing to `match` / `recover` / `orElse` as the in-thesis alternatives.

## Changes

- `core.ts` — `getOrThrow` on `Res` (sync) and `AsyncRes` (async).
- `types.ts` — added to `ResultMethods` / `AsyncResultMethods` with honest escape-hatch TSDoc.
- Tests — all three branches sync (`result.spec.ts`), Ok/Err/Defect async (`async-result.spec.ts`), and the not-type-gated `ReturnType` assertions (`types.test-d.ts`).
- Docs — combinator guide eliminator list + `CLAUDE.md` spec.
- Changeset — `minor` bump.

## Gate

Typecheck (incl. type-d), 200 tests, **100% line/function coverage**, lint, TypeDoc (warning-free), and build all green. The only `format`/`knip` failures in the repo are pre-existing, in untracked `packages/prisma/` — untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)