### PR TITLE
refactor(core): rename operators for channel-suffix consistency

### DIFF
--- a/.changeset/get-or-throw.md
+++ b/.changeset/get-or-throw.md
@@ -4,12 +4,12 @@
 
 Add the `getOrThrow()` eliminator on `Result` / `AsyncResult`. It completes the
 `getOr…` family (`getOrNull` / `getOrUndefined` / `getOrThrow`): it extracts `T`
-from any `Result<T, E>` — not type-gated like `unwrap()` — and **throws the
+from any `Result<T, E>` — not type-gated like `get()` — and **throws the
 modeled error as-is** on `Err` (panicking on a `Defect`, like the rest of the
 family). On `AsyncResult` it returns a `Promise<T>` that rejects the same way.
 
 This is a deliberate escape hatch off the errors-as-values model: its purpose is
 to move a literal `throw` behind a method, so a `no-throw` lint rule can ban raw
 throws while this one sanctioned extraction remains — the faithful, lint-clean
-form of `.orElse((e) => { throw e }).unwrap()`. Prefer `match` / `recover` /
-`orElse` whenever the error can stay a value.
+form of `.flatMapErr((e) => { throw e }).get()`. Prefer `match` / `recoverErr` /
+`flatMapErr` whenever the error can stay a value.

--- a/.changeset/rename-operators.md
+++ b/.changeset/rename-operators.md
@@ -1,0 +1,19 @@
+---
+"unthrown": minor
+---
+
+Rename several operators for channel-suffix consistency, keeping the old names as
+**deprecated, runtime-identical aliases** (no breaking change; the aliases are
+slated for removal in a future major):
+
+- `orElse` → **`flatMapErr`** — it is `flatMap` on the error channel, so it now
+  follows the `…Err` convention (like `mapErr` / `flatTapErr`).
+- `recover` → **`recoverErr`** — pairs with `recoverDefect`.
+- The extractor family unifies under `get…`: `unwrap` → **`get`**, `unwrapErr` →
+  **`getErr`**, `unwrapOr` → **`getOr`**, `unwrapOrElse` → **`getOrElse`** (joining
+  the existing `getOrNull` / `getOrUndefined` / `getOrThrow`).
+
+Both `Result` and `AsyncResult` gain the new names; each deprecated alias just
+delegates to its replacement (the gated `unwrap`/`unwrapErr` keep their `this`
+type-gate). Editors will surface the old names with a deprecation strike-through
+and point at the replacement.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ qualification when crossing async boundaries; `effect` is too heavy and conflate
 error handling with context, runtime, etc. `unthrown` does one thing.
 
 The name states the concern: ordinary errors are _unthrown_ — returned as values,
-not flung up the stack. Only a true defect ever throws (at `unwrap`).
+not flung up the stack. Only a true defect ever throws (at `get`).
 
 This file is the authoritative spec — the rules _and_ the reasoning behind them.
 Keep it in sync with the code as the library evolves (describe what _is_, not what
@@ -57,14 +57,14 @@ was planned).
 ## Load-bearing runtime invariants (tests must guard these)
 
 - **Throw → defect.** Any value thrown by a callback inside a combinator
-  (`map`, `flatMap`, `flatTap`, `bind`, `let`, `mapErr`, `orElse`, `recover`,
+  (`map`, `flatMap`, `flatTap`, `bind`, `let`, `mapErr`, `flatMapErr`, `recoverErr`,
   `tap*`, `flatTapErr`, `recoverDefect`) is caught and converted to a `Defect`. Nothing
   escapes a pipeline as a raw throw.
   This is what lets an HTTP adapter do a single `match({ ok, err, defect })`
   with **no surrounding `try/catch`**.
 - **A `Defect` flows through every method untouched EXCEPT `match()`,
   `recoverDefect()`, and `tapDefect()` (which observes it without consuming
-  it).** Therefore `unwrapOr`, `unwrapOrElse`, `getOrNull`, `getOrUndefined`
+  it).** Therefore `getOr`, `getOrElse`, `getOrNull`, `getOrUndefined`
   still **throw** on a `Defect` — they recover the modeled `Err`, never an
   unmodeled defect (a defect is a bug, not an absent value).
 - **A failure-observer throw preserves the original failure.** A throw inside
@@ -73,7 +73,7 @@ was planned).
   (A throw in the success-channel `tap`/`map` keeps the plain thrown cause.)
 - **Thenable callback returns are rejected at compile time.** Every combinator
   callback not already constrained to return a `Result` (`map`, `tap*`, `let`,
-  `mapErr`, `recover`) intersects its return with `NotThenable<R>` — an `async`
+  `mapErr`, `recoverErr`) intersects its return with `NotThenable<R>` — an `async`
   callback is a compile error, because its rejection would bypass
   qualification. `match` handlers are deliberately exempt (edge elimination).
 - **Result instances are frozen.** `okRes`/`errRes`/`defectRes` return
@@ -83,17 +83,17 @@ was planned).
   (widened cast, JS caller) an unknown or reserved (`"Ok"`/`"Defect"`) `_tag`
   routes to the `Defect` handler; reserved tags in `E` are additionally a
   compile error.
-- **`unwrap()` / `unwrapErr()` are type-gated.** `unwrap()` compiles only when the
-  error channel is empty (`this: Result<T, never>`); `unwrapErr()` only when the
+- **`get()` / `getErr()` are type-gated.** `get()` compiles only when the
+  error channel is empty (`this: Result<T, never>`); `getErr()` only when the
   success channel is empty (`this: Result<never, E>`). Eliminate the opposite
-  channel first (`match` / `recover` / `orElse`), or use the `unwrapOr` /
-  `unwrapOrElse` / `getOrNull` / `getOrUndefined` family (which recover an `Err`).
+  channel first (`match` / `recoverErr` / `flatMapErr`), or use the `getOr` /
+  `getOrElse` / `getOrNull` / `getOrUndefined` family (which recover an `Err`).
   On a `Defect` they still **rethrow the original `cause`** (they _panic_) with its
   original stack — so `Result<T, never>` means the modeled error channel is empty,
-  **not** that `unwrap()` cannot throw. The `UnwrapError`-on-wrong-variant branch
+  **not** that `get()` cannot throw. The `UnwrapError`-on-wrong-variant branch
   remains at runtime as a defensive guard but is **unreachable through well-typed
   code** (only a cast or a raw-JS caller can reach it).
-- **`recover` returns `Result<T | U, never>`, and `never` means only the _error_
+- **`recoverErr` returns `Result<T | U, never>`, and `never` means only the _error_
   channel is empty — a `Defect` can still be present at runtime.** This is the one
   place the type intentionally under-describes the runtime. Do not read `never`
   as "total".
@@ -127,24 +127,31 @@ async work re-enters via `fromPromise` / `fromSafePromise` and composes with
   pure value). On `AsyncResult`, `bind`'s `f` may return a `Result` or an
   `AsyncResult`. A throw in either becomes a `Defect`; `Err`/`Defect`
   short-circuits/passes through. To go async, lift with `toAsync()`.
-- error: `mapErr`, `orElse`, `recover`, `tapErr`, `flatTapErr` (the error-channel
+- error: `mapErr`, `flatMapErr`, `recoverErr`, `tapErr`, `flatTapErr` (the error-channel
   mirror of `flatTap` — runs a `Result`-returning effect on the error, keeps the
   original error, threads the effect's error)
 - defect: `recoverDefect`, `tapDefect`
-- eliminate: `match`, `unwrap`/`unwrapErr` (type-gated — `unwrap` only compiles on
-  `Result<T, never>`, `unwrapErr` only on `Result<never, E>`; use `match` /
-  `recover` / `orElse` to empty the opposite channel first), `unwrapOr` (signature
-  `unwrapOr<U>(fallback: U): T | U` — widening, not narrowed to `T`), `unwrapOrElse`
-  (same `T | U` widening), `getOrNull`, `getOrUndefined` — the `unwrapOr…`/`getOr…`
+- eliminate: `match`, `get`/`getErr` (type-gated — `get` only compiles on
+  `Result<T, never>`, `getErr` only on `Result<never, E>`; use `match` /
+  `recoverErr` / `flatMapErr` to empty the opposite channel first), `getOr` (signature
+  `getOr<U>(fallback: U): T | U` — widening, not narrowed to `T`), `getOrElse`
+  (same `T | U` widening), `getOrNull`, `getOrUndefined` — the `getOr…`
   family extracts from a still-fallible `Result` with a fallback, since
-  `unwrap`/`unwrapErr` won't compile on it. `getOrThrow` completes the `getOr…`
+  `get`/`getErr` won't compile on it. `getOrThrow` completes the `getOr…`
   family with a **deliberate escape hatch**: not type-gated, it extracts `T` from
   any `Result<T, E>` and **throws the modeled `error` as-is** on `Err` (and
   panics on a `Defect`, like the rest of the family). It exists so a `no-throw`
   lint rule can ban raw `throw` while this one sanctioned extraction remains — the
-  faithful, lint-clean form of `.orElse((e) => { throw e }).unwrap()`; it is
-  **off the errors-as-values thesis** by design, so reach for `match` / `recover`
-  / `orElse` whenever the error can stay a value
+  faithful, lint-clean form of `.flatMapErr((e) => { throw e }).get()`; it is
+  **off the errors-as-values thesis** by design, so reach for `match` / `recoverErr`
+  / `flatMapErr` whenever the error can stay a value
+- deprecated aliases: the error/eliminate operators were renamed for channel-suffix
+  consistency (success `map`/`flatMap` ↔ error `mapErr`/`flatMapErr`; the extractor
+  family unified under `get…`). The old names remain as **deprecated, runtime-identical
+  aliases** — one concept, not a second: `orElse` → `flatMapErr`, `recover` →
+  `recoverErr`, `unwrap` → `get`, `unwrapErr` → `getErr`, `unwrapOr` → `getOr`,
+  `unwrapOrElse` → `getOrElse`. Each alias just delegates to its replacement (the
+  gated `unwrap`/`unwrapErr` keep their `this` gate); slated for removal in a future major.
 - guards: methods `isOk`/`isErr`/`isDefect` **and** standalone
   `isOk`/`isErr`/`isDefect` both narrow (to `OkView`/`ErrView`/`DefectView`) — the
   methods are `this is …` type predicates, so `if (r.isErr()) r.error` compiles.
@@ -370,7 +377,7 @@ configured outside the repo).
   enforced by thresholds in its `vitest.config.ts`.
 - **Type-level tests:** `packages/core/src/types.test-d.ts` asserts the
   type-level behaviour the runtime can't (the conditional `all`/`allFromDict`
-  shapes, `Exclude<R, Defect>` boundary inference, `flatTap`/`recover` channel
+  shapes, `Exclude<R, Defect>` boundary inference, `flatTap`/`recoverErr` channel
   widening, the `this is …` guard narrowing, `matchTags` exhaustiveness) with a
   `Expect<Equal<…>>` helper plus `@ts-expect-error` for must-not-compile cases.
   They are checked by `tsc` via `tsconfig.test-d.json` (which relaxes

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 </div>
 
 Ordinary errors are _unthrown_ — returned as values, not flung up the stack.
-Only a true defect ever throws, and only at `unwrap`.
+Only a true defect ever throws, and only at `get`.
 
 ## Why unthrown?
 

--- a/docs/guide/async-results.md
+++ b/docs/guide/async-results.md
@@ -11,7 +11,7 @@ value or error — directly with `OkAsync` / `ErrAsync`.
 import { fromSafePromise } from "unthrown";
 
 const result = await fromSafePromise(Promise.resolve(1)).map((n) => n + 1);
-result.unwrap(); // => 2
+result.get(); // => 2
 ```
 
 `OkAsync(value)` / `ErrAsync(error)` are the pre-lifted constructors — exactly
@@ -47,9 +47,9 @@ not interchangeable with a raw promise.
 > `Result` you get back.
 
 ::: warning Eliminators still reject on a Defect
-The async eliminators reject when they hit a `Defect`: `await result.unwrap()`
-rethrows the defect's cause, just like the synchronous `unwrap()`. (Like its sync
-form, `unwrap()` is type-gated — it compiles only when the error channel is
+The async eliminators reject when they hit a `Defect`: `await result.get()`
+rethrows the defect's cause, just like the synchronous `get()`. (Like its sync
+form, `get()` is type-gated — it compiles only when the error channel is
 `never` — so in well-typed code an `Err` can't reach it; a `Defect` is the only
 rejection you'll see.) It is the _internal_ promise — the one `await result`
 resolves — that never rejects.
@@ -64,7 +64,7 @@ This is the rule that keeps qualification honest:
 If `.map(async …)` were allowed, a rejection inside that callback would silently
 become a defect — an un-qualified async boundary, exactly what the library exists
 to prevent. So combinator callbacks are synchronous, and the binds (`flatMap`,
-`orElse`, `recoverDefect`) accept a `Result` or an `AsyncResult`, but never a raw
+`flatMapErr`, `recoverDefect`) accept a `Result` or an `AsyncResult`, but never a raw
 promise.
 
 To do more async work, re-enter through a qualified boundary and compose it with

--- a/docs/guide/choosing-a-combinator.md
+++ b/docs/guide/choosing-a-combinator.md
@@ -23,8 +23,8 @@ the API reference.
 ## By intent
 
 The `→ Result<…>` half of each signature is the tell — it shows how the combinator
-moves the channels: `flatMap` widens `E` to `E | E2`, `recover` empties it to
-`never`, `orElse` widens the value to `T | U`.
+moves the channels: `flatMap` widens `E` to `E | E2`, `recoverErr` empties it to
+`never`, `flatMapErr` widens the value to `T | U`.
 
 | I want to…                                     | use               | signature                                                    | channel |
 | ---------------------------------------------- | ----------------- | ------------------------------------------------------------ | ------- |
@@ -35,8 +35,8 @@ moves the channels: `flatMap` widens `E` to `E | E2`, `recover` empties it to
 | sequence steps into a named scope              | `Do`/`bind`/`let` | `bind(k, (scope) => Result<U, E2>)` → `Result<{…}, E \| E2>` | Ok      |
 | replace the value with a constant              | `as`              | `(value: U)` → `Result<U, E>`                                | Ok      |
 | transform the error                            | `mapErr`          | `(e: E) => E2` → `Result<T, E2>`                             | Err     |
-| try a fallback that returns a `Result`         | `orElse`          | `(e: E) => Result<U, E2>` → `Result<T \| U, E2>`             | Err     |
-| turn an error into a success value             | `recover`         | `(e: E) => U` → `Result<T \| U, never>`                      | Err     |
+| try a fallback that returns a `Result`         | `flatMapErr`      | `(e: E) => Result<U, E2>` → `Result<T \| U, E2>`             | Err     |
+| turn an error into a success value             | `recoverErr`      | `(e: E) => U` → `Result<T \| U, never>`                      | Err     |
 | run a side effect on the error                 | `tapErr`          | `(e: E) => void` → `Result<T, E>`                            | Err     |
 | run a **failable** side effect on the error    | `flatTapErr`      | `(e: E) => Result<unknown, E2>` → `Result<T, E \| E2>`       | Err     |
 | recover from a defect (rare)                   | `recoverDefect`   | `(cause) => Result<U, E2>` → `Result<T \| U, E \| E2>`       | Defect  |
@@ -58,15 +58,15 @@ invariant to remember:
 | `flatMap`               | runs `f` | passes ▸        | passes ▸    | `E \| E2`       |
 | `tap` / `flatTap`       | runs `f` | passes ▸        | passes ▸    | `E` / `E \| E2` |
 | `mapErr`                | passes ▸ | runs `f`        | passes ▸    | `E2`            |
-| `orElse`                | passes ▸ | runs `f`        | passes ▸    | `E2`            |
-| `recover`               | passes ▸ | runs `f` → `Ok` | passes ▸    | `never`         |
+| `flatMapErr`            | passes ▸ | runs `f`        | passes ▸    | `E2`            |
+| `recoverErr`            | passes ▸ | runs `f` → `Ok` | passes ▸    | `never`         |
 | `tapErr` / `flatTapErr` | passes ▸ | runs `f`        | passes ▸    | `E` / `E \| E2` |
 | `recoverDefect`         | passes ▸ | passes ▸        | runs `f`    | `E \| E2`       |
 | `tapDefect`             | passes ▸ | passes ▸        | runs `f`    | `E`             |
 | `match`                 | `ok()`   | `err()`         | `defect()`  | —               |
 
-::: tip `recover`'s `never` under-describes the runtime
-`recover` empties only the **error** channel to `never` — a `Defect` can still be
+::: tip `recoverErr`'s `never` under-describes the runtime
+`recoverErr` empties only the **error** channel to `never` — a `Defect` can still be
 present at runtime and flows past it untouched. See
 [The Defect Channel](./the-defect-channel).
 :::
@@ -82,11 +82,11 @@ exactly three ways:
   that would skip qualification and silently become a defect. Do async work by
   re-entering a boundary and composing it with `flatMap`.
 - **The `Result`-returning combinators accept `Result` _or_ `AsyncResult`.**
-  `flatMap`, `flatTap`, `orElse`, `flatTapErr`, `bind`, and `recoverDefect` take a
+  `flatMap`, `flatTap`, `flatMapErr`, `flatTapErr`, `bind`, and `recoverDefect` take a
   callback returning either, so you can freely mix sync and async steps in one
   chain.
 - **Eliminators return a `Promise`.** `await result.match({ … })` /
-  `await result.unwrap()` — or `await` the `AsyncResult` first to collapse it to a
+  `await result.get()` — or `await` the `AsyncResult` first to collapse it to a
   `Result`, then match synchronously.
 
 Use this table to move between the two:
@@ -164,28 +164,28 @@ otherwise the same effect ends up `tap`ped at one site and `flatTap`ped at
 another, and a reviewer has to guess which one is the bug.
 :::
 
-**`orElse` vs `recover`** — both run on `Err`. `recover` produces a plain success
-value (emptying the error channel to `never`); `orElse` produces another `Result`
+**`flatMapErr` vs `recoverErr`** — both run on `Err`. `recoverErr` produces a plain success
+value (emptying the error channel to `never`); `flatMapErr` produces another `Result`
 (which may still be an `Err`).
 
-**`recover` vs `recoverDefect`** — `recover` handles a modeled `Err`;
+**`recoverErr` vs `recoverDefect`** — `recoverErr` handles a modeled `Err`;
 `recoverDefect` is the **only** combinator that can touch a `Defect`. Neither is
-the other's fallback — a defect flows past `recover` untouched.
+the other's fallback — a defect flows past `recoverErr` untouched.
 
 ## When to leave the pipeline
 
 Reach for an eliminator once you're done chaining:
 
 - `match` — the default at the edge; fold all three channels into one value.
-- `unwrap` / `unwrapErr` — extract; type-gated to compile only when the
-  opposite channel is `never` (`unwrap` needs `Result<T, never>`, `unwrapErr`
+- `get` / `getErr` — extract; type-gated to compile only when the
+  opposite channel is `never` (`get` needs `Result<T, never>`, `getErr`
   needs `Result<never, E>`), and _panicking_ (rethrowing the cause) on a defect.
-- `unwrapOr` / `unwrapOrElse` / `getOrNull` / `getOrUndefined` — recover an `Err`
+- `getOr` / `getOrElse` / `getOrNull` / `getOrUndefined` — recover an `Err`
   to a fallback, but **re-throw a defect** (it's a bug, not an absent value).
 - `getOrThrow` — extract `T`, but **throw the modeled error as-is** on `Err`
   (panicking on a defect). A deliberate escape hatch off errors-as-values: its
   point is to move a literal `throw` behind a method so a `no-throw` lint rule can
-  ban raw throws. Prefer `match` / `recover` / `orElse` when the error can stay a
+  ban raw throws. Prefer `match` / `recoverErr` / `flatMapErr` when the error can stay a
   value.
 
 On an `AsyncResult` every eliminator returns a `Promise` — `await` it (an `Err` or

--- a/docs/guide/core-concepts.md
+++ b/docs/guide/core-concepts.md
@@ -26,9 +26,9 @@ Every `Result` shares one method surface, grouped by the channel it touches:
 - **success** (runs on `Ok`): `map`, `flatMap`, `tap`, `flatTap`, `as`
 - **do-notation** (runs on `Ok`): `bind`, `let` — accumulate a named scope; see
   [Do Notation](./do-notation)
-- **error** (runs on `Err`): `mapErr`, `orElse`, `recover`, `tapErr`, `flatTapErr`
+- **error** (runs on `Err`): `mapErr`, `flatMapErr`, `recoverErr`, `tapErr`, `flatTapErr`
 - **defect** (the only door to a `Defect`): `recoverDefect`, `tapDefect`
-- **eliminate**: `match`, `unwrap`, `unwrapErr`, `unwrapOr`, `unwrapOrElse`,
+- **eliminate**: `match`, `get`, `getErr`, `getOr`, `getOrElse`,
   `getOrNull`, `getOrUndefined`
 
 A combinator only runs its callback on its own channel — the other states flow
@@ -118,14 +118,14 @@ matched.
 Once you are ready to leave the `Result` world, pick the right exit:
 
 ```ts
-Ok(1).unwrap(); // => 1         — panics on a Defect (Err doesn't compile here)
-Err("e").unwrapErr(); // => "e" — panics on a Defect (Ok doesn't compile here)
-Err("e").unwrapOr(0); // => 0   — recovers an Err; rethrows a Defect
+Ok(1).get(); // => 1         — panics on a Defect (Err doesn't compile here)
+Err("e").getErr(); // => "e" — panics on a Defect (Ok doesn't compile here)
+Err("e").getOr(0); // => 0   — recovers an Err; rethrows a Defect
 Err("e").getOrNull(); // => null — recovers an Err; rethrows a Defect
 Ok(1).match({ ok, err, defect }); // fold all three channels
 ```
 
-`unwrapOr`, `unwrapOrElse`, `getOrNull`, and `getOrUndefined` recover a modeled
+`getOr`, `getOrElse`, `getOrNull`, and `getOrUndefined` recover a modeled
 `Err` but **rethrow a `Defect`** — a defect is a bug, not an absent value. See
 [The Defect Channel](./the-defect-channel).
 
@@ -139,8 +139,8 @@ earlier `Err`). A fixed tuple keeps its positional types; a dynamic
 ```ts
 import { all, Ok, type Result } from "unthrown";
 
-all([Ok(1), Ok("two"), Ok(true)]).unwrap(); // => [1, "two", true] (typed [number, string, boolean])
-all([Ok(1), Ok(2)] as Result<number, never>[]).unwrap(); // => number[]
+all([Ok(1), Ok("two"), Ok(true)]).get(); // => [1, "two", true] (typed [number, string, boolean])
+all([Ok(1), Ok(2)] as Result<number, never>[]).get(); // => number[]
 ```
 
 For **named** parallel work, `allFromDict` takes a record instead — same rules,
@@ -149,7 +149,7 @@ no tupling:
 ```ts
 import { allFromDict, Ok } from "unthrown";
 
-allFromDict({ id: Ok(1), name: Ok("ada") }).unwrap(); // => { id: 1, name: "ada" }
+allFromDict({ id: Ok(1), name: Ok("ada") }).get(); // => { id: 1, name: "ada" }
 ```
 
 Both short-circuit on the first `Err` — this is **not** error accumulation. If
@@ -163,7 +163,7 @@ folding rules, inputs resolved concurrently (order preserved), and (like every
 ```ts
 import { allAsync, fromSafePromise } from "unthrown";
 
-const [a, b] = (await allAsync([fromSafePromise(loadA()), fromSafePromise(loadB())])).unwrap();
+const [a, b] = (await allAsync([fromSafePromise(loadA()), fromSafePromise(loadB())])).get();
 ```
 
 → Continue to [The Defect Channel](./the-defect-channel).

--- a/docs/guide/from-try-catch.md
+++ b/docs/guide/from-try-catch.md
@@ -41,7 +41,7 @@ The call site drops its `try`/`catch` for a combinator:
 
 ```ts
 function loadConfig(text: string): Config {
-  return parseConfig(text).unwrapOr(DEFAULT_CONFIG);
+  return parseConfig(text).getOr(DEFAULT_CONFIG);
 }
 ```
 
@@ -91,21 +91,21 @@ user.match({
 
 `Result` composes at whatever boundary you choose to draw it — there's no
 requirement that every function up and down the call stack returns one.
-`unwrap()` exists precisely so you can re-enter throw-land at the edges you
+`get()` exists precisely so you can re-enter throw-land at the edges you
 haven't converted yet, on purpose:
 
 ```ts
 // Only the read is converted. Everything downstream still expects a plain
-// Config, or a thrown error — and that's fine, unwrap() is the deliberate seam.
+// Config, or a thrown error — and that's fine, get() is the deliberate seam.
 function loadConfig(text: string): Config {
-  return parseConfig(text).unwrap(); // throws UnwrapError("invalid_json") on bad input
+  return parseConfig(text).get(); // throws UnwrapError("invalid_json") on bad input
 }
 ```
 
 Convert the parts of the codebase where an untyped failure actually costs you
 something — a boundary you keep getting wrong, a `catch` block that silently
 swallows a bug. Leave the rest throwing until it earns the conversion. A
-`Result` two layers deep in a call chain that's `unwrap()`'d immediately by
+`Result` two layers deep in a call chain that's `get()`'d immediately by
 its only caller isn't buying you anything yet.
 
 ## `try`/`catch` idioms → combinators
@@ -115,7 +115,7 @@ block has a direct combinator equivalent:
 
 | `try`/`catch` idiom       | unthrown combinator                             | Example                                               |
 | ------------------------- | ----------------------------------------------- | ----------------------------------------------------- |
-| catch-and-default         | `unwrapOr(fallback)`                            | `parseConfig(text).unwrapOr(DEFAULT_CONFIG)`          |
+| catch-and-default         | `getOr(fallback)`                               | `parseConfig(text).getOr(DEFAULT_CONFIG)`             |
 | catch-and-rethrow-wrapped | `mapErr(f)`                                     | `parseConfig(text).mapErr((e) => new ConfigError(e))` |
 | catch-log-rethrow         | `tapErr(f)`                                     | `parseConfig(text).tapErr((e) => logger.warn(e))`     |
 | `finally` cleanup         | run before eliminating, or in every `match` arm | see below                                             |
@@ -130,7 +130,7 @@ try {
   return DEFAULT_CONFIG;
 }
 // after
-parseConfig(text).unwrapOr(DEFAULT_CONFIG);
+parseConfig(text).getOr(DEFAULT_CONFIG);
 ```
 
 `catch-and-rethrow-wrapped`:

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -57,8 +57,8 @@ can chain without checking at every step:
 parseAge("42")
   .map((n) => n + 1) // => Ok(43)   — map: callback returns a plain value
   .flatMap((n) => (n >= 18 ? Ok(n) : Err("underage"))) // => Ok(43) — flatMap: callback returns a Result
-  .unwrapOrElse((e) => {
-    throw new Error(e); // eliminate the error channel first — unwrap() needs E = never
+  .getOrElse((e) => {
+    throw new Error(e); // eliminate the error channel first — get() needs E = never
   }); // => 43
 // the error type widens to AgeError | "underage" — flatMap unions the channels
 ```

--- a/docs/guide/migrating-from-neverthrow.md
+++ b/docs/guide/migrating-from-neverthrow.md
@@ -13,9 +13,9 @@ search-and-replace.
 | `ok(v)` / `err(e)`                   | `Ok(v)` / `Err(e)`           | constructors are capitalized                                        |
 | `result.andThen(f)`                  | `result.flatMap(f)`          | one name per concept                                                |
 | `result.map(f)` / `mapErr(f)`        | same                         | callbacks must be synchronous                                       |
-| `result.orElse(f)`                   | `orElse(f)`                  | same shape                                                          |
+| `result.orElse(f)`                   | `result.flatMapErr(f)`       | `flatMap` on the error channel (`orElse` is a deprecated alias)     |
 | `result.match(okFn, errFn)`          | `match({ ok, err, defect })` | the third channel is new — see below                                |
-| `result.unwrapOr(v)`                 | `unwrapOr(v)`                | still throws on a Defect (a bug is not an absent value)             |
+| `result.unwrapOr(v)`                 | `result.getOr(v)`            | still throws on a Defect (a bug is not an absent value)             |
 | `ResultAsync`                        | `AsyncResult`                | `await` collapses it to a `Result`; it never rejects                |
 | `ResultAsync.fromPromise(p, mapErr)` | `fromPromise(p, qualify)`    | `qualify` must return `E` **or** `defect(cause)` — triage is forced |
 | `ResultAsync.fromSafePromise(p)`     | `fromSafePromise(p)`         | a rejection becomes a `Defect`, not an `Err`                        |

--- a/docs/guide/the-defect-channel.md
+++ b/docs/guide/the-defect-channel.md
@@ -36,19 +36,19 @@ const d = Ok(1).map(() => {
 
 d.map((n) => n + 1); // still a Defect — callback skipped
 d.mapErr((e) => e); // still a Defect — callback skipped
-d.recover(() => 0); // still a Defect — see below
+d.recoverErr(() => 0); // still a Defect — see below
 ```
 
 That last line is the crucial one.
 
-## `recover` clears the error channel, not the runtime
+## `recoverErr` clears the error channel, not the runtime
 
-`recover` turns an `Err` into an `Ok`, so its type is `Result<T | U, never>`. But
+`recoverErr` turns an `Err` into an `Ok`, so its type is `Result<T | U, never>`. But
 `never` describes only the **error** channel — a defect can still be present at
 runtime:
 
 ```ts
-const recovered = d.recover(() => 99);
+const recovered = d.recoverErr(() => 99);
 // type: Result<number, never>
 recovered.isDefect(); // => true — `never` does NOT mean "total"
 ```
@@ -57,39 +57,39 @@ A defect is a bug; you should not be able to accidentally "recover" it into a
 success. So the recovering eliminators **rethrow** on a defect:
 
 ```ts
-d.unwrapOr(0); // throws the original cause
+d.getOr(0); // throws the original cause
 d.getOrNull(); // throws the original cause
-d.unwrapOrElse(() => 0); // throws the original cause
+d.getOrElse(() => 0); // throws the original cause
 ```
 
 They recover a modeled `Err`, never an unmodeled defect.
 
-::: warning `unwrapOr` / `getOrNull` still throw on a defect
-It's tempting to read `unwrapOr(0)` as "always give me a value." It doesn't — it
+::: warning `getOr` / `getOrNull` still throw on a defect
+It's tempting to read `getOr(0)` as "always give me a value." It doesn't — it
 supplies the fallback for a modeled `Err` but **rethrows a defect** (a bug is not
 an absent value). If you must not throw, handle the defect explicitly first with
 `match` or `recoverDefect`.
 :::
 
-## `unwrap` is asymmetric
+## `get` is asymmetric
 
-`unwrap()` / `unwrapErr()` are **type-gated**: `unwrap()` only compiles when the
-error channel is `never` (`Result<T, never>`), `unwrapErr()` only when the success
-channel is `never` (`Result<never, E>`). Calling `.unwrap()` on a still-fallible
+`get()` / `getErr()` are **type-gated**: `get()` only compiles when the
+error channel is `never` (`Result<T, never>`), `getErr()` only when the success
+channel is `never` (`Result<never, E>`). Calling `.get()` on a still-fallible
 `Result<T, E>` is a compile error, not a runtime throw — so the `Err` case can't
 reach either eliminator in well-typed code. The remaining wrong-variant throw
 (`UnwrapError`) is a defensive runtime guard for unsound edges (e.g. a cast), not
 something you should hit normally.
 
 A `Defect`, though, is invisible to the type system — `never` on the error
-channel says nothing about it (see above). So on a `Defect`, `unwrap()` /
-`unwrapErr()` **rethrow the original cause** with its original stack — so an
+channel says nothing about it (see above). So on a `Defect`, `get()` /
+`getErr()` **rethrow the original cause** with its original stack — so an
 unhandled defect reaches the global handler looking like the real failure, not
 wrapped in library noise.
 
 ```ts
 try {
-  d.unwrap();
+  d.get();
 } catch (e) {
   e === boom; // true — same instance, original stack
 }

--- a/docs/guide/why-unthrown.md
+++ b/docs/guide/why-unthrown.md
@@ -5,7 +5,7 @@ values**, with a separate **defect channel** for the unexpected.
 
 The name states the concern: ordinary errors are _unthrown_ — returned as
 values, not flung up the stack. Only a true defect ever throws, and only at
-`unwrap`.
+`get`.
 
 ## The problem with throwing
 
@@ -52,7 +52,7 @@ disagreed.
 the type**. `Result<T, E>` exposes only your anticipated errors in `E`. Anything
 unexpected becomes a defect that short-circuits to the edge, where you log it and
 return a 500. A defect can only be observed by `match` or `recoverDefect`; it is
-never silently recovered by `unwrapOr`, `getOrNull`, or `recover`.
+never silently recovered by `getOr`, `getOrNull`, or `recoverErr`.
 
 Two more deliberate choices follow from this:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ hero:
 features:
   - icon: { src: /icons/target.svg }
     title: Errors as values
-    details: Ordinary errors are returned in a Result<T, E>, not thrown. Only a true defect ever throws — and only at unwrap.
+    details: Ordinary errors are returned in a Result<T, E>, not thrown. Only a true defect ever throws — and only at get().
   - icon: { src: /icons/channels.svg }
     title: A separate defect channel
     details: Unmodeled failures become a Defect — a third runtime state invisible to the type. A bug in a .map can't masquerade as a domain error.

--- a/packages/core/src/aggregate.spec.ts
+++ b/packages/core/src/aggregate.spec.ts
@@ -22,7 +22,7 @@ const defectOf = (cause: unknown): Result<number, never> =>
 describe("all", () => {
   it("collects a tuple of Ok values, preserving positional types", () => {
     const r = all([Ok(1), Ok("two"), Ok(true)]);
-    expect(r.unwrap()).toEqual([1, "two", true]);
+    expect(r.get()).toEqual([1, "two", true]);
   });
 
   it("returns Ok([]) for an empty tuple, typed as the empty tuple (not never[])", () => {
@@ -30,7 +30,7 @@ describe("all", () => {
     // Compiles only if the empty input keeps tuple typing `Result<[], never>`
     // rather than collapsing to `Result<never[], never>`.
     const empty: Result<[], never> = r;
-    expect(empty.unwrap()).toEqual([]);
+    expect(empty.get()).toEqual([]);
   });
 
   it("short-circuits on the first Err", () => {
@@ -50,7 +50,7 @@ describe("all", () => {
   it("keeps the first Defect when several are present", () => {
     const first = new Error("first");
     const r = all([defectOf(first), defectOf(new Error("second"))]);
-    expect(r.recoverDefect((c) => Ok(c === first)).unwrap()).toBe(true);
+    expect(r.recoverDefect((c) => Ok(c === first)).get()).toBe(true);
   });
 
   it("collapses a dynamic Result[] to Result<T[], E> without a cast", () => {
@@ -70,7 +70,7 @@ describe("allFromDict", () => {
   it("collects a record of Ok values into a record, keyed by name", () => {
     const r = allFromDict({ id: Ok(1), name: Ok("ada"), admin: Ok(true) });
     // Typed `Result<{ id: number; name: string; admin: boolean }, never>`.
-    const value: { id: number; name: string; admin: boolean } = r.unwrap();
+    const value: { id: number; name: string; admin: boolean } = r.get();
     expect(value).toEqual({ id: 1, name: "ada", admin: true });
   });
 
@@ -86,7 +86,7 @@ describe("allFromDict", () => {
   });
 
   it("returns Ok({}) for an empty record", () => {
-    expect(allFromDict({}).unwrap()).toEqual({});
+    expect(allFromDict({}).get()).toEqual({});
   });
 
   it("does not let a `__proto__` key pollute the prototype", () => {
@@ -104,11 +104,11 @@ describe("allAsync", () => {
       fromSafePromise(Promise.resolve("two")),
       fromSafePromise(Promise.resolve(true)),
     ]);
-    expect(r.unwrap()).toEqual([1, "two", true]);
+    expect(r.get()).toEqual([1, "two", true]);
   });
 
   it("returns Ok([]) for an empty input", async () => {
-    expect((await allAsync([])).unwrap()).toEqual([]);
+    expect((await allAsync([])).get()).toEqual([]);
   });
 
   it("short-circuits on the first Err", async () => {
@@ -142,7 +142,7 @@ describe("allAsync", () => {
       fromSafePromise(Promise.resolve(1)),
       fromSafePromise(Promise.resolve(2)),
     ]);
-    expect(r.unwrap()).toEqual([1, 2]);
+    expect(r.get()).toEqual([1, 2]);
   });
 });
 
@@ -152,7 +152,7 @@ describe("allFromDictAsync", () => {
       id: fromSafePromise(Promise.resolve(1)),
       name: fromSafePromise(Promise.resolve("ada")),
     });
-    const value: { id: number; name: string } = r.unwrap();
+    const value: { id: number; name: string } = r.get();
     expect(value).toEqual({ id: 1, name: "ada" });
   });
 
@@ -174,7 +174,7 @@ describe("allFromDictAsync", () => {
   });
 
   it("returns Ok({}) for an empty record", async () => {
-    expect((await allFromDictAsync({})).unwrap()).toEqual({});
+    expect((await allFromDictAsync({})).get()).toEqual({});
   });
 
   it("does not let a `__proto__` key pollute the prototype", async () => {

--- a/packages/core/src/async-result.spec.ts
+++ b/packages/core/src/async-result.spec.ts
@@ -14,8 +14,8 @@ const asyncDefect = (): AsyncResult<number, never> =>
 
 describe("AsyncResult is awaitable and never rejects", () => {
   it("await yields a Result for each channel and never throws", async () => {
-    expect((await asyncOk(7)).unwrap()).toBe(7);
-    expect((await asyncErr("e")).unwrapErr()).toBe("e");
+    expect((await asyncOk(7)).get()).toBe(7);
+    expect((await asyncErr("e")).getErr()).toBe("e");
     expect((await asyncDefect()).isDefect()).toBe(true);
   });
 
@@ -25,13 +25,13 @@ describe("AsyncResult is awaitable and never rejects", () => {
   });
 
   it("fromSafePromise: a resolved value becomes Ok", async () => {
-    expect((await fromSafePromise(Promise.resolve(3))).unwrap()).toBe(3);
-    expect((await fromSafePromise(() => Promise.resolve(4))).unwrap()).toBe(4);
+    expect((await fromSafePromise(Promise.resolve(3))).get()).toBe(3);
+    expect((await fromSafePromise(() => Promise.resolve(4))).get()).toBe(4);
   });
 
   it("fromPromise: a rejection is triaged by qualify into Err or Defect", async () => {
     const asErr = await fromPromise(Promise.reject("modeled"), (c) => c as string);
-    expect(asErr.unwrapErr()).toBe("modeled");
+    expect(asErr.getErr()).toBe("modeled");
 
     const asDefect = await fromPromise(Promise.reject(boom), (c, defect) => defect(c));
     expect(asDefect.isDefect()).toBe(true);
@@ -69,8 +69,8 @@ describe("AsyncResult: a throw in any combinator becomes a Defect", () => {
     expect((await asyncOk(1).tap(t)).isDefect()).toBe(true);
     expect((await asyncOk(1).flatTap(t)).isDefect()).toBe(true);
     expect((await asyncErr("e").mapErr(t)).isDefect()).toBe(true);
-    expect((await asyncErr("e").orElse(t)).isDefect()).toBe(true);
-    expect((await asyncErr("e").recover(t)).isDefect()).toBe(true);
+    expect((await asyncErr("e").flatMapErr(t)).isDefect()).toBe(true);
+    expect((await asyncErr("e").recoverErr(t)).isDefect()).toBe(true);
     expect((await asyncErr("e").tapErr(t)).isDefect()).toBe(true);
     expect((await asyncErr("e").flatTapErr(t)).isDefect()).toBe(true);
     expect((await asyncDefect().recoverDefect(t)).isDefect()).toBe(true);
@@ -80,7 +80,7 @@ describe("AsyncResult: a throw in any combinator becomes a Defect", () => {
 
 describe("AsyncResult success channel", () => {
   it("map transforms the Ok value", async () => {
-    expect((await asyncOk(2).map((n) => n + 1)).unwrap()).toBe(3);
+    expect((await asyncOk(2).map((n) => n + 1)).get()).toBe(3);
   });
 
   it("map converts a thrown sync callback into a Defect", async () => {
@@ -91,24 +91,24 @@ describe("AsyncResult success channel", () => {
   });
 
   it("flatMap composes with a Result", async () => {
-    expect((await asyncOk(2).flatMap((n) => Ok(n * 5))).unwrap()).toBe(10);
+    expect((await asyncOk(2).flatMap((n) => Ok(n * 5))).get()).toBe(10);
   });
 
   it("flatMap composes further async work via a qualified boundary", async () => {
     const r = await asyncOk(2).flatMap((n) => fromSafePromise(Promise.resolve(n * 10)));
-    expect(r.unwrap()).toBe(20);
+    expect(r.get()).toBe(20);
   });
 
   it("tap runs the side effect and preserves the value", async () => {
     const seen: number[] = [];
     const r = await asyncOk(5).tap((n) => seen.push(n));
     expect(seen).toEqual([5]);
-    expect(r.unwrap()).toBe(5);
+    expect(r.get()).toBe(5);
   });
 
   it("flatTap keeps the original value when the effect succeeds", async () => {
     const r = await asyncOk(5).flatTap((n) => Ok(n * 100));
-    expect(r.unwrap()).toBe(5); // original, not 500
+    expect(r.get()).toBe(5); // original, not 500
   });
 
   it("flatTap short-circuits to the effect's Err", async () => {
@@ -119,18 +119,18 @@ describe("AsyncResult success channel", () => {
 
   it("flatTap composes an async effect via a qualified boundary, keeping the value", async () => {
     const r = await asyncOk(5).flatTap(() => fromSafePromise(Promise.resolve("logged")));
-    expect(r.unwrap()).toBe(5);
+    expect(r.get()).toBe(5);
   });
 
   it("flatTap does not run the effect on Err or Defect", async () => {
     const f = vi.fn(() => Ok(1));
-    expect((await asyncErr("e").flatTap(f)).unwrapErr()).toBe("e");
+    expect((await asyncErr("e").flatTap(f)).getErr()).toBe("e");
     expect((await asyncDefect().flatTap(f)).isDefect()).toBe(true);
     expect(f).not.toHaveBeenCalled();
   });
 
   it("as replaces the Ok value, and passes Err/Defect through", async () => {
-    expect((await asyncOk(1).as("x")).unwrap()).toBe("x");
+    expect((await asyncOk(1).as("x")).get()).toBe("x");
     const r = await asyncErr("e").as("x");
     expect(r.isErr()).toBe(true);
     if (r.isErr()) expect(r.error).toBe("e");
@@ -140,50 +140,48 @@ describe("AsyncResult success channel", () => {
 
 describe("AsyncResult error channel", () => {
   it("mapErr transforms the Err", async () => {
-    expect((await asyncErr("e").mapErr((s) => `${s}!`)).unwrapErr()).toBe("e!");
+    expect((await asyncErr("e").mapErr((s) => `${s}!`)).getErr()).toBe("e!");
   });
 
-  it("orElse recovers an Err", async () => {
-    expect((await asyncErr("e").orElse(() => Ok(9))).unwrap()).toBe(9);
+  it("flatMapErr recovers an Err", async () => {
+    expect((await asyncErr("e").flatMapErr(() => Ok(9))).get()).toBe(9);
   });
 
-  it("orElse composes async recovery via a qualified boundary", async () => {
-    const r = await asyncErr<string>("e").orElse(() =>
+  it("flatMapErr composes async recovery via a qualified boundary", async () => {
+    const r = await asyncErr<string>("e").flatMapErr(() =>
       fromSafePromise(Promise.resolve("recovered")),
     );
-    expect(r.unwrap()).toBe("recovered");
+    expect(r.get()).toBe("recovered");
   });
 
-  it("recover turns an Err into an Ok", async () => {
-    expect((await asyncErr("e").recover(() => 1)).unwrap()).toBe(1);
+  it("recoverErr turns an Err into an Ok", async () => {
+    expect((await asyncErr("e").recoverErr(() => 1)).get()).toBe(1);
   });
 
   it("tapErr runs the side effect and preserves the error", async () => {
     const seen: string[] = [];
     const r = await asyncErr("e").tapErr((s) => seen.push(s));
     expect(seen).toEqual(["e"]);
-    expect(r.unwrapErr()).toBe("e");
+    expect(r.getErr()).toBe("e");
   });
 
   it("flatTapErr keeps the original error when the effect succeeds", async () => {
     const r = await asyncErr("e").flatTapErr(() => Ok("ignored"));
-    expect(r.unwrapErr()).toBe("e");
+    expect(r.getErr()).toBe("e");
   });
 
   it("flatTapErr threads the effect's Err", async () => {
-    expect((await asyncErr("e").flatTapErr(() => Err("log_failed"))).unwrapErr()).toBe(
-      "log_failed",
-    );
+    expect((await asyncErr("e").flatTapErr(() => Err("log_failed"))).getErr()).toBe("log_failed");
   });
 
   it("flatTapErr composes an async effect via a qualified boundary, keeping the error", async () => {
     const r = await asyncErr("e").flatTapErr(() => fromSafePromise(Promise.resolve("logged")));
-    expect(r.unwrapErr()).toBe("e");
+    expect(r.getErr()).toBe("e");
   });
 
   it("flatTapErr does not run the effect on Ok or Defect", async () => {
     const f = vi.fn(() => Ok(1));
-    expect((await asyncOk(1).flatTapErr(f)).unwrap()).toBe(1);
+    expect((await asyncOk(1).flatTapErr(f)).get()).toBe(1);
     expect((await asyncDefect().flatTapErr(f)).isDefect()).toBe(true);
     expect(f).not.toHaveBeenCalled();
   });
@@ -217,13 +215,13 @@ describe("AsyncResult Defect channel", () => {
     const f = vi.fn();
     expect((await asyncDefect().map(f)).isDefect()).toBe(true);
     expect((await asyncDefect().mapErr(f)).isDefect()).toBe(true);
-    expect((await asyncDefect().recover(f)).isDefect()).toBe(true);
+    expect((await asyncDefect().recoverErr(f)).isDefect()).toBe(true);
     expect(f).not.toHaveBeenCalled();
   });
 
   it("recoverDefect is the only door — it replaces the Defect", async () => {
     const r = await asyncDefect().recoverDefect((c) => Ok(c === boom));
-    expect(r.unwrap()).toBe(true);
+    expect(r.get()).toBe(true);
   });
 
   it("tapDefect observes the cause and passes the Defect through", async () => {
@@ -255,23 +253,23 @@ describe("AsyncResult eliminators", () => {
     expect(await fold(asyncDefect())).toBe("defect");
   });
 
-  it("unwrap resolves the value and rejects (via UnwrapError) on Err", async () => {
-    await expect(asyncOk(1).unwrap()).resolves.toBe(1);
-    // The Err branch is unreachable in typed code (unwrap needs E = never);
+  it("get resolves the value and rejects (via UnwrapError) on Err", async () => {
+    await expect(asyncOk(1).get()).resolves.toBe(1);
+    // The Err branch is unreachable in typed code (get needs E = never);
     // force it via a cast to exercise the defensive runtime guard.
     await expect(
-      (asyncErr("e") as unknown as AsyncResult<number, never>).unwrap(),
+      (asyncErr("e") as unknown as AsyncResult<number, never>).get(),
     ).rejects.toMatchObject({ name: "UnwrapError", error: "e" });
   });
 
-  it("unwrapErr resolves the error", async () => {
-    await expect(asyncErr("e").unwrapErr()).resolves.toBe("e");
+  it("getErr resolves the error", async () => {
+    await expect(asyncErr("e").getErr()).resolves.toBe("e");
   });
 
-  it("unwrapOr / unwrapOrElse recover an Err", async () => {
+  it("getOr / getOrElse recover an Err", async () => {
     const e: AsyncResult<number, string> = Err("e").toAsync();
-    await expect(e.unwrapOr(9)).resolves.toBe(9);
-    await expect(e.unwrapOrElse((s) => s.length)).resolves.toBe(1);
+    await expect(e.getOr(9)).resolves.toBe(9);
+    await expect(e.getOrElse((s) => s.length)).resolves.toBe(1);
   });
 
   it("getOrNull / getOrUndefined return the empty sentinel on Err", async () => {
@@ -286,14 +284,14 @@ describe("AsyncResult eliminators", () => {
   });
 
   it("a Defect rejects the eliminators with the original cause", async () => {
-    await expect(asyncDefect().unwrap()).rejects.toBe(boom);
-    // Also type-unreachable (unwrapErr needs T = never; asyncDefect's declared
+    await expect(asyncDefect().get()).rejects.toBe(boom);
+    // Also type-unreachable (getErr needs T = never; asyncDefect's declared
     // T is number) — cast to exercise the Defect-rethrow guard.
-    await expect((asyncDefect() as unknown as AsyncResult<never, never>).unwrapErr()).rejects.toBe(
+    await expect((asyncDefect() as unknown as AsyncResult<never, never>).getErr()).rejects.toBe(
       boom,
     );
-    await expect(asyncDefect().unwrapOr(0)).rejects.toBe(boom);
-    await expect(asyncDefect().unwrapOrElse(() => 0)).rejects.toBe(boom);
+    await expect(asyncDefect().getOr(0)).rejects.toBe(boom);
+    await expect(asyncDefect().getOrElse(() => 0)).rejects.toBe(boom);
     await expect(asyncDefect().getOrNull()).rejects.toBe(boom);
     await expect(asyncDefect().getOrUndefined()).rejects.toBe(boom);
     await expect(asyncDefect().getOrThrow()).rejects.toBe(boom);

--- a/packages/core/src/constructors.spec.ts
+++ b/packages/core/src/constructors.spec.ts
@@ -26,7 +26,7 @@ describe("constructors", () => {
     expect(r.isOk()).toBe(true);
     expect(r.isErr()).toBe(false);
     expect(r.isDefect()).toBe(false);
-    expect(r.unwrap()).toBe(42);
+    expect(r.get()).toBe(42);
   });
 
   it("Err wraps a modeled error", () => {
@@ -34,7 +34,7 @@ describe("constructors", () => {
     expect(r.isErr()).toBe(true);
     expect(r.isOk()).toBe(false);
     expect(r.isDefect()).toBe(false);
-    expect(r.unwrapErr()).toBe("nope");
+    expect(r.getErr()).toBe("nope");
   });
 
   it("Err(undefined) and Err(null) are real Errs — discrimination is by tag, never payload presence", () => {
@@ -59,13 +59,13 @@ describe("pre-lifted async constructors (OkAsync / ErrAsync)", () => {
   it("OkAsync lifts a value into a success AsyncResult — no Ok(x).toAsync()", async () => {
     const r = await OkAsync(42);
     expect(r.isOk()).toBe(true);
-    expect(r.unwrap()).toBe(42);
+    expect(r.get()).toBe(42);
   });
 
   it("ErrAsync lifts an error into a failed AsyncResult", async () => {
     const r = await ErrAsync("nope");
     expect(r.isErr()).toBe(true);
-    expect(r.unwrapErr()).toBe("nope");
+    expect(r.getErr()).toBe("nope");
   });
 
   it("await-ing never throws and yields the same outcome as Ok(x).toAsync()", async () => {

--- a/packages/core/src/constructors.ts
+++ b/packages/core/src/constructors.ts
@@ -14,7 +14,7 @@ import type { AsyncResult, DefectView, ErrView, OkView, Result } from "./types.j
  * import { Ok } from "unthrown";
  *
  * Ok(2).map((n) => n + 1); // => Ok(3)
- * Ok(42).unwrap(); // => 42
+ * Ok(42).get(); // => 42
  * ```
  *
  * @category Constructors
@@ -34,7 +34,7 @@ export function Ok<T>(value: T): Result<T, never> {
  * import { Err } from "unthrown";
  *
  * Err("not_found").map((n) => n + 1); // => Err("not_found") (map skipped)
- * Err("not_found").unwrapErr(); // => "not_found"
+ * Err("not_found").getErr(); // => "not_found"
  * ```
  *
  * @category Constructors

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -25,8 +25,8 @@ import type {
 } from "./types.js";
 
 /**
- * Thrown by a {@link Result}'s `unwrap` / `unwrapErr` when the assertion is
- * wrong on a *modeled* result — `unwrap()` on an `Err`, or `unwrapErr()` on an
+ * Thrown by a {@link Result}'s `get` / `getErr` when the assertion is
+ * wrong on a *modeled* result — `get()` on an `Err`, or `getErr()` on an
  * `Ok`.
  *
  * @remarks
@@ -38,7 +38,7 @@ import type {
  * A `Defect` is never wrapped in an `UnwrapError`: its original cause is
  * re-thrown (with its original stack) instead.
  *
- * `unwrap()` and `unwrapErr()` are type-gated (`this: Result<T, never>` /
+ * `get()` and `getErr()` are type-gated (`this: Result<T, never>` /
  * `Result<never, E>`), so the wrong-variant branch that throws this is
  * unreachable through well-typed code — it remains only as a defensive guard
  * against unsound runtime misuse (e.g. an `as` cast past the gate).
@@ -49,8 +49,8 @@ import type {
  */
 export class UnwrapError<E = unknown> extends Error {
   /**
-   * The offending value: the `Err` error for `unwrap()`, or the `Ok` value for
-   * `unwrapErr()`.
+   * The offending value: the `Err` error for `get()`, or the `Ok` value for
+   * `getErr()`.
    */
   readonly error: E;
   constructor(error: E) {
@@ -158,7 +158,7 @@ class Res<T, E> {
     }
   }
 
-  orElse<U, E2>(this: Result<T, E>, f: (error: E) => Result<U, E2>): Result<T | U, E2> {
+  flatMapErr<U, E2>(this: Result<T, E>, f: (error: E) => Result<U, E2>): Result<T | U, E2> {
     if (this.tag !== "Err") return passThrough(this);
     try {
       return f(this.error);
@@ -167,13 +167,23 @@ class Res<T, E> {
     }
   }
 
-  recover<U>(this: Result<T, E>, f: (error: E) => U & NotThenable<U>): Result<T | U, never> {
+  /** @deprecated Use {@link Res.flatMapErr}. */
+  orElse<U, E2>(this: Result<T, E>, f: (error: E) => Result<U, E2>): Result<T | U, E2> {
+    return this.flatMapErr(f);
+  }
+
+  recoverErr<U>(this: Result<T, E>, f: (error: E) => U & NotThenable<U>): Result<T | U, never> {
     if (this.tag !== "Err") return passThrough(this);
     try {
       return okRes(f(this.error));
     } catch (cause) {
       return defectRes(cause);
     }
+  }
+
+  /** @deprecated Use {@link Res.recoverErr}. */
+  recover<U>(this: Result<T, E>, f: (error: E) => U & NotThenable<U>): Result<T | U, never> {
+    return this.recoverErr(f);
   }
 
   tapErr<R>(this: Result<T, E>, f: (error: E) => R & NotThenable<R>): Result<T, E> {
@@ -237,7 +247,7 @@ class Res<T, E> {
     }
   }
 
-  unwrap(this: Result<T, E>): T {
+  get(this: Result<T, E>): T {
     switch (this.tag) {
       case "Ok":
         return this.value;
@@ -248,7 +258,14 @@ class Res<T, E> {
     }
   }
 
-  unwrapErr(this: Result<T, E>): E {
+  /** @deprecated Use {@link Res.get}. */
+  unwrap(this: Result<T, E>): T {
+    // Runtime-identical alias; the cast only sidesteps `get`'s type-gate, which
+    // is re-imposed on the public `unwrap` signature in `types.ts`.
+    return (this as Result<T, never>).get();
+  }
+
+  getErr(this: Result<T, E>): E {
     switch (this.tag) {
       case "Err":
         return this.error;
@@ -259,16 +276,32 @@ class Res<T, E> {
     }
   }
 
-  unwrapOr<U>(this: Result<T, E>, fallback: U): T | U {
+  /** @deprecated Use {@link Res.getErr}. */
+  unwrapErr(this: Result<T, E>): E {
+    // Runtime-identical alias; the cast only sidesteps `getErr`'s type-gate.
+    return (this as Result<never, E>).getErr();
+  }
+
+  getOr<U>(this: Result<T, E>, fallback: U): T | U {
     if (this.tag === "Ok") return this.value;
     if (this.tag === "Defect") throw this.cause;
     return fallback;
   }
 
-  unwrapOrElse<U>(this: Result<T, E>, f: (error: E) => U): T | U {
+  /** @deprecated Use {@link Res.getOr}. */
+  unwrapOr<U>(this: Result<T, E>, fallback: U): T | U {
+    return this.getOr(fallback);
+  }
+
+  getOrElse<U>(this: Result<T, E>, f: (error: E) => U): T | U {
     if (this.tag === "Ok") return this.value;
     if (this.tag === "Defect") throw this.cause;
     return f(this.error);
+  }
+
+  /** @deprecated Use {@link Res.getOrElse}. */
+  unwrapOrElse<U>(this: Result<T, E>, f: (error: E) => U): T | U {
+    return this.getOrElse(f);
   }
 
   getOrNull(this: Result<T, E>): T | null {
@@ -573,7 +606,7 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
     );
   }
 
-  orElse<U, E2>(f: (error: E) => Result<U, E2> | AsyncResult<U, E2>): AsyncResult<T | U, E2> {
+  flatMapErr<U, E2>(f: (error: E) => Result<U, E2> | AsyncResult<U, E2>): AsyncResult<T | U, E2> {
     return new AsyncRes<T | U, E2>(
       this.promise.then(async (r) => {
         if (r.tag !== "Err") return passThrough(r);
@@ -586,7 +619,12 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
     );
   }
 
-  recover<U>(f: (error: E) => U & NotThenable<U>): AsyncResult<T | U, never> {
+  /** @deprecated Use {@link AsyncRes.flatMapErr}. */
+  orElse<U, E2>(f: (error: E) => Result<U, E2> | AsyncResult<U, E2>): AsyncResult<T | U, E2> {
+    return this.flatMapErr(f);
+  }
+
+  recoverErr<U>(f: (error: E) => U & NotThenable<U>): AsyncResult<T | U, never> {
     return new AsyncRes<T | U, never>(
       this.promise.then((r) => {
         if (r.tag !== "Err") return passThrough(r);
@@ -597,6 +635,11 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
         }
       }),
     );
+  }
+
+  /** @deprecated Use {@link AsyncRes.recoverErr}. */
+  recover<U>(f: (error: E) => U & NotThenable<U>): AsyncResult<T | U, never> {
+    return this.recoverErr(f);
   }
 
   tapErr<R>(f: (error: E) => R & NotThenable<R>): AsyncResult<T, E> {
@@ -667,17 +710,33 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
     return this.promise.then((r) => r.match(cases));
   }
 
+  get(): Promise<T> {
+    return this.promise.then((r) => (r as Result<T, never>).get());
+  }
+  /** @deprecated Use {@link AsyncRes.get}. */
   unwrap(): Promise<T> {
-    return this.promise.then((r) => (r as Result<T, never>).unwrap());
+    return this.get();
   }
+  getErr(): Promise<E> {
+    return this.promise.then((r) => (r as Result<never, E>).getErr());
+  }
+  /** @deprecated Use {@link AsyncRes.getErr}. */
   unwrapErr(): Promise<E> {
-    return this.promise.then((r) => (r as Result<never, E>).unwrapErr());
+    return this.getErr();
   }
+  getOr<U>(fallback: U): Promise<T | U> {
+    return this.promise.then((r) => r.getOr(fallback));
+  }
+  /** @deprecated Use {@link AsyncRes.getOr}. */
   unwrapOr<U>(fallback: U): Promise<T | U> {
-    return this.promise.then((r) => r.unwrapOr(fallback));
+    return this.getOr(fallback);
   }
+  getOrElse<U>(f: (error: E) => U): Promise<T | U> {
+    return this.promise.then((r) => r.getOrElse(f));
+  }
+  /** @deprecated Use {@link AsyncRes.getOrElse}. */
   unwrapOrElse<U>(f: (error: E) => U): Promise<T | U> {
-    return this.promise.then((r) => r.unwrapOrElse(f));
+    return this.getOrElse(f);
   }
   getOrNull(): Promise<T | null> {
     return this.promise.then((r) => r.getOrNull());

--- a/packages/core/src/deprecated-aliases.spec.ts
+++ b/packages/core/src/deprecated-aliases.spec.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import { Err, Ok, type Result } from "./index.js";
+
+// The renamed operators keep their old names as deprecated, runtime-identical
+// aliases (orElse→flatMapErr, recover→recoverErr, unwrap→get, unwrapErr→getErr,
+// unwrapOr→getOr, unwrapOrElse→getOrElse). These guard that each alias still
+// delegates to its replacement — both the sync and async surfaces.
+
+const boom = new Error("boom");
+const defectOf = (cause: unknown): Result<number, never> =>
+  Ok(0).map<number>(() => {
+    throw cause;
+  });
+
+describe("deprecated sync aliases delegate to the renamed operator", () => {
+  it("orElse === flatMapErr", () => {
+    const e: Result<number, string> = Err("e");
+    // recovers into a new Ok
+    expect(e.orElse((s) => Ok(s.length)).getOrThrow()).toBe(1);
+    // recovers into a differently-typed Err
+    const reErr = e.orElse(() => Err("e2"));
+    expect(reErr.isErr() && reErr.error).toBe("e2");
+    // Ok passes through untouched
+    expect(
+      Ok<number>(3)
+        .orElse(() => Ok(9))
+        .getOrThrow(),
+    ).toBe(3);
+  });
+
+  it("recover === recoverErr", () => {
+    const e: Result<number, string> = Err("e");
+    expect(e.recover((s) => s.length).getOrThrow()).toBe(1);
+    expect(
+      Ok<number>(3)
+        .recover(() => 9)
+        .getOrThrow(),
+    ).toBe(3);
+  });
+
+  it("unwrap === get", () => {
+    expect(Ok(42).unwrap()).toBe(42);
+    expect(() => defectOf(boom).unwrap()).toThrow(boom);
+  });
+
+  it("unwrapErr === getErr", () => {
+    expect(Err("nope").unwrapErr()).toBe("nope");
+  });
+
+  it("unwrapOr === getOr", () => {
+    const e: Result<number, string> = Err("e");
+    expect(e.unwrapOr(9)).toBe(9);
+    expect(Ok(3).unwrapOr(9)).toBe(3);
+    expect(() => defectOf(boom).unwrapOr(0)).toThrow(boom);
+  });
+
+  it("unwrapOrElse === getOrElse", () => {
+    const e: Result<number, string> = Err("e");
+    expect(e.unwrapOrElse((s) => s.length)).toBe(1);
+    expect(Ok(3).unwrapOrElse(() => 9)).toBe(3);
+    expect(() => defectOf(boom).unwrapOrElse(() => 0)).toThrow(boom);
+  });
+});
+
+describe("deprecated async aliases delegate to the renamed operator", () => {
+  it("orElse === flatMapErr", async () => {
+    const e = Err<string>("e").toAsync();
+    await expect(e.orElse((s) => Ok(s.length)).getOrThrow()).resolves.toBe(1);
+  });
+
+  it("recover === recoverErr", async () => {
+    const e = Err<string>("e").toAsync();
+    await expect(e.recover((s) => s.length).getOrThrow()).resolves.toBe(1);
+  });
+
+  it("unwrap === get", async () => {
+    await expect(Ok(42).toAsync().unwrap()).resolves.toBe(42);
+  });
+
+  it("unwrapErr === getErr", async () => {
+    await expect(Err("nope").toAsync().unwrapErr()).resolves.toBe("nope");
+  });
+
+  it("unwrapOr === getOr", async () => {
+    await expect(Err<string>("e").toAsync().unwrapOr(9)).resolves.toBe(9);
+  });
+
+  it("unwrapOrElse === getOrElse", async () => {
+    await expect(
+      Err<string>("e")
+        .toAsync()
+        .unwrapOrElse((s) => s.length),
+    ).resolves.toBe(1);
+  });
+});

--- a/packages/core/src/do.spec.ts
+++ b/packages/core/src/do.spec.ts
@@ -10,7 +10,7 @@ const defectOf = (cause: unknown): Result<number, never> =>
 
 describe("Do / bind / let", () => {
   it("Do() starts an empty object scope", () => {
-    expect(Do().unwrap()).toEqual({});
+    expect(Do().get()).toEqual({});
   });
 
   it("accumulates bound Results and pure lets into a named scope", () => {
@@ -18,7 +18,7 @@ describe("Do / bind / let", () => {
       .bind("a", () => Ok(1))
       .bind("b", ({ a }) => Ok(a + 1))
       .let("c", ({ a, b }) => a + b);
-    expect(r.unwrap()).toEqual({ a: 1, b: 2, c: 3 });
+    expect(r.get()).toEqual({ a: 1, b: 2, c: 3 });
   });
 
   it("short-circuits on the first Err and skips later steps", () => {
@@ -108,7 +108,7 @@ describe("Do / bind / let — async", () => {
       .bind("a", () => fromSafePromise(Promise.resolve(1)))
       .bind("b", ({ a }) => Ok(a + 1)) // a sync Result is accepted too
       .let("c", ({ a, b }) => a + b);
-    expect(r.unwrap()).toEqual({ a: 1, b: 2, c: 3 });
+    expect(r.get()).toEqual({ a: 1, b: 2, c: 3 });
   });
 
   it("short-circuits on an async Err", async () => {

--- a/packages/core/src/facade.spec.ts
+++ b/packages/core/src/facade.spec.ts
@@ -24,8 +24,8 @@ const boom = new Error("boom");
 
 describe("Result facade mirrors the free functions", () => {
   it("exposes the same constructors", () => {
-    expect(Result.Ok(5).unwrap()).toBe(5);
-    expect(Result.Err("e").unwrapErr()).toBe("e");
+    expect(Result.Ok(5).get()).toBe(5);
+    expect(Result.Err("e").getErr()).toBe("e");
     expect(Result.Ok).toBe(Ok);
     expect(Result.Err).toBe(Err);
   });
@@ -52,9 +52,9 @@ describe("Result facade mirrors the free functions", () => {
     expect(Result.Do).toBe(Do);
     expect(Result.all).toBe(all);
     expect(Result.allFromDict).toBe(allFromDict);
-    expect(Result.fromNullable(null, () => "absent").unwrapErr()).toBe("absent");
-    expect(Result.all([Result.Ok(1), Result.Ok(2)]).unwrap()).toEqual([1, 2]);
-    expect(Result.allFromDict({ a: Result.Ok(1) }).unwrap()).toEqual({ a: 1 });
+    expect(Result.fromNullable(null, () => "absent").getErr()).toBe("absent");
+    expect(Result.all([Result.Ok(1), Result.Ok(2)]).get()).toEqual([1, 2]);
+    expect(Result.allFromDict({ a: Result.Ok(1) }).get()).toEqual({ a: 1 });
   });
 
   it("does NOT carry the async entry points (those live on AsyncResult)", () => {
@@ -74,15 +74,15 @@ describe("AsyncResult facade groups the async-producing entry points", () => {
   });
 
   it("constructs and aggregates async results", async () => {
-    expect((await AsyncResult.fromSafePromise(Promise.resolve(3))).unwrap()).toBe(3);
+    expect((await AsyncResult.fromSafePromise(Promise.resolve(3))).get()).toBe(3);
     const both = await AsyncResult.all([
       AsyncResult.fromSafePromise(Promise.resolve(1)),
       AsyncResult.fromSafePromise(Promise.resolve(2)),
     ]);
-    expect(both.unwrap()).toEqual([1, 2]);
+    expect(both.get()).toEqual([1, 2]);
     const dict = await AsyncResult.allFromDict({
       a: AsyncResult.fromSafePromise(Promise.resolve("x")),
     });
-    expect(dict.unwrap()).toEqual({ a: "x" });
+    expect(dict.get()).toEqual({ a: "x" });
   });
 });

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -41,7 +41,7 @@ import type { AsyncResult as AsyncResultType, Result as ResultType } from "./typ
  * @example
  * ```ts
  * import { Result } from "unthrown";
- * Result.Ok(1).flatMap((n) => Result.Ok(n + 1)).unwrap(); // => 2
+ * Result.Ok(1).flatMap((n) => Result.Ok(n + 1)).get(); // => 2
  * ```
  */
 export const Result = {
@@ -65,7 +65,7 @@ export const Result = {
  *
  * @remarks
  * A `Result` is a discriminated union, so TypeDoc can't list its methods on this
- * alias. Its fluent combinators (`map`, `flatMap`, `match`, `unwrap`, …) are
+ * alias. Its fluent combinators (`map`, `flatMap`, `match`, `get`, …) are
  * documented one per entry on {@link ResultMethods} — the shared method surface
  * every variant carries. For "which one do I reach for?", see the
  * [Choosing a combinator](/guide/choosing-a-combinator) guide.
@@ -100,7 +100,7 @@ export type Result<T, E> = ResultType<T, E>;
  * ```ts
  * import { AsyncResult } from "unthrown";
  * const user = await AsyncResult.fromPromise(fetchUser(id), (c, defect) => defect(c));
- * user.unwrap(); // => the fetched user (on success)
+ * user.get(); // => the fetched user (on success)
  * ```
  */
 export const AsyncResult = {
@@ -119,7 +119,7 @@ export const AsyncResult = {
  *
  * @remarks
  * `AsyncResult` carries the async fluent surface; its combinators (`map`,
- * `flatMap`, `match`, `unwrap`, …) are documented one per entry — with their
+ * `flatMap`, `match`, `get`, …) are documented one per entry — with their
  * async signatures — on {@link AsyncResultMethods}. For "which one do I reach
  * for?", see the [Choosing a combinator](/guide/choosing-a-combinator) guide.
  *

--- a/packages/core/src/interop.spec.ts
+++ b/packages/core/src/interop.spec.ts
@@ -14,8 +14,8 @@ const boom = new Error("boom");
 
 describe("fromNullable", () => {
   it("turns null/undefined into a modeled Err", () => {
-    expect(fromNullable(null, () => "absent").unwrapErr()).toBe("absent");
-    expect(fromNullable(undefined, () => "absent").unwrapErr()).toBe("absent");
+    expect(fromNullable(null, () => "absent").getErr()).toBe("absent");
+    expect(fromNullable(undefined, () => "absent").getErr()).toBe("absent");
   });
 
   it("keeps a present value as Ok (and treats falsy non-null as present)", () => {
@@ -76,7 +76,7 @@ describe("fromThrowable", () => {
     const r = fn();
     expect(r.isDefect()).toBe(true);
     // the original cause is preserved on the Defect channel
-    expect(r.recoverDefect((c) => Ok(c === boom)).unwrap()).toBe(true);
+    expect(r.recoverDefect((c) => Ok(c === boom)).get()).toBe(true);
     // the injected helper yields an opaque marker carrying the cause — NOT a
     // Result (it has no Result methods).
     expect(marker).toMatchObject({ cause: boom });
@@ -102,7 +102,7 @@ describe("fromThrowable", () => {
     );
     // Compiles only if `E` is `never` — `Defect` must not leak into the channel.
     const r: Result<number, never> = fn();
-    expect(r.unwrap()).toBe(1);
+    expect(r.get()).toBe(1);
   });
 
   it("keeps the modeled arm while subtracting Defect: mixed qualify yields just E", () => {
@@ -129,7 +129,7 @@ describe("fromPromise — error-channel inference", () => {
     );
     const typed: AsyncResult<never, "known"> = ar;
     // `boom` matches the modeled arm, so it lands in Err — not a Defect.
-    expect((await typed).unwrapErr()).toBe("known");
+    expect((await typed).getErr()).toBe("known");
   });
 });
 

--- a/packages/core/src/interop.ts
+++ b/packages/core/src/interop.ts
@@ -27,9 +27,9 @@ import type { AsyncErrOf, AsyncOkOf, AsyncResult, ErrOf, OkOf, Result } from "./
  * import { fromNullable } from "unthrown";
  *
  * const map = new Map([["a", 1]]);
- * fromNullable(map.get("a"), () => "absent").unwrapOr(0); // => 1
+ * fromNullable(map.get("a"), () => "absent").getOr(0); // => 1
  * fromNullable(map.get("z"), () => "absent"); // => Err("absent")
- * fromNullable(0, () => "absent").unwrapOr(-1); // => 0 (falsy but present)
+ * fromNullable(0, () => "absent").getOr(-1); // => 0 (falsy but present)
  * ```
  */
 export function fromNullable<T, E>(
@@ -77,7 +77,7 @@ export function fromNullable<T, E>(
  *     cause instanceof SyntaxError ? ("invalid_json" as const) : defect(cause),
  * );
  *
- * parse('{"ok":true}').unwrapOr(null); // => { ok: true }
+ * parse('{"ok":true}').getOr(null); // => { ok: true }
  * parse("nope"); // => Err("invalid_json")
  * ```
  */
@@ -168,7 +168,7 @@ export function fromPromise<T, R>(
  * ```ts
  * import { fromSafePromise } from "unthrown";
  *
- * (await fromSafePromise(Promise.resolve(3))).unwrap(); // => 3
+ * (await fromSafePromise(Promise.resolve(3))).get(); // => 3
  * // a rejection becomes a Defect (never a modeled Err):
  * await fromSafePromise(Promise.reject(new Error("boom"))); // => Defect(Error("boom"))
  * ```
@@ -292,7 +292,7 @@ function foldRecord(results: ResultRecord): Result<unknown, unknown> {
  * ```ts
  * import { all, Ok, Err } from "unthrown";
  *
- * all([Ok(1), Ok("a"), Ok(true)]).unwrap(); // => [1, "a", true] (typed [number, string, boolean])
+ * all([Ok(1), Ok("a"), Ok(true)]).get(); // => [1, "a", true] (typed [number, string, boolean])
  * all([Ok(1), Err("e"), Ok(3)]); // => Err("e") (short-circuits on the first Err)
  * ```
  */
@@ -321,7 +321,7 @@ export function all<Rs extends readonly Result<unknown, unknown>[]>(
  * ```ts
  * import { allFromDict, Ok, Err } from "unthrown";
  *
- * allFromDict({ id: Ok(1), name: Ok("ada") }).unwrap(); // => { id: 1, name: "ada" }
+ * allFromDict({ id: Ok(1), name: Ok("ada") }).get(); // => { id: 1, name: "ada" }
  * allFromDict({ id: Ok(1), name: Err("missing") }); // => Err("missing")
  * ```
  */
@@ -351,7 +351,7 @@ export function allFromDict<R extends ResultRecord>(
  * import { allAsync, fromSafePromise } from "unthrown";
  *
  * const both = allAsync([fromSafePromise(Promise.resolve(1)), fromSafePromise(Promise.resolve(2))]);
- * (await both).unwrap(); // => [1, 2]
+ * (await both).get(); // => [1, 2]
  * ```
  */
 export function allAsync<Rs extends readonly AsyncResult<unknown, unknown>[]>(
@@ -386,7 +386,7 @@ export function allAsync<Rs extends readonly AsyncResult<unknown, unknown>[]>(
  *   a: fromSafePromise(Promise.resolve(1)),
  *   b: fromSafePromise(Promise.resolve("x")),
  * });
- * (await both).unwrap(); // => { a: 1, b: "x" }
+ * (await both).get(); // => { a: 1, b: "x" }
  * ```
  */
 export function allFromDictAsync<R extends AsyncResultRecord>(

--- a/packages/core/src/invariants.spec.ts
+++ b/packages/core/src/invariants.spec.ts
@@ -25,8 +25,8 @@ describe("Invariant 1: throw inside any combinator becomes a Defect", () => {
     expect(Do().bind("a", t).isDefect()).toBe(true);
     expect(Do().let("a", t).isDefect()).toBe(true);
     expect(Err("e").mapErr(t).isDefect()).toBe(true);
-    expect(Err("e").orElse(t).isDefect()).toBe(true);
-    expect(Err("e").recover(t).isDefect()).toBe(true);
+    expect(Err("e").flatMapErr(t).isDefect()).toBe(true);
+    expect(Err("e").recoverErr(t).isDefect()).toBe(true);
     expect(Err("e").tapErr(t).isDefect()).toBe(true);
     expect(Err("e").flatTapErr(t).isDefect()).toBe(true);
     expect(defectOf(boom).recoverDefect(t).isDefect()).toBe(true);
@@ -46,8 +46,8 @@ describe("Invariant 2: a Defect flows through every method except match() and re
       defectOf(boom).let("a", f),
       defectOf(boom).as(1),
       defectOf(boom).mapErr(f),
-      defectOf(boom).orElse(f),
-      defectOf(boom).recover(f),
+      defectOf(boom).flatMapErr(f),
+      defectOf(boom).recoverErr(f),
       defectOf(boom).tapErr(f),
       defectOf(boom).flatTapErr(f),
     ];
@@ -55,10 +55,10 @@ describe("Invariant 2: a Defect flows through every method except match() and re
     expect(f).not.toHaveBeenCalled();
   });
 
-  it("the recovering eliminators still THROW on a Defect (they recover Err, not a Defect)", () => {
+  it("the recovering eliminators still THROW on a Defect (they recoverErr Err, not a Defect)", () => {
     const d = defectOf(boom);
-    expect(() => d.unwrapOr(0)).toThrow();
-    expect(() => d.unwrapOrElse(() => 0)).toThrow();
+    expect(() => d.getOr(0)).toThrow();
+    expect(() => d.getOrElse(() => 0)).toThrow();
     expect(() => d.getOrNull()).toThrow();
     expect(() => d.getOrUndefined()).toThrow();
   });
@@ -68,17 +68,17 @@ describe("Invariant 2: a Defect flows through every method except match() and re
     expect(
       defectOf(boom)
         .recoverDefect(() => Ok("handled"))
-        .unwrap(),
+        .get(),
     ).toBe("handled");
   });
 });
 
-describe("Invariant 3: unwrap() is asymmetric", () => {
+describe("Invariant 3: get() is asymmetric", () => {
   it("on Err throws an UnwrapError carrying E", () => {
     try {
-      // The Err branch is unreachable in typed code (unwrap needs E = never);
+      // The Err branch is unreachable in typed code (get needs E = never);
       // force it via a cast to exercise the defensive runtime guard.
-      (Err("modeled") as unknown as Result<number, never>).unwrap();
+      (Err("modeled") as unknown as Result<number, never>).get();
       expect.unreachable();
     } catch (e) {
       expect(e).toBeInstanceOf(UnwrapError);
@@ -90,7 +90,7 @@ describe("Invariant 3: unwrap() is asymmetric", () => {
 
   it("on a Defect rethrows the ORIGINAL cause with its original stack", () => {
     try {
-      defectOf(boom).unwrap();
+      defectOf(boom).get();
       expect.unreachable();
     } catch (e) {
       expect(e).toBe(boom); // same instance ⇒ original stack preserved
@@ -99,9 +99,9 @@ describe("Invariant 3: unwrap() is asymmetric", () => {
   });
 });
 
-describe("Invariant 4: recover empties the error channel in the type, not the runtime", () => {
-  it("recover() returns a value whose type is Result<_, never> but may still be a Defect", () => {
-    const recovered = defectOf(boom).recover(() => 1);
+describe("Invariant 4: recoverErr empties the error channel in the type, not the runtime", () => {
+  it("recoverErr() returns a value whose type is Result<_, never> but may still be a Defect", () => {
+    const recovered = defectOf(boom).recoverErr(() => 1);
     // `never` in the type does not mean total — a Defect survives at runtime.
     expect(recovered.isDefect()).toBe(true);
   });
@@ -113,7 +113,7 @@ describe("Invariant 5: an AsyncResult's internal promise never rejects", () => {
     await expect(fromSafePromise(Promise.reject(boom))).resolves.toMatchObject({});
     const okR = await fromSafePromise(Promise.resolve(1));
     const defectR = await fromSafePromise(Promise.reject(boom));
-    expect(okR.unwrap()).toBe(1);
+    expect(okR.get()).toBe(1);
     expect(defectR.isDefect()).toBe(true);
   });
 });

--- a/packages/core/src/invariants.spec.ts
+++ b/packages/core/src/invariants.spec.ts
@@ -55,7 +55,7 @@ describe("Invariant 2: a Defect flows through every method except match() and re
     expect(f).not.toHaveBeenCalled();
   });
 
-  it("the recovering eliminators still THROW on a Defect (they recoverErr Err, not a Defect)", () => {
+  it("the recovering eliminators still THROW on a Defect (they recover an Err, not a Defect)", () => {
     const d = defectOf(boom);
     expect(() => d.getOr(0)).toThrow();
     expect(() => d.getOrElse(() => 0)).toThrow();

--- a/packages/core/src/result.spec.ts
+++ b/packages/core/src/result.spec.ts
@@ -13,7 +13,7 @@ describe("Result.map", () => {
     expect(
       Ok(2)
         .map((n) => n + 1)
-        .unwrap(),
+        .get(),
     ).toBe(3);
   });
 
@@ -37,7 +37,7 @@ describe("Result.map", () => {
       throw boom;
     });
     expect(r.isDefect()).toBe(true);
-    expect(r.recoverDefect((c) => Ok(c === boom)).unwrap()).toBe(true);
+    expect(r.recoverDefect((c) => Ok(c === boom)).get()).toBe(true);
   });
 });
 
@@ -46,7 +46,7 @@ describe("Result.flatMap", () => {
     expect(
       Ok(2)
         .flatMap((n) => Ok(n * 10))
-        .unwrap(),
+        .get(),
     ).toBe(20);
   });
 
@@ -54,7 +54,7 @@ describe("Result.flatMap", () => {
     expect(
       Ok(2)
         .flatMap(() => Err("downstream"))
-        .unwrapErr(),
+        .getErr(),
     ).toBe("downstream");
   });
 
@@ -88,7 +88,7 @@ describe("Result.tap", () => {
     const seen: number[] = [];
     const r = Ok(5).tap((n) => seen.push(n));
     expect(seen).toEqual([5]);
-    expect(r.unwrap()).toBe(5);
+    expect(r.get()).toBe(5);
   });
 
   it("does not run on Err or Defect", () => {
@@ -117,7 +117,7 @@ describe("Result.flatTap", () => {
       return Ok("ignored");
     });
     expect(seen).toEqual([5]);
-    expect(r.unwrap()).toBe(5); // original value preserved, not "ignored"
+    expect(r.get()).toBe(5); // original value preserved, not "ignored"
   });
 
   it("short-circuits to the effect's Err", () => {
@@ -151,7 +151,7 @@ describe("Result.flatTap", () => {
 
 describe("Result.as", () => {
   it("replaces the Ok value", () => {
-    expect(Ok(1).as("x").unwrap()).toBe("x");
+    expect(Ok(1).as("x").get()).toBe("x");
   });
 
   it("passes Err and Defect through", () => {
@@ -167,7 +167,7 @@ describe("Result.mapErr", () => {
     expect(
       Err("e")
         .mapErr((s) => `${s}!`)
-        .unwrapErr(),
+        .getErr(),
     ).toBe("e!");
   });
 
@@ -196,26 +196,26 @@ describe("Result.mapErr", () => {
   });
 });
 
-describe("Result.orElse", () => {
+describe("Result.flatMapErr", () => {
   it("recovers an Err into an Ok", () => {
     expect(
       Err("e")
-        .orElse(() => Ok(99))
-        .unwrap(),
+        .flatMapErr(() => Ok(99))
+        .get(),
     ).toBe(99);
   });
 
   it("recovers an Err into another Err", () => {
     expect(
       Err("e")
-        .orElse(() => Err("e2"))
-        .unwrapErr(),
+        .flatMapErr(() => Err("e2"))
+        .getErr(),
     ).toBe("e2");
   });
 
   it("passes Ok through and does not call the callback", () => {
     const f = vi.fn();
-    const r = Ok(1).orElse(f);
+    const r = Ok(1).flatMapErr(f);
     expect(r.isOk()).toBe(true);
     if (r.isOk()) expect(r.value).toBe(1);
     expect(f).not.toHaveBeenCalled();
@@ -223,14 +223,14 @@ describe("Result.orElse", () => {
 
   it("passes a Defect through and does not call the callback", () => {
     const f = vi.fn();
-    expect(defectOf(boom).orElse(f).isDefect()).toBe(true);
+    expect(defectOf(boom).flatMapErr(f).isDefect()).toBe(true);
     expect(f).not.toHaveBeenCalled();
   });
 
   it("converts a throw into a Defect", () => {
     expect(
       Err("e")
-        .orElse(() => {
+        .flatMapErr(() => {
           throw boom;
         })
         .isDefect(),
@@ -238,24 +238,24 @@ describe("Result.orElse", () => {
   });
 });
 
-describe("Result.recover", () => {
+describe("Result.recoverErr", () => {
   it("turns an Err into an Ok", () => {
     expect(
       Err("e")
-        .recover(() => 7)
-        .unwrap(),
+        .recoverErr(() => 7)
+        .get(),
     ).toBe(7);
   });
 
   it("passes Ok through and does not call the callback", () => {
     const f = vi.fn();
-    expect(Ok(1).recover(f).unwrap()).toBe(1);
+    expect(Ok(1).recoverErr(f).get()).toBe(1);
     expect(f).not.toHaveBeenCalled();
   });
 
   it("does NOT recover a Defect — `never` empties only the error channel", () => {
     const f = vi.fn();
-    const recovered = defectOf(boom).recover(f);
+    const recovered = defectOf(boom).recoverErr(f);
     expect(f).not.toHaveBeenCalled();
     expect(recovered.isDefect()).toBe(true);
   });
@@ -263,7 +263,7 @@ describe("Result.recover", () => {
   it("converts a throw into a Defect", () => {
     expect(
       Err("e")
-        .recover(() => {
+        .recoverErr(() => {
           throw boom;
         })
         .isDefect(),
@@ -276,12 +276,12 @@ describe("Result.tapErr", () => {
     const seen: string[] = [];
     const r = Err("e").tapErr((s) => seen.push(s));
     expect(seen).toEqual(["e"]);
-    expect(r.unwrapErr()).toBe("e");
+    expect(r.getErr()).toBe("e");
   });
 
   it("does not run on Ok or Defect", () => {
     const f = vi.fn();
-    expect(Ok(1).tapErr(f).unwrap()).toBe(1);
+    expect(Ok(1).tapErr(f).get()).toBe(1);
     expect(defectOf(boom).tapErr(f).isDefect()).toBe(true);
     expect(f).not.toHaveBeenCalled();
   });
@@ -295,12 +295,12 @@ describe("Result.flatTapErr", () => {
       return Ok("ignored");
     });
     expect(seen).toEqual(["e"]);
-    expect(r.unwrapErr()).toBe("e"); // original error preserved
+    expect(r.getErr()).toBe("e"); // original error preserved
   });
 
   it("threads the effect's Err", () => {
     const r = Err("e").flatTapErr(() => Err("log_failed"));
-    expect(r.unwrapErr()).toBe("log_failed");
+    expect(r.getErr()).toBe("log_failed");
   });
 
   it("propagates a Defect from the effect", () => {
@@ -310,7 +310,7 @@ describe("Result.flatTapErr", () => {
 
   it("does not run on Ok or Defect", () => {
     const f = vi.fn(() => Ok(1));
-    expect(Ok(1).flatTapErr(f).unwrap()).toBe(1);
+    expect(Ok(1).flatTapErr(f).get()).toBe(1);
     expect(defectOf(boom).flatTapErr(f).isDefect()).toBe(true);
     expect(f).not.toHaveBeenCalled();
   });
@@ -331,7 +331,7 @@ describe("Result.recoverDefect (the only door to a Defect)", () => {
     expect(
       defectOf(boom)
         .recoverDefect((c) => Ok(c === boom ? "handled" : "other"))
-        .unwrap(),
+        .get(),
     ).toBe("handled");
   });
 
@@ -373,8 +373,8 @@ describe("Result.tapDefect", () => {
 
   it("does not run on Ok or Err", () => {
     const f = vi.fn();
-    expect(Ok(1).tapDefect(f).unwrap()).toBe(1);
-    expect(Err("e").tapDefect(f).unwrapErr()).toBe("e");
+    expect(Ok(1).tapDefect(f).get()).toBe(1);
+    expect(Err("e").tapDefect(f).getErr()).toBe("e");
     expect(f).not.toHaveBeenCalled();
   });
 });
@@ -441,12 +441,12 @@ describe("Result.match", () => {
 });
 
 describe("Result eliminators on Ok / Err", () => {
-  it("unwrap returns the Ok value; throws UnwrapError on Err", () => {
-    expect(Ok(1).unwrap()).toBe(1);
+  it("get returns the Ok value; throws UnwrapError on Err", () => {
+    expect(Ok(1).get()).toBe(1);
     try {
-      // The Err branch is unreachable in typed code (unwrap needs E = never);
+      // The Err branch is unreachable in typed code (get needs E = never);
       // force it via a cast to exercise the defensive runtime guard.
-      (Err("e") as unknown as Result<number, never>).unwrap();
+      (Err("e") as unknown as Result<number, never>).get();
       expect.unreachable();
     } catch (e) {
       expect(e).toBeInstanceOf(Error);
@@ -455,32 +455,32 @@ describe("Result eliminators on Ok / Err", () => {
     }
   });
 
-  it("unwrapErr returns the Err; throws UnwrapError on Ok; rethrows the cause on a Defect", () => {
-    expect(Err("e").unwrapErr()).toBe("e");
+  it("getErr returns the Err; throws UnwrapError on Ok; rethrows the cause on a Defect", () => {
+    expect(Err("e").getErr()).toBe("e");
     try {
-      // The Ok branch is unreachable in typed code (unwrapErr needs T = never);
+      // The Ok branch is unreachable in typed code (getErr needs T = never);
       // force it via a cast to exercise the defensive runtime guard.
-      (Ok(1) as unknown as Result<never, number>).unwrapErr();
+      (Ok(1) as unknown as Result<never, number>).getErr();
       expect.unreachable();
     } catch (e) {
       expect((e as { name: string }).name).toBe("UnwrapError");
       expect((e as { error: unknown }).error).toBe(1);
     }
     try {
-      // Also type-unreachable (unwrapErr needs T = never; defectOf's declared
+      // Also type-unreachable (getErr needs T = never; defectOf's declared
       // T is number) — cast to exercise the Defect-rethrow guard.
-      (defectOf(boom) as unknown as Result<never, never>).unwrapErr();
+      (defectOf(boom) as unknown as Result<never, never>).getErr();
       expect.unreachable();
     } catch (e) {
       expect(e).toBe(boom);
     }
   });
 
-  it("unwrapOr / unwrapOrElse recover an Err", () => {
+  it("getOr / getOrElse recover an Err", () => {
     const e: Result<number, string> = Err("e");
-    expect(e.unwrapOr(9)).toBe(9);
-    expect(e.unwrapOrElse((s) => s.length)).toBe(1);
-    expect(Ok(3).unwrapOr(9)).toBe(3);
+    expect(e.getOr(9)).toBe(9);
+    expect(e.getOrElse((s) => s.length)).toBe(1);
+    expect(Ok(3).getOr(9)).toBe(3);
   });
 
   it("getOrNull / getOrUndefined return the value or the empty sentinel on Err", () => {
@@ -494,7 +494,7 @@ describe("Result eliminators on Ok / Err", () => {
     expect(Ok(3).getOrThrow()).toBe(3);
 
     // Err throws the error value itself, BY REFERENCE (faithful to
-    // `.orElse((e) => { throw e })`). `toThrow(err)` only matches the message,
+    // `.flatMapErr((e) => { throw e })`). `toThrow(err)` only matches the message,
     // so assert identity via try/catch instead.
     const err = new Error("modeled");
     try {
@@ -524,8 +524,8 @@ describe("Result eliminators on Ok / Err", () => {
 
 describe("Result.toAsync", () => {
   it("lifts a Result into an awaitable AsyncResult", async () => {
-    expect((await Ok(5).toAsync()).unwrap()).toBe(5);
-    expect((await Err("e").toAsync()).unwrapErr()).toBe("e");
+    expect((await Ok(5).toAsync()).get()).toBe(5);
+    expect((await Err("e").toAsync()).getErr()).toBe("e");
     expect((await defectOf(boom).toAsync()).isDefect()).toBe(true);
   });
 });

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -137,8 +137,8 @@ type _flatTapped = Expect<Equal<typeof flatTapped, Result<number, "e1" | "e2">>>
 const flatTapErred = r1.flatTapErr(() => Err<"e2">("e2"));
 type _flatTapErred = Expect<Equal<typeof flatTapErred, Result<number, "e1" | "e2">>>;
 
-// recover empties the error channel (to `never`)
-const recovered = r1.recover(() => 0);
+// recoverErr empties the error channel (to `never`)
+const recovered = r1.recoverErr(() => 0);
 type _recovered = Expect<Equal<typeof recovered, Result<number, never>>>;
 
 // map changes the value type; mapErr changes the error type
@@ -219,25 +219,25 @@ const _noValue = g.value;
 // @ts-expect-error - `.error` only exists on the Err variant
 const _noError = g.error;
 
-// --- unwrap / unwrapErr are gated on an empty opposite channel ---------------
+// --- get / getErr are gated on an empty opposite channel ---------------
 
 declare const rNever: Result<number, never>;
 declare const rFallible: Result<number, "e">;
 declare const rErrOnly: Result<never, "e">;
-rNever.unwrap(); // ok: E = never
-rErrOnly.unwrapErr(); // ok: T = never
-// @ts-expect-error - unwrap requires E = never
-rFallible.unwrap();
-// @ts-expect-error - unwrapErr requires T = never
-rFallible.unwrapErr();
+rNever.get(); // ok: E = never
+rErrOnly.getErr(); // ok: T = never
+// @ts-expect-error - get requires E = never
+rFallible.get();
+// @ts-expect-error - getErr requires T = never
+rFallible.getErr();
 
 declare const arNever: AsyncResult<number, never>;
 declare const arFallible: AsyncResult<number, "e">;
-arNever.unwrap();
-// @ts-expect-error - async unwrap requires E = never
-arFallible.unwrap();
-// @ts-expect-error - async unwrapErr requires T = never
-arFallible.unwrapErr();
+arNever.get();
+// @ts-expect-error - async get requires E = never
+arFallible.get();
+// @ts-expect-error - async getErr requires T = never
+arFallible.getErr();
 
 // getOrThrow is NOT gated — it compiles on a fallible Result and returns T
 // (it throws the modeled error at runtime instead of eliminating it in the type)
@@ -311,8 +311,8 @@ new WithMsg({ ticketId: "t1" });
   r.map(async (n) => n + 1);
   // @ts-expect-error — async mapErr callback is banned
   r.mapErr(async (e) => e);
-  // @ts-expect-error — async recover callback is banned
-  r.recover(async () => 0);
+  // @ts-expect-error — async recoverErr callback is banned
+  r.recoverErr(async () => 0);
   // @ts-expect-error — async tapErr callback is banned
   r.tapErr(async () => {});
   // @ts-expect-error — async tapDefect callback is banned
@@ -326,8 +326,8 @@ new WithMsg({ ticketId: "t1" });
   ar.map(async (n) => n + 1);
   // @ts-expect-error — async mapErr callback is banned (async surface)
   ar.mapErr(async (e) => e);
-  // @ts-expect-error — async recover callback is banned (async surface)
-  ar.recover(async () => 0);
+  // @ts-expect-error — async recoverErr callback is banned (async surface)
+  ar.recoverErr(async () => 0);
   // @ts-expect-error — async tapErr callback is banned (async surface)
   ar.tapErr(async () => {});
   // @ts-expect-error — async tapDefect callback is banned (async surface)
@@ -339,7 +339,7 @@ new WithMsg({ ticketId: "t1" });
   // Synchronous callbacks still infer exactly as before.
   const mapped = r.map((n) => n + 1);
   type _MapKeeps = Expect<Equal<typeof mapped, Result<number, "e">>>;
-  const recovered = r.recover((e) => e.length);
+  const recovered = r.recoverErr((e) => e.length);
   type _RecoverKeeps = Expect<Equal<typeof recovered, Result<number, never>>>;
 
   // match handlers may still be async (edge elimination is not a combinator).
@@ -350,18 +350,18 @@ new WithMsg({ ticketId: "t1" });
   });
 }
 
-// --- unwrapOr widens: the fallback may be a different type ----
+// --- getOr widens: the fallback may be a different type ----
 
 {
   const r = Ok(1) as Result<number, "e">;
-  const widened = r.unwrapOr(null);
+  const widened = r.getOr(null);
   type _Widens = Expect<Equal<typeof widened, number | null>>;
 }
 
-// --- unwrapOrElse widens: the fallback function may return a different type ----
+// --- getOrElse widens: the fallback function may return a different type ----
 
 {
   const r = Ok(1) as Result<number, "e">;
-  const widened = r.unwrapOrElse(() => null);
+  const widened = r.getOrElse(() => null);
   type _Widens = Expect<Equal<typeof widened, number | null>>;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -186,7 +186,7 @@ export type ResultMethods<T, E> = {
    */
   flatMapErr<U, E2>(f: (error: E) => Result<U, E2>): Result<T | U, E2>;
   /**
-   * The success value or the produced fallback `Result`.
+   * Sequence from an `Err` by producing another `Result`.
    *
    * @deprecated Renamed to {@link ResultMethods.flatMapErr | flatMapErr} — it is
    * `flatMap` on the error channel, so it now follows the `…Err` convention. This

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -40,7 +40,7 @@ export type NotThenable<R> = [R] extends [PromiseLike<unknown>]
 
 /**
  * The fluent method surface every {@link Result} variant carries — the
- * combinators (`map`, `flatMap`, `mapErr`, `match`, `unwrap`, …), documented one
+ * combinators (`map`, `flatMap`, `mapErr`, `match`, `get`, …), documented one
  * per entry below. Factored out so the three variants ({@link OkView},
  * {@link ErrView}, {@link DefectView}) can each intersect it; {@link AsyncResult}
  * mirrors this surface with async signatures.
@@ -174,7 +174,8 @@ export type ResultMethods<T, E> = {
    */
   mapErr<E2>(f: (error: E) => E2 & NotThenable<E2>): Result<T, E2>;
   /**
-   * Recover from an `Err` by producing another `Result`.
+   * Sequence from an `Err` by producing another `Result` — the error-channel
+   * mirror of {@link ResultMethods.flatMap | flatMap}.
    *
    * Runs `f` only on `Err`; `Ok` and `Defect` pass through. If `f` throws, the
    * throw becomes a `Defect`.
@@ -183,10 +184,22 @@ export type ResultMethods<T, E> = {
    * @typeParam E2 - the error type `f` may produce instead.
    * @param f - produces a fallback `Result` from the current error.
    */
+  flatMapErr<U, E2>(f: (error: E) => Result<U, E2>): Result<T | U, E2>;
+  /**
+   * The success value or the produced fallback `Result`.
+   *
+   * @deprecated Renamed to {@link ResultMethods.flatMapErr | flatMapErr} — it is
+   * `flatMap` on the error channel, so it now follows the `…Err` convention. This
+   * alias will be removed in a future major.
+   *
+   * @typeParam U - an alternative success type `f` may produce.
+   * @typeParam E2 - the error type `f` may produce instead.
+   * @param f - produces a fallback `Result` from the current error.
+   */
   orElse<U, E2>(f: (error: E) => Result<U, E2>): Result<T | U, E2>;
   /**
    * Recover from an `Err` by producing a success value, emptying the error
-   * channel.
+   * channel. Pairs with {@link ResultMethods.recoverDefect | recoverDefect}.
    *
    * @remarks
    * The result type is `Result<T | U, never>`, but `never` describes only the
@@ -194,6 +207,17 @@ export type ResultMethods<T, E> = {
    * read `never` as "total". Runs `f` only on `Err`; `Ok` and `Defect` pass
    * through. If `f` throws, the throw becomes a `Defect`. An async callback is
    * rejected at compile time ({@link NotThenable}).
+   *
+   * @typeParam U - the recovered success type.
+   * @param f - produces a success value from the current error.
+   */
+  recoverErr<U>(f: (error: E) => U & NotThenable<U>): Result<T | U, never>;
+  /**
+   * Recover from an `Err` by producing a success value.
+   *
+   * @deprecated Renamed to {@link ResultMethods.recoverErr | recoverErr} — it now
+   * pairs with {@link ResultMethods.recoverDefect | recoverDefect} and follows the
+   * `…Err` convention. This alias will be removed in a future major.
    *
    * @typeParam U - the recovered success type.
    * @param f - produces a success value from the current error.
@@ -281,14 +305,23 @@ export type ResultMethods<T, E> = {
    *
    * @remarks
    * Compiles only when the error channel is empty (`E = never`) — eliminate
-   * modeled errors first (`match` / `recover` / `orElse`), or reach for the
-   * `unwrapOr` / `unwrapOrElse` / `getOrNull` / `getOrUndefined` family (which
+   * modeled errors first (`match` / `recoverErr` / `flatMapErr`), or reach for the
+   * `getOr` / `getOrElse` / `getOrNull` / `getOrUndefined` family (which
    * recover an `Err`). If you get a `'this' context` type error here, that is
    * the gate: the receiver still has a non-`never` error channel.
    *
    * `E = never` empties only the **modeled** error channel — a `Defect` can
-   * still be present, and `unwrap()` **rethrows its original cause** (it
-   * _panics_); `Result<T, never>` does not mean `unwrap()` cannot throw.
+   * still be present, and `get()` **rethrows its original cause** (it
+   * _panics_); `Result<T, never>` does not mean `get()` cannot throw.
+   *
+   * @returns the `Ok` value.
+   */
+  get(this: Result<T, never>): T;
+  /**
+   * Extract the success value.
+   *
+   * @deprecated Renamed to {@link ResultMethods.get | get}, unifying the extractor
+   * family under `get…`. This alias will be removed in a future major.
    *
    * @returns the `Ok` value.
    */
@@ -302,7 +335,16 @@ export type ResultMethods<T, E> = {
    * `Result` you hold usually still has a success type), so to inspect an
    * error prefer an `isErr()` guard or, in tests, `@unthrown/vitest`'s
    * `toBeErrWith`. A `Defect` still **rethrows its original cause** (a defect is
-   * a bug, not an absent value), so this does not mean `unwrapErr()` can't throw.
+   * a bug, not an absent value), so this does not mean `getErr()` can't throw.
+   *
+   * @returns the `Err` value.
+   */
+  getErr(this: Result<never, E>): E;
+  /**
+   * Extract the modeled error.
+   *
+   * @deprecated Renamed to {@link ResultMethods.getErr | getErr}, unifying the
+   * extractor family under `get…`. This alias will be removed in a future major.
    *
    * @returns the `Err` value.
    */
@@ -315,12 +357,34 @@ export type ResultMethods<T, E> = {
    * @throws Re-throws on a `Defect` — a Defect is a bug, not an absent value, so
    * it is never silently replaced.
    */
+  getOr<U>(fallback: U): T | U;
+  /**
+   * The success value, or `fallback` on `Err`.
+   *
+   * @deprecated Renamed to {@link ResultMethods.getOr | getOr}, unifying the
+   * extractor family under `get…`. This alias will be removed in a future major.
+   *
+   * @typeParam U - the fallback type (may differ from `T`; the return widens to `T | U`).
+   * @param fallback - returned when the result is an `Err`.
+   * @throws Re-throws on a `Defect`.
+   */
   unwrapOr<U>(fallback: U): T | U;
   /**
    * The success value, or `f(error)` on `Err`.
    *
    * @typeParam U - the fallback type (may differ from `T`; the return widens to `T | U`).
    * @param f - lazily computes the fallback from the error (may return a different type; the return widens to `T | U`).
+   * @throws Re-throws on a `Defect`.
+   */
+  getOrElse<U>(f: (error: E) => U): T | U;
+  /**
+   * The success value, or `f(error)` on `Err`.
+   *
+   * @deprecated Renamed to {@link ResultMethods.getOrElse | getOrElse}, unifying
+   * the extractor family under `get…`. This alias will be removed in a future major.
+   *
+   * @typeParam U - the fallback type (may differ from `T`; the return widens to `T | U`).
+   * @param f - lazily computes the fallback from the error.
    * @throws Re-throws on a `Defect`.
    */
   unwrapOrElse<U>(f: (error: E) => U): T | U;
@@ -341,13 +405,13 @@ export type ResultMethods<T, E> = {
    *
    * @remarks
    * A deliberate escape hatch off the errors-as-values model. Unlike
-   * {@link ResultMethods.unwrap | unwrap} (type-gated to an empty error
+   * {@link ResultMethods.get | get} (type-gated to an empty error
    * channel), this compiles on any `Result<T, E>` and **throws the `Err` value
    * as-is** at the call site. Its purpose is to move a literal `throw` behind a
    * method, so a `no-throw` lint rule can ban raw throws while this one
    * sanctioned extraction remains — _not_ to replace principled handling. When
    * you can keep the error a value, prefer {@link ResultMethods.match | match} /
-   * {@link ResultMethods.recover | recover} / {@link ResultMethods.orElse | orElse}.
+   * {@link ResultMethods.recoverErr | recoverErr} / {@link ResultMethods.flatMapErr | flatMapErr}.
    *
    * @returns the `Ok` value.
    * @throws the modeled `error` on `Err`; re-throws the original `cause` on a
@@ -486,7 +550,7 @@ export type Awaitable<T> = {
 
 /**
  * The async method surface every {@link AsyncResult} carries — the combinators
- * (`map`, `flatMap`, `mapErr`, `match`, `unwrap`, …) with their asynchronous
+ * (`map`, `flatMap`, `mapErr`, `match`, `get`, …) with their asynchronous
  * signatures, documented one per entry below. The async mirror of
  * {@link ResultMethods}: each entry links its synchronous counterpart and states
  * only the async delta.
@@ -565,14 +629,24 @@ export type AsyncResultMethods<T, E> = {
    */
   mapErr<E2>(f: (error: E) => E2 & NotThenable<E2>): AsyncResult<T, E2>;
   /**
-   * Asynchronous {@link ResultMethods.orElse | orElse}. `f` may return a `Result`
-   * or an `AsyncResult`.
+   * Asynchronous {@link ResultMethods.flatMapErr | flatMapErr}. `f` may return a
+   * `Result` or an `AsyncResult`.
+   */
+  flatMapErr<U, E2>(f: (error: E) => Result<U, E2> | AsyncResult<U, E2>): AsyncResult<T | U, E2>;
+  /**
+   * @deprecated Renamed to {@link AsyncResultMethods.flatMapErr | flatMapErr}.
+   * This alias will be removed in a future major.
    */
   orElse<U, E2>(f: (error: E) => Result<U, E2> | AsyncResult<U, E2>): AsyncResult<T | U, E2>;
   /**
-   * Asynchronous {@link ResultMethods.recover | recover}. `f` is synchronous; a
-   * throw becomes a `Defect`. An async callback is rejected at compile time
-   * ({@link NotThenable}).
+   * Asynchronous {@link ResultMethods.recoverErr | recoverErr}. `f` is
+   * synchronous; a throw becomes a `Defect`. An async callback is rejected at
+   * compile time ({@link NotThenable}).
+   */
+  recoverErr<U>(f: (error: E) => U & NotThenable<U>): AsyncResult<T | U, never>;
+  /**
+   * @deprecated Renamed to {@link AsyncResultMethods.recoverErr | recoverErr}.
+   * This alias will be removed in a future major.
    */
   recover<U>(f: (error: E) => U & NotThenable<U>): AsyncResult<T | U, never>;
   /**
@@ -622,20 +696,40 @@ export type AsyncResultMethods<T, E> = {
     defect: (cause: unknown) => R;
   }): Promise<R>;
   /**
-   * Asynchronous {@link ResultMethods.unwrap | unwrap}. Compiles only when the
+   * Asynchronous {@link ResultMethods.get | get}. Compiles only when the
    * error channel is empty (`this: AsyncResult<T, never>`); the returned promise
    * rejects on a `Defect` (rethrowing its cause).
    */
+  get(this: AsyncResult<T, never>): Promise<T>;
+  /**
+   * @deprecated Renamed to {@link AsyncResultMethods.get | get}. This alias will
+   * be removed in a future major.
+   */
   unwrap(this: AsyncResult<T, never>): Promise<T>;
   /**
-   * Asynchronous {@link ResultMethods.unwrapErr | unwrapErr}. Compiles only when
+   * Asynchronous {@link ResultMethods.getErr | getErr}. Compiles only when
    * the success channel is empty (`this: AsyncResult<never, E>`); the returned
    * promise rejects on a `Defect` (rethrowing its cause).
    */
+  getErr(this: AsyncResult<never, E>): Promise<E>;
+  /**
+   * @deprecated Renamed to {@link AsyncResultMethods.getErr | getErr}. This alias
+   * will be removed in a future major.
+   */
   unwrapErr(this: AsyncResult<never, E>): Promise<E>;
-  /** Asynchronous {@link ResultMethods.unwrapOr | unwrapOr}. */
+  /** Asynchronous {@link ResultMethods.getOr | getOr}. */
+  getOr<U>(fallback: U): Promise<T | U>;
+  /**
+   * @deprecated Renamed to {@link AsyncResultMethods.getOr | getOr}. This alias
+   * will be removed in a future major.
+   */
   unwrapOr<U>(fallback: U): Promise<T | U>;
-  /** Asynchronous {@link ResultMethods.unwrapOrElse | unwrapOrElse}. */
+  /** Asynchronous {@link ResultMethods.getOrElse | getOrElse}. */
+  getOrElse<U>(f: (error: E) => U): Promise<T | U>;
+  /**
+   * @deprecated Renamed to {@link AsyncResultMethods.getOrElse | getOrElse}. This
+   * alias will be removed in a future major.
+   */
   unwrapOrElse<U>(f: (error: E) => U): Promise<T | U>;
   /** Asynchronous {@link ResultMethods.getOrNull | getOrNull}. */
   getOrNull(): Promise<T | null>;
@@ -660,8 +754,8 @@ export type AsyncResultMethods<T, E> = {
  * rejection would silently become a `Defect`, skipping the triage that
  * {@link fromPromise} forces. To do further async work, re-enter through a
  * qualified boundary and compose it: `ar.flatMap((v) => fromPromise(work(v),
- * qualify))`. The eliminators (`unwrap`, …) return promises; the binds
- * (`flatMap`, `flatTap`, `orElse`, `recoverDefect`) additionally accept an
+ * qualify))`. The eliminators (`get`, …) return promises; the binds
+ * (`flatMap`, `flatTap`, `flatMapErr`, `recoverDefect`) additionally accept an
  * `AsyncResult`. Its combinators are documented one per entry on
  * {@link AsyncResultMethods}.
  *

--- a/packages/standard-schema/src/index.ts
+++ b/packages/standard-schema/src/index.ts
@@ -56,8 +56,8 @@ function isThenable(value: unknown): value is PromiseLike<unknown> {
  * ```ts
  * import { fromSchema } from "@unthrown/standard-schema";
  * const parse = fromSchema(z.string());
- * parse("hi").unwrap(); // "hi"
- * parse(42).unwrapErr(); // the issues array
+ * parse("hi").get(); // "hi"
+ * parse(42).getErr(); // the issues array
  * ```
  */
 export function fromSchema<S extends StandardSchemaV1>(


### PR DESCRIPTION
Follow-up to the naming-consistency audit. Renames the operators that broke the library's own `…Err` / `get…` conventions, **keeping every old name as a deprecated, runtime-identical alias** — no breaking change.

## Renames

| old | new | why |
| --- | --- | --- |
| `orElse` | **`flatMapErr`** | it's `flatMap` on the error channel — now follows the `…Err` rule (like `mapErr`, `flatTapErr`) |
| `recover` | **`recoverErr`** | pairs with `recoverDefect` |
| `unwrap` | **`get`** | unify the extractor family under `get…` |
| `unwrapErr` | **`getErr`** | ″ |
| `unwrapOr` | **`getOr`** | ″ (also resolves the old `unwrapOr` / `getOr` prefix split) |
| `unwrapOrElse` | **`getOrElse`** | ″ — joins `getOrNull` / `getOrUndefined` / `getOrThrow` |

The error channel now mirrors the success channel exactly: `map`/`flatMap`/`tap`/`flatTap` ↔ `mapErr`/`flatMapErr`/`tapErr`/`flatTapErr`, with `recoverErr`/`recoverDefect` as the cross-channel pair. All seven extractors share the `get…` prefix.

## Deprecation, not removal

Both `Result` and `AsyncResult` gain the new names. Each old name stays as a `@deprecated` alias that just delegates to its replacement (the gated `unwrap`/`unwrapErr` keep their `this` type-gate via a runtime-identical cast). Editors show the old names struck through, pointing at the new one. Scheduled for removal in a future major.

## Scope

- **Core**: `types.ts` (both `*Methods` surfaces + TSDoc), `core.ts` (`Res` + `AsyncRes` impls & aliases, `UnwrapError` prose).
- **Migrated to new names**: every call site, all specs, `types.test-d.ts`, `standard-schema` TSDoc examples, the guide docs, `README`, `docs/index.md`, and the `CLAUDE.md` spec (which also gains a "deprecated aliases" section). Prose verbs "recover"/"unwrap" were left intact; the `migrating-from-neverthrow` table keeps neverthrow's own `orElse`/`unwrapOr` in its left column.
- **New**: `deprecated-aliases.spec.ts` proves every alias (sync + async) still delegates.

## Gate

Typecheck (incl. type-d) 15/15, 212 tests, **100% line/function coverage**, lint, TypeDoc (warning-free), and all 16 builds green. Generated API docs are gitignored (regenerate on deploy). `minor` changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)