### PR TITLE
feat(orpc): add @unthrown/orpc — the oRPC v2 bridge

### DIFF
--- a/.changeset/orpc-integration.md
+++ b/.changeset/orpc-integration.md
@@ -1,0 +1,25 @@
+---
+"@unthrown/orpc": minor
+---
+
+Initial release of **@unthrown/orpc** — a two-way bridge between oRPC v2 and
+unthrown, built on v2's returned-`ORPCError` end-to-end inference.
+
+**Server** (`@unthrown/orpc/server`): `handlerResult(fn)` adapts a
+`Result`-returning procedure handler — `Ok` becomes the output; `Err`
+(constrained to `ORPCError`) is returned as a value, which oRPC marks
+_inferable_ so the client sees it fully typed; a `Defect` rethrows its cause
+and collapses to `INTERNAL_SERVER_ERROR`. The opt-in
+`@unthrown/orpc/extensions/result` subpath patches a `.result()` method onto
+every builder state and contract-first implementers (the package's one
+side-effectful entry point).
+
+**Client** (`@unthrown/orpc/client`): `createResultClient(client)` wraps a
+whole router so every call returns `AsyncResult<Output, InferableErrors>`;
+`fromCall(promise)` is the one-shot form (also lifts the server-side
+`call(...)`). The error channel is the raw inferable `ORPCError` union,
+discriminated by `code`; everything non-inferable is a `Defect`.
+
+Peer deps `@orpc/client` / `@orpc/server` at `^2.0.0-beta`; versioned outside
+the unthrown fixed group — majors track oRPC's cadence. Event-iterator
+(streaming) procedures are out of scope.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,13 +325,46 @@ library can be "done".
   group** — its majors track `@prisma/client`'s cadence, not the family's.
   `engines: { node: ">=20.19" }` (Prisma 7's floor), the one exception to the
   family's `>=20`. Documented in the Prisma guide page.)
+- `packages/orpc` → `@unthrown/orpc` (peerDeps `@orpc/client` + `@orpc/server`
+  at `^2.0.0-beta` — **peers, not deps**: `isInferableError` is an
+  `instanceof ORPCError` check, the same dual-copy hazard as `isResult`;
+  `@orpc/server` is an **optional** peer so a browser-only consumer skips it.
+  A two-way bridge built on oRPC v2's returned-`ORPCError` inference (an error
+  a procedure declares via `.errors({...})` or returns as a value is
+  _inferable_ — typed end-to-end; everything else collapses to
+  `INTERNAL_SERVER_ERROR`), which maps onto the variants exactly: `Ok` ↔
+  output, `Err` ↔ returned inferable `ORPCError`, `Defect` ↔ the rest. Three
+  entry points, **no root export**: `./server` — `handlerResult(fn)` adapts a
+  `Result`-returning handler (`Err` is constrained to `ORPCError`, so the
+  `mapErr` into `errors.CODE(...)` at the endpoint is the Thesis-#3 triage
+  point; a `Defect` rethrows its cause; a non-`ORPCError` `Err` smuggled past
+  the types routes to the defect path — it must never be served as a
+  successful output; the callback may be async — an elimination edge, exempt
+  like `match`). `./extensions/result` — the opt-in `.result()` builder
+  method via `declare module "@orpc/server"` augmentation + two prototype
+  patches (`Builder`, `ProcedureImplementer` — every builder state shares the
+  `Builder` class at runtime); the package's ONE side-effectful entry, listed
+  in a `sideEffects` array (the `@orpc/experimental-effect` packaging).
+  `./client` — `fromCall(promise)` lifts a single call (client call or
+  server-side `call(...)`), `createResultClient(client)` recursively wraps a
+  router (the `createSafeClient` mirror): `E` is the raw inferable `ORPCError`
+  union discriminated by `code` — deliberately NOT re-wrapped into
+  `TaggedError` (`matchTags` doesn't apply to this package); non-inferable →
+  `Defect`. Event-iterator (streaming) procedures are deliberately out of
+  scope — the raw client is the escape hatch. Tested end-to-end against real
+  oRPC machinery: `createRouterClient` in-process plus an
+  `RPCHandler`/`RPCLink` loop through a custom `fetch` (real JSON
+  serialization, where the defect-collapse to `INTERNAL_SERVER_ERROR`
+  actually happens). **Deliberately outside the fixed version group** — its
+  majors track oRPC's cadence, not the family's. Documented in the oRPC guide
+  page.)
 - `tools/tsconfig`, `tools/typedoc` → private shared config (`@unthrown/tsconfig`,
   `@unthrown/typedoc`)
 - `docs` → `@unthrown/docs`, the VitePress site (guide + TypeDoc-generated API
   reference); deployed to GitHub Pages by `deploy-docs.yml`
 
 Never pull `ts-pattern`, `vitest`, or any interop peer (`effect`, `neverthrow`,
-`@bloodyowl/boxed`) into core.
+`@bloodyowl/boxed`, `@orpc/*`) into core.
 
 Every satellite package depends on core via `workspace:^` (an exact pin would
 create a dual-copy hazard with the `instanceof`-based `isResult`); for the same

--- a/README.md
+++ b/README.md
@@ -80,15 +80,18 @@ defect, so the edge of your program needs a single `match` and no `try`/`catch`.
 
 ## Packages
 
-| Package                                         | Description                                                                                    |
-| ----------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| [`unthrown`](./packages/core)                   | The core `Result` / `AsyncResult`, interop, `TaggedError`, `matchTags`. Zero runtime deps.     |
-| [`@unthrown/vitest`](./packages/vitest)         | Vitest matchers: `toBeOk`, `toBeOkWith`, `toBeErr`, `toBeErrTagged`, `toBeDefect`.             |
-| [`@unthrown/pattern`](./packages/pattern)       | Thin `ts-pattern` sugar for the natively-matchable `Result`: `P.Ok`/`P.Err`/`P.Defect`, `tag`. |
-| [`@unthrown/effect`](./packages/effect)         | Effect interop: `Result ↔ Exit` (bijection), `Either`, `Effect`.                               |
-| [`@unthrown/neverthrow`](./packages/neverthrow) | neverthrow interop: `Result ↔ Result`, `AsyncResult ↔ ResultAsync`.                            |
-| [`@unthrown/boxed`](./packages/boxed)           | Boxed interop: `Result ↔ Result`, `AsyncResult ↔ Future<Result>`.                              |
-| [`@unthrown/prisma`](./packages/prisma)         | Prisma Client extension: `try*` query methods returning `AsyncResult`, per-operation errors.   |
+| Package                                                   | Description                                                                                    |
+| --------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| [`unthrown`](./packages/core)                             | The core `Result` / `AsyncResult`, interop, `TaggedError`, `matchTags`. Zero runtime deps.     |
+| [`@unthrown/vitest`](./packages/vitest)                   | Vitest matchers: `toBeOk`, `toBeOkWith`, `toBeErr`, `toBeErrTagged`, `toBeDefect`.             |
+| [`@unthrown/pattern`](./packages/pattern)                 | Thin `ts-pattern` sugar for the natively-matchable `Result`: `P.Ok`/`P.Err`/`P.Defect`, `tag`. |
+| [`@unthrown/effect`](./packages/effect)                   | Effect interop: `Result ↔ Exit` (bijection), `Either`, `Effect`.                               |
+| [`@unthrown/neverthrow`](./packages/neverthrow)           | neverthrow interop: `Result ↔ Result`, `AsyncResult ↔ ResultAsync`.                            |
+| [`@unthrown/boxed`](./packages/boxed)                     | Boxed interop: `Result ↔ Result`, `AsyncResult ↔ Future<Result>`.                              |
+| [`@unthrown/prisma`](./packages/prisma)                   | Prisma Client extension: `try*` query methods returning `AsyncResult`, per-operation errors.   |
+| [`@unthrown/orpc`](./packages/orpc)                       | oRPC (v2) bridge: `Result`-returning handlers, `AsyncResult` client, typed errors end-to-end.  |
+| [`@unthrown/standard-schema`](./packages/standard-schema) | `fromSchema` / `fromSchemaAsync`: any Standard Schema validator into a `Result`.               |
+| [`@unthrown/oxlint`](./packages/oxlint)                   | oxlint plugin: `no-ambiguous-error-type`, `prefer-async-result`.                               |
 
 ## Contributing
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -109,6 +109,7 @@ export default defineConfig({
             { text: "Testing", link: "/guide/testing" },
             { text: "Pattern Matching", link: "/guide/pattern-matching" },
             { text: "Prisma", link: "/guide/prisma" },
+            { text: "oRPC", link: "/guide/orpc" },
             { text: "Linting", link: "/guide/linting" },
             { text: "Interop", link: "/guide/interop" },
             {
@@ -131,6 +132,7 @@ export default defineConfig({
             { text: "@unthrown/boxed", link: "/api/boxed/" },
             { text: "@unthrown/standard-schema", link: "/api/standard-schema/" },
             { text: "@unthrown/prisma", link: "/api/prisma/" },
+            { text: "@unthrown/orpc", link: "/api/orpc/" },
           ],
         },
       ],

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -26,6 +26,10 @@ This reference is generated from the source with
 - [**@unthrown/standard-schema**](./standard-schema/) — `fromSchema` /
   `fromSchemaAsync`: run any Standard Schema validator (Zod, Valibot, ArkType)
   into a `Result` with the validation issues as the modeled error.
+- [**@unthrown/orpc**](./orpc/) — the oRPC (v2) bridge: `handlerResult` /
+  `.result()` for `Result`-returning procedure handlers, `createResultClient` /
+  `fromCall` for an `AsyncResult` client, with the inferable `ORPCError` union
+  as the modeled error.
 
 `@unthrown/oxlint` (the lint rules `no-ambiguous-error-type` and
 `prefer-async-result`) has no generated API page — it is documented in the

--- a/docs/guide/orpc.md
+++ b/docs/guide/orpc.md
@@ -1,0 +1,188 @@
+# oRPC
+
+[`@unthrown/orpc`](/api/orpc/) bridges [oRPC](https://orpc.dev) (v2) and
+unthrown in both directions: procedure handlers that _return_ a
+[`Result`](./core-concepts) on the server, and a client whose every call yields
+an [`AsyncResult`](./async-results) — with oRPC's end-to-end typed errors as
+the modeled error channel.
+
+```sh
+pnpm add @unthrown/orpc unthrown
+```
+
+oRPC is an unusually good fit for unthrown, because its error model already
+agrees with the [thesis](./why-unthrown): an error a procedure **declares**
+(`.errors({...})`) or **returns as a value** is _inferable_ — typed end-to-end,
+recognisable at runtime — while everything else is collapsed to
+`INTERNAL_SERVER_ERROR`. That is exactly the `Err` / [`Defect`](./the-defect-channel)
+split:
+
+| unthrown     | oRPC v2                                       |
+| ------------ | --------------------------------------------- |
+| `Ok(value)`  | the procedure's output                        |
+| `Err(error)` | a returned `ORPCError` — inferable, typed E2E |
+| `Defect`     | everything else (`INTERNAL_SERVER_ERROR`)     |
+
+Qualification happens **once, inside the bridge**
+([Boundaries](./boundaries)): the triage decision was already made when the
+procedure declared (or returned) its errors, so no per-call `qualify` is asked
+of you.
+
+::: info oRPC v2
+The package targets oRPC **v2** (in beta at the time of writing; peer range
+`^2.0.0-beta`), whose returned-`ORPCError` inference is what the server half
+builds on. Its majors track oRPC's cadence, not the unthrown family's.
+:::
+
+## Server: handlers that return a `Result`
+
+`handlerResult` adapts a `Result`-returning handler into a plain oRPC handler —
+your service layer keeps speaking `Result`, and the endpoint stops needing to
+unwrap it into throws:
+
+```ts
+import { handlerResult } from "@unthrown/orpc/server";
+import { os } from "@orpc/server";
+import * as z from "zod";
+
+const find = os
+  .input(z.object({ id: z.string() }))
+  .errors({ NOT_FOUND: {} })
+  .handler(
+    handlerResult(({ input, errors }) =>
+      repo.findPlanet(input.id).mapErr(() => errors.NOT_FOUND()),
+    ),
+  );
+```
+
+- `Ok` becomes the procedure's output.
+- `Err` is **returned as a value**; oRPC marks it inferable, so the client sees
+  it fully typed. The error channel is constrained to `ORPCError` — the
+  `mapErr` that turns a domain error into one (here `errors.NOT_FOUND()`, the
+  constructor oRPC injects) is the explicit triage point at the transport
+  boundary.
+- A `Defect` rethrows its original cause, which oRPC collapses to
+  `INTERNAL_SERVER_ERROR`. A bug stays a defect — it never becomes a typed
+  error your client is invited to handle.
+
+A returned `ORPCError` needs no `.errors({...})` declaration at all — v2 infers
+it from the handler's type:
+
+```ts
+const limited = os.handler(
+  handlerResult(({ input }) =>
+    tooMany(input)
+      ? Err(new ORPCError("RATE_LIMITED", { data: { retryAfter: 60 } }))
+      : Ok("welcome"),
+  ),
+);
+// the client's error channel: ORPCError<"RATE_LIMITED", { retryAfter: number }>
+```
+
+The handler may be synchronous, `async`, or return an `AsyncResult` directly —
+an elimination edge is exempt from the no-thenable rule (same as `match`
+handlers): a throw or rejection inside it cannot skip triage, because oRPC's
+own boundary already treats it as the defect path.
+
+### The `.result()` builder extension
+
+If you prefer a builder method over wrapping, opt into the extension — one
+side-effectful import (the packaging `@orpc/experimental-effect` uses for
+`.effect()`):
+
+```ts
+import "@unthrown/orpc/extensions/result";
+
+const find = os
+  .input(z.object({ id: z.string() }))
+  .errors({ NOT_FOUND: {} })
+  .result(({ input, errors }) => repo.findPlanet(input.id).mapErr(() => errors.NOT_FOUND()));
+```
+
+It is available on every builder state (`os`, after `.use`, `.input`,
+`.output`, `.errors`) and on contract-first `implement(...)` implementers, and
+is runtime-identical to `.handler(handlerResult(...))`. Everything else in the
+package is side-effect-free; reach for `handlerResult` when patching a
+third-party prototype is unwelcome.
+
+## Client: calls that return an `AsyncResult`
+
+`createResultClient` wraps an oRPC client so every procedure returns an
+`AsyncResult` — the mirror of oRPC's own `createSafeClient`, producing
+`Result`s instead of `[error, data, inferableError]` tuples:
+
+```ts
+import { createResultClient } from "@unthrown/orpc/client";
+
+const rc = createResultClient(client);
+
+const greeting = await rc.planet
+  .find({ id })
+  .map((planet) => `Hello, ${planet.name}!`)
+  .match({
+    ok: (msg) => msg,
+    err: (e) => (e.code === "NOT_FOUND" ? "Hello, void!" : "Hello, trouble!"),
+    defect: () => "Hello, bug tracker!",
+  });
+```
+
+The error channel is the raw inferable `ORPCError` union, discriminated by
+`code` — deliberately **not** re-wrapped into [tagged errors](./tagged-errors):
+oRPC already ships a discriminated error type, and one concept should have one
+name. Branch on `code` (a `switch`, [ts-pattern](./pattern-matching), or the
+`.errors` data types); `matchTags` does not apply to this package.
+
+Anything non-inferable — a network failure, an undeclared throw collapsed to
+`INTERNAL_SERVER_ERROR`, a malformed response — is a `Defect`: it flows past
+your error combinators and [panics at `get`](./the-defect-channel), because it
+is a bug (or an outage), not an outcome your domain models.
+
+`fromCall` is the one-shot form, and also lifts oRPC's server-side
+`call(procedure, input)`:
+
+```ts
+import { fromCall } from "@unthrown/orpc/client";
+import { call } from "@orpc/server";
+
+const planet = await fromCall(client.planet.find({ id })); // a client call
+const seeded = await fromCall(call(find, { id: "1" })); // a server-side call
+```
+
+Call options (`signal`, `context`, `lastEventId`) pass through untouched.
+
+::: warning Streaming is out of scope
+Event-iterator procedures don't collapse to one `Result` — modelling a stream's
+per-event and terminal failures is its own design. Call those on the raw
+client.
+:::
+
+## End to end
+
+Both halves compose into one error vocabulary across layers — a
+[Prisma](./prisma)-backed service chains into an oRPC handler, and the browser
+consumes it, all in `Result`:
+
+```ts
+// server — the one mapErr is the whole edge: each domain error is either given
+// a client-facing code or declared not the client's business (a 500).
+const createUser = os
+  .input(z.object({ email: z.string() }))
+  .errors({ EMAIL_TAKEN: {} })
+  .handler(
+    handlerResult(({ input, errors }) =>
+      db.user
+        .tryCreate({ data: input })
+        .mapErr((e) =>
+          e._tag === "UniqueConstraintViolation"
+            ? errors.EMAIL_TAKEN()
+            : new ORPCError("INTERNAL_SERVER_ERROR", { cause: e }),
+        ),
+    ),
+  );
+
+// client
+const outcome = await rc.createUser({ email });
+if (outcome.isErr() && outcome.error.code === "EMAIL_TAKEN") {
+  form.setError("email", "already registered");
+}
+```

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,6 +14,7 @@
     "@unthrown/boxed": "workspace:*",
     "@unthrown/effect": "workspace:*",
     "@unthrown/neverthrow": "workspace:*",
+    "@unthrown/orpc": "workspace:*",
     "@unthrown/pattern": "workspace:*",
     "@unthrown/prisma": "workspace:*",
     "@unthrown/standard-schema": "workspace:*",

--- a/docs/scripts/copy-docs.ts
+++ b/docs/scripts/copy-docs.ts
@@ -12,6 +12,7 @@ import "@unthrown/neverthrow";
 import "@unthrown/boxed";
 import "@unthrown/standard-schema";
 import "@unthrown/prisma";
+import "@unthrown/orpc/client";
 
 import { cp, mkdir, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
@@ -30,6 +31,7 @@ const packages: ReadonlyArray<{ readonly pkg: string; readonly out: string }> = 
   { pkg: "@unthrown/boxed", out: "boxed" },
   { pkg: "@unthrown/standard-schema", out: "standard-schema" },
   { pkg: "@unthrown/prisma", out: "prisma" },
+  { pkg: "@unthrown/orpc", out: "orpc" },
 ];
 
 await mkdir(apiDir, { recursive: true });

--- a/docs/scripts/copy-docs.ts
+++ b/docs/scripts/copy-docs.ts
@@ -12,6 +12,11 @@ import "@unthrown/neverthrow";
 import "@unthrown/boxed";
 import "@unthrown/standard-schema";
 import "@unthrown/prisma";
+// @unthrown/orpc deliberately has NO root export (its API is split across
+// `./client` / `./server` / `./extensions/result`), so its dependency is
+// established through a subpath — a bare `import "@unthrown/orpc"` fails at
+// runtime. The `packages` list below still uses the bare package name: the
+// copy reads `node_modules/@unthrown/orpc/docs` directly, not an export.
 import "@unthrown/orpc/client";
 
 import { cp, mkdir, rm } from "node:fs/promises";

--- a/packages/orpc/LICENSE
+++ b/packages/orpc/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Benoit Travers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/orpc/README.md
+++ b/packages/orpc/README.md
@@ -1,0 +1,94 @@
+# @unthrown/orpc
+
+> An [oRPC](https://orpc.dev) (v2) integration for
+> [unthrown](https://github.com/btravstack/unthrown)'s `Result`:
+> `Result`-returning procedure handlers on the server, an `AsyncResult` client
+> on the caller side — with oRPC's end-to-end typed errors as the error channel.
+
+📖 **[Documentation](https://btravstack.github.io/unthrown/guide/orpc)** ·
+[API Reference](https://btravstack.github.io/unthrown/api/orpc/)
+
+```sh
+pnpm add @unthrown/orpc unthrown
+```
+
+oRPC v2 splits failures the way unthrown does: an error a procedure **declares**
+(`.errors({...})`) or **returns as a value** is _inferable_ — typed end-to-end —
+while everything else collapses to `INTERNAL_SERVER_ERROR`. The bridge maps that
+split onto the `Result` variants, in both directions:
+
+| unthrown     | oRPC v2                                       |
+| ------------ | --------------------------------------------- |
+| `Ok(value)`  | the procedure's output                        |
+| `Err(error)` | a returned `ORPCError` — inferable, typed E2E |
+| `Defect`     | everything else (`INTERNAL_SERVER_ERROR`)     |
+
+The error channel stays the raw `ORPCError` union, discriminated by `code` — no
+second error concept in between.
+
+## Server — `handlerResult` / `.result()`
+
+```ts
+import { handlerResult } from "@unthrown/orpc/server";
+
+const find = os
+  .input(z.object({ id: z.string() }))
+  .errors({ NOT_FOUND: {} })
+  .handler(
+    handlerResult(({ input, errors }) =>
+      repo.findPlanet(input.id).mapErr(() => errors.NOT_FOUND()),
+    ),
+  );
+```
+
+`Ok` becomes the output; `Err` (constrained to `ORPCError` — the `mapErr` at the
+endpoint is the explicit triage point) is returned as a value and oRPC marks it
+inferable; a `Defect` rethrows its cause and stays a defect. A handler may also
+be written as `.result(...)` directly, by opting into the builder extension:
+
+```ts
+import "@unthrown/orpc/extensions/result";
+
+const find = os
+  .input(z.object({ id: z.string() }))
+  .errors({ NOT_FOUND: {} })
+  .result(({ input, errors }) => repo.findPlanet(input.id).mapErr(() => errors.NOT_FOUND()));
+```
+
+(The import patches oRPC's builders — a deliberate import-time side effect, and
+the only entry point of this package that has one. Works on every builder state
+and on contract-first `implement(...)` implementers.)
+
+## Client — `createResultClient` / `fromCall`
+
+```ts
+import { createResultClient } from "@unthrown/orpc/client";
+
+const rc = createResultClient(client);
+
+const greeting = await rc.planet
+  .find({ id })
+  .map((planet) => `Hello, ${planet.name}!`)
+  .match({
+    ok: (msg) => msg,
+    err: (e) => (e.code === "NOT_FOUND" ? "Hello, void!" : "Hello, trouble!"),
+    defect: () => "Hello, bug tracker!",
+  });
+```
+
+Every procedure returns `AsyncResult<Output, InferableErrors>`: the inferable
+`ORPCError`s land in the error channel, anything else (network failure, an
+undeclared throw, a malformed response) is a `Defect`. `fromCall(promise)` is
+the one-shot form — it also lifts oRPC's server-side `call(procedure, input)`.
+
+Event-iterator (streaming) procedures are out of scope: a stream does not
+collapse to one `Result`. Keep calling those on the raw client.
+
+## Versioning
+
+`@unthrown/orpc` targets **oRPC v2** (peer range `^2.0.0-beta` while v2 is in
+beta) and its majors track oRPC's cadence, not the unthrown family's.
+
+## License
+
+[MIT](./LICENSE)

--- a/packages/orpc/package.json
+++ b/packages/orpc/package.json
@@ -1,0 +1,102 @@
+{
+  "name": "@unthrown/orpc",
+  "version": "0.0.0",
+  "description": "oRPC integration for unthrown: Result-returning procedure handlers and an AsyncResult client, with end-to-end typed errors",
+  "keywords": [
+    "errors-as-values",
+    "orpc",
+    "result",
+    "rpc",
+    "typescript",
+    "unthrown"
+  ],
+  "homepage": "https://github.com/btravstack/unthrown#readme",
+  "bugs": {
+    "url": "https://github.com/btravstack/unthrown/issues"
+  },
+  "license": "MIT",
+  "author": "Benoit TRAVERS <benoit.travers.fr@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/btravstack/unthrown.git",
+    "directory": "packages/orpc"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "sideEffects": [
+    "./dist/extensions/result.mjs",
+    "./dist/extensions/result.cjs"
+  ],
+  "exports": {
+    "./client": {
+      "import": {
+        "types": "./dist/client.d.mts",
+        "default": "./dist/client.mjs"
+      },
+      "require": {
+        "types": "./dist/client.d.cts",
+        "default": "./dist/client.cjs"
+      }
+    },
+    "./server": {
+      "import": {
+        "types": "./dist/server.d.mts",
+        "default": "./dist/server.mjs"
+      },
+      "require": {
+        "types": "./dist/server.d.cts",
+        "default": "./dist/server.cjs"
+      }
+    },
+    "./extensions/result": {
+      "import": {
+        "types": "./dist/extensions/result.d.mts",
+        "default": "./dist/extensions/result.mjs"
+      },
+      "require": {
+        "types": "./dist/extensions/result.d.cts",
+        "default": "./dist/extensions/result.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsdown src/client.ts src/server.ts src/extensions/result.ts --format cjs,esm --dts --clean",
+    "build:docs": "typedoc",
+    "dev": "tsdown src/client.ts src/server.ts src/extensions/result.ts --format cjs,esm --dts --watch",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "unthrown": "workspace:^"
+  },
+  "devDependencies": {
+    "@orpc/client": "catalog:",
+    "@orpc/contract": "catalog:",
+    "@orpc/server": "catalog:",
+    "@types/node": "catalog:",
+    "@unthrown/tsconfig": "workspace:*",
+    "@unthrown/typedoc": "workspace:*",
+    "@unthrown/vitest": "workspace:*",
+    "@vitest/coverage-v8": "catalog:",
+    "tsdown": "catalog:",
+    "typedoc": "catalog:",
+    "typedoc-plugin-markdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "@orpc/client": "^2.0.0-beta",
+    "@orpc/server": "^2.0.0-beta"
+  },
+  "peerDependenciesMeta": {
+    "@orpc/server": {
+      "optional": true
+    }
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/orpc/src/client.ts
+++ b/packages/orpc/src/client.ts
@@ -1,0 +1,130 @@
+// @unthrown/orpc/client — the client half of the oRPC bridge.
+//
+// oRPC v2 splits failures exactly the way unthrown does: an error a procedure
+// declares (`.errors({...})`) or returns as a value is *inferable* — typed
+// end-to-end and recognisable at runtime via `isInferableError` — while
+// everything else is collapsed to `INTERNAL_SERVER_ERROR`. The bridge maps
+// that split onto the `Result` variants: inferable → `Err`, anything else →
+// `Defect`. Qualification happens once, in here (Thesis #3): the triage
+// decision was already made when the procedure declared (or returned) its
+// errors, so no per-call `qualify` is asked of the caller.
+//
+// The error channel stays the raw `ORPCError` union, discriminated by `code` —
+// no re-wrapping into a second error concept.
+
+import {
+  type AnyNestedClient,
+  type AnyORPCError,
+  type Client,
+  type ClientRest,
+  isInferableError,
+  type PromiseWithError,
+  type ThrowableError,
+} from "@orpc/client";
+import { type AsyncResult, fromPromise } from "unthrown";
+
+/**
+ * Lift a single oRPC call into an `AsyncResult`.
+ *
+ * @remarks
+ * The error channel is the call's *inferable* errors — the `ORPCError`s the
+ * procedure declares via `.errors({...})` or returns as values, extracted as
+ * `Extract<TError, AnyORPCError>` and discriminated by `code`. Any other
+ * rejection (network failure, an undeclared throw collapsed to
+ * `INTERNAL_SERVER_ERROR`, a malformed response) is a `Defect`: unmodeled,
+ * flowing past the error combinators, panicking at `get`.
+ *
+ * Accepts the promise of a client procedure call or of oRPC's server-side
+ * `call(procedure, input)` — anything typed `PromiseWithError`.
+ *
+ * @typeParam TOutput - the procedure's output type.
+ * @typeParam TError - the call's error union; only its `ORPCError` arm is
+ * modeled, the rest is subtracted into the defect channel.
+ * @param promise - the in-flight call to lift.
+ *
+ * @category Client
+ *
+ * @example
+ * ```ts
+ * import { fromCall } from "@unthrown/orpc/client";
+ *
+ * const planet = await fromCall(client.planet.find({ id }));
+ * // planet: Result<Planet, ORPCError<"NOT_FOUND", undefined>>
+ * if (planet.isErr()) planet.error.code; // "NOT_FOUND"
+ * ```
+ */
+export function fromCall<TOutput, TError = ThrowableError>(
+  promise: PromiseWithError<TOutput, TError>,
+): AsyncResult<TOutput, Extract<TError, AnyORPCError>> {
+  return fromPromise(promise, (cause, defect) => {
+    // `isInferableError` narrows against the call's declared error union; the
+    // cast re-attaches that union to the untyped rejection cause.
+    const candidate = cause as TError;
+    return isInferableError(candidate) ? candidate : defect(cause);
+  });
+}
+
+/**
+ * The type of a {@link createResultClient} client: every procedure of `T`
+ * returns an `AsyncResult` instead of a throwing promise.
+ *
+ * @category Client
+ */
+export type ResultClient<T extends AnyNestedClient> =
+  T extends Client<infer UContext, infer UInput, infer UOutput, infer UError>
+    ? (...rest: ClientRest<UContext, UInput>) => AsyncResult<UOutput, Extract<UError, AnyORPCError>>
+    : { [K in keyof T]: T[K] extends AnyNestedClient ? ResultClient<T[K]> : never };
+
+/**
+ * Wrap an oRPC client so every procedure call returns an
+ * `AsyncResult` — {@link fromCall} applied to the whole router.
+ *
+ * @remarks
+ * The mirror of oRPC's own `createSafeClient`, producing `AsyncResult`s
+ * instead of `SafeResult` tuples: inferable errors land in the error channel
+ * (the raw `ORPCError` union, discriminated by `code`), everything else is a
+ * `Defect`. Call options (`signal`, `context`, `lastEventId`) pass through
+ * untouched.
+ *
+ * Event-iterator (streaming) procedures are out of scope: a stream does not
+ * collapse to one `Result`. Keep calling those on the raw client.
+ *
+ * @param client - the oRPC client (or any nested router segment) to wrap.
+ *
+ * @category Client
+ *
+ * @example
+ * ```ts
+ * import { createResultClient } from "@unthrown/orpc/client";
+ *
+ * const rc = createResultClient(client);
+ *
+ * const greeting = await rc.planet
+ *   .find({ id })
+ *   .map((planet) => `Hello, ${planet.name}!`)
+ *   .match({
+ *     ok: (msg) => msg,
+ *     err: (e) => (e.code === "NOT_FOUND" ? "Hello, void!" : "Hello, trouble!"),
+ *     defect: () => "Hello, bug tracker!",
+ *   });
+ * ```
+ */
+export function createResultClient<T extends AnyNestedClient>(client: T): ResultClient<T> {
+  const target = (...args: unknown[]) => {
+    const procedure = client as (...rest: unknown[]) => PromiseWithError<unknown, unknown>;
+    return fromCall(procedure(...args));
+  };
+  const proxy = new Proxy(target, {
+    get(_, prop) {
+      const value = (client as Record<PropertyKey, unknown>)[prop];
+      // A nested router segment (object) or procedure (function) is wrapped
+      // recursively; anything else (a symbol-keyed well-known, an own field
+      // of a callable client) passes through untouched.
+      if ((typeof value !== "object" || value === null) && typeof value !== "function") {
+        return value;
+      }
+      return createResultClient(value as AnyNestedClient);
+    },
+  });
+  return proxy as ResultClient<T>;
+}

--- a/packages/orpc/src/extensions/result.ts
+++ b/packages/orpc/src/extensions/result.ts
@@ -1,0 +1,229 @@
+// @unthrown/orpc/extensions/result — the opt-in `.result()` builder method.
+//
+// Importing this module patches oRPC's builders (module augmentation + a
+// prototype assignment, the packaging `@orpc/experimental-effect` uses for
+// `.effect()`), so a procedure can be declared directly from a
+// `Result`-returning handler:
+//
+//   import "@unthrown/orpc/extensions/result";
+//
+//   const find = os
+//     .input(z.object({ id: z.string() }))
+//     .errors({ NOT_FOUND: {} })
+//     .result(({ input, errors }) =>
+//       repo.findPlanet(input.id).mapErr(() => errors.NOT_FOUND()),
+//     );
+//
+// This registration is a genuine import-time side effect — the one entry
+// point of the package excluded from `sideEffects: false`. Prefer the plain
+// `handlerResult(fn)` from `@unthrown/orpc/server` when patching a
+// third-party prototype is unwelcome; the two are runtime-identical.
+//
+// Every builder state (`os`, after `.use`, after `.input`/`.output`) shares
+// the one `Builder` class at runtime — the `BuilderWith*` interfaces are
+// typed views over it — so two prototype assignments (`Builder`,
+// `ProcedureImplementer`) cover the whole surface.
+
+import {
+  type AnyORPCError,
+  type AnySchema,
+  Builder,
+  type Context,
+  type DecoratedProcedure,
+  type ErrorMap,
+  type ImplementedProcedure,
+  type InferSchemaInput,
+  type InferSchemaOutput,
+  type MergedContext,
+  ProcedureImplementer,
+  type Schema,
+} from "@orpc/server";
+
+import { handlerResult, type ResultHandler } from "../server.js";
+
+// `Schema<void, unknown>` / `Schema<unknown>` spell out oRPC's
+// `InitialInputSchema` / `InitialOutputSchema` aliases (not re-exported from
+// `@orpc/server`) — the schema-less builder states.
+// oxlint-disable typescript/consistent-type-definitions -- declaration merging into @orpc/server's builder declarations requires `interface`; a `type` cannot merge.
+declare module "@orpc/server" {
+  interface Builder<TInitialContext extends Context, TErrorMap extends ErrorMap> {
+    /**
+     * `.handler(handlerResult(fn))` as a builder method: declare the
+     * procedure from a `Result`-returning handler. `Ok` is the output, `Err`
+     * (an `ORPCError`) surfaces to the client fully typed, a `Defect` stays a
+     * defect (`INTERNAL_SERVER_ERROR`).
+     */
+    result<TOutput, TError extends AnyORPCError>(
+      handler: ResultHandler<TInitialContext, unknown, TOutput, TError, TErrorMap>,
+    ): DecoratedProcedure<
+      TInitialContext,
+      object,
+      Schema<void, unknown>,
+      Schema<Exclude<TOutput, AnyORPCError>>,
+      TErrorMap,
+      TError | Extract<TOutput, AnyORPCError>
+    >;
+  }
+
+  interface BuilderWithMiddlewares<
+    TInitialContext extends Context,
+    TInjectedContext extends Context,
+    TErrorMap extends ErrorMap,
+  > {
+    /** {@inheritDoc Builder.result} */
+    result<TOutput, TError extends AnyORPCError>(
+      handler: ResultHandler<
+        MergedContext<TInitialContext, TInjectedContext>,
+        unknown,
+        TOutput,
+        TError,
+        TErrorMap
+      >,
+    ): DecoratedProcedure<
+      TInitialContext,
+      TInjectedContext,
+      Schema<void, unknown>,
+      Schema<Exclude<TOutput, AnyORPCError>>,
+      TErrorMap,
+      TError | Extract<TOutput, AnyORPCError>
+    >;
+  }
+
+  interface BuilderWithInput<
+    TInitialContext extends Context,
+    TInjectedContext extends Context,
+    TInputSchema extends AnySchema,
+    TErrorMap extends ErrorMap,
+  > {
+    /** {@inheritDoc Builder.result} */
+    result<TOutput, TError extends AnyORPCError>(
+      handler: ResultHandler<
+        MergedContext<TInitialContext, TInjectedContext>,
+        InferSchemaOutput<TInputSchema>,
+        TOutput,
+        TError,
+        TErrorMap
+      >,
+    ): DecoratedProcedure<
+      TInitialContext,
+      TInjectedContext,
+      TInputSchema,
+      Schema<Exclude<TOutput, AnyORPCError>>,
+      TErrorMap,
+      TError | Extract<TOutput, AnyORPCError>
+    >;
+  }
+
+  interface BuilderWithOutput<
+    TInitialContext extends Context,
+    TInjectedContext extends Context,
+    TOutputSchema extends AnySchema,
+    TErrorMap extends ErrorMap,
+  > {
+    /** {@inheritDoc Builder.result} */
+    result<TOutput extends InferSchemaInput<TOutputSchema>, TError extends AnyORPCError>(
+      handler: ResultHandler<
+        MergedContext<TInitialContext, TInjectedContext>,
+        unknown,
+        TOutput,
+        TError,
+        TErrorMap
+      >,
+    ): DecoratedProcedure<
+      TInitialContext,
+      TInjectedContext,
+      Schema<void, unknown>,
+      TOutputSchema,
+      TErrorMap,
+      TError | Extract<TOutput, AnyORPCError>
+    >;
+  }
+
+  interface BuilderWithInputOutput<
+    TInitialContext extends Context,
+    TInjectedContext extends Context,
+    TInputSchema extends AnySchema,
+    TOutputSchema extends AnySchema,
+    TErrorMap extends ErrorMap,
+  > {
+    /** {@inheritDoc Builder.result} */
+    result<TOutput extends InferSchemaInput<TOutputSchema>, TError extends AnyORPCError>(
+      handler: ResultHandler<
+        MergedContext<TInitialContext, TInjectedContext>,
+        InferSchemaOutput<TInputSchema>,
+        TOutput,
+        TError,
+        TErrorMap
+      >,
+    ): DecoratedProcedure<
+      TInitialContext,
+      TInjectedContext,
+      TInputSchema,
+      TOutputSchema,
+      TErrorMap,
+      TError | Extract<TOutput, AnyORPCError>
+    >;
+  }
+
+  interface ProcedureImplementer<
+    TInitialContext extends Context,
+    TInjectedContext extends Context,
+    TInputSchema extends AnySchema,
+    TOutputSchema extends AnySchema,
+    TErrorMap extends ErrorMap,
+  > {
+    /**
+     * {@inheritDoc Builder.result}
+     *
+     * @remarks
+     * Contract-first: the contract already declares the error map, so the
+     * returned errors are not re-inferred onto the procedure type (same rule
+     * as oRPC's own `.handler`).
+     */
+    result(
+      handler: ResultHandler<
+        MergedContext<TInitialContext, TInjectedContext>,
+        InferSchemaOutput<TInputSchema>,
+        InferSchemaInput<TOutputSchema>,
+        AnyORPCError,
+        TErrorMap
+      >,
+    ): ImplementedProcedure<
+      TInitialContext,
+      TInjectedContext,
+      TInputSchema,
+      TOutputSchema,
+      TErrorMap
+    >;
+  }
+}
+
+// The runtime signatures are the widest instantiation; the `as` casts align
+// them with the generic method declared above (the same one-place widening the
+// blueprint adapter relies on — the generic contract is enforced at the call
+// site by the augmented interfaces).
+Builder.prototype.result = function (
+  this: Builder<Context, ErrorMap>,
+  handler: ResultHandler<Context, unknown, unknown, AnyORPCError, ErrorMap>,
+) {
+  return this.handler(handlerResult(handler));
+} as Builder<Context, ErrorMap>["result"];
+
+ProcedureImplementer.prototype.result = function (
+  this: ProcedureImplementer<
+    Context,
+    Context,
+    Schema<unknown, unknown>,
+    Schema<unknown, unknown>,
+    ErrorMap
+  >,
+  handler: ResultHandler<Context, unknown, unknown, AnyORPCError, ErrorMap>,
+) {
+  return this.handler(handlerResult(handler));
+} as ProcedureImplementer<
+  Context,
+  Context,
+  Schema<unknown, unknown>,
+  Schema<unknown, unknown>,
+  ErrorMap
+>["result"];

--- a/packages/orpc/src/index.spec.ts
+++ b/packages/orpc/src/index.spec.ts
@@ -1,0 +1,277 @@
+// End-to-end tests against REAL oRPC machinery, no HTTP server: procedures run
+// through `createRouterClient` (the in-process client, sharing the exact
+// `createProcedureClient` pipeline the transports use), and one block loops a
+// `RPCLink` client back into a `RPCHandler` via a custom `fetch` — proving the
+// three-way mapping survives genuine JSON serialization, where a defect is
+// collapsed to `INTERNAL_SERVER_ERROR` instead of surfacing raw.
+//
+// The load-bearing mappings, each provoked for real:
+//   Ok        → the procedure's output           → `Ok` on the client
+//   Err       → a RETURNED ORPCError (inferable) → typed `Err` on the client
+//   Defect    → a rethrown cause                 → `Defect` on the client
+
+import { createORPCClient, isInferableError, ORPCError } from "@orpc/client";
+import { RPCLink } from "@orpc/client/fetch";
+import { oc } from "@orpc/contract";
+import {
+  type AnyORPCError,
+  call,
+  createRouterClient,
+  implement,
+  os,
+  type RouterClient,
+  type,
+} from "@orpc/server";
+import { RPCHandler } from "@orpc/server/fetch";
+import "@unthrown/vitest";
+import { Err, fromSafePromise, Ok, type Result } from "unthrown";
+import { describe, expect, test } from "vitest";
+
+import { createResultClient, fromCall } from "./client.js";
+import "./extensions/result.js";
+import { handlerResult } from "./server.js";
+
+// --- fixture router, one procedure per mapping under test ---------------------
+
+const find = os
+  .input(type<{ id: number }>())
+  .errors({ NOT_FOUND: { message: "no such planet" } })
+  .handler(
+    handlerResult(({ input, errors }) =>
+      input.id === 1 ? Ok({ name: "Mars" }) : Err(errors.NOT_FOUND()),
+    ),
+  );
+
+// An error RETURNED as a value without any `.errors({...})` declaration — the
+// v2 path this whole design leans on.
+const returned = os
+  .input(type<{ limit: number }>())
+  .handler(
+    handlerResult(({ input }) =>
+      input.limit > 0
+        ? Ok(input.limit)
+        : Err(new ORPCError("RATE_LIMITED", { data: { retryAfter: 60 } })),
+    ),
+  );
+
+// A defect minted INSIDE a pipeline (a throwing combinator callback)…
+const buggy = os.handler(
+  handlerResult(() =>
+    Ok(1).map(() => {
+      throw new Error("combinator boom");
+    }),
+  ),
+);
+
+// …and a handler that itself throws before producing a Result.
+const throwing = os.handler(
+  handlerResult((): Result<number, never> => {
+    throw new Error("handler boom");
+  }),
+);
+
+const asyncOk = os.handler(handlerResult(async () => Ok("async")));
+const liftedOk = os.handler(handlerResult(() => fromSafePromise(Promise.resolve(42))));
+
+const router = { planet: { find }, returned, buggy, throwing, asyncOk, liftedOk };
+const client = createRouterClient(router);
+const rc = createResultClient(client);
+
+describe("handlerResult over the in-process client", () => {
+  test("Ok becomes the procedure output", async () => {
+    await expect(rc.planet.find({ id: 1 })).toBeOkWith({ name: "Mars" });
+  });
+
+  test("Err(errors.X()) surfaces as a typed, inferable Err", async () => {
+    const result = await rc.planet.find({ id: 999 });
+    expect(result).toBeErr();
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(ORPCError);
+      expect(result.error.code).toBe("NOT_FOUND");
+      expect(isInferableError(result.error)).toBe(true);
+    }
+  });
+
+  test("a returned, undeclared ORPCError is inferable too — data preserved", async () => {
+    const result = await rc.returned({ limit: 0 });
+    expect(result).toBeErr();
+    if (result.isErr()) {
+      expect(result.error.code).toBe("RATE_LIMITED");
+      expect(result.error.data).toEqual({ retryAfter: 60 });
+    }
+  });
+
+  test("a defect minted in a combinator stays a Defect, cause preserved", async () => {
+    const result = await rc.buggy();
+    expect(result).toBeDefect();
+    if (result.isDefect()) {
+      expect(result.cause).toBeInstanceOf(Error);
+      expect((result.cause as Error).message).toBe("combinator boom");
+    }
+  });
+
+  test("a throwing handler callback stays a defect", async () => {
+    const result = await rc.throwing();
+    expect(result).toBeDefect();
+    if (result.isDefect()) expect((result.cause as Error).message).toBe("handler boom");
+  });
+
+  test("the handler may be async (edge elimination) or return an AsyncResult", async () => {
+    await expect(rc.asyncOk()).toBeOkWith("async");
+    await expect(rc.liftedOk()).toBeOkWith(42);
+  });
+
+  test("a non-ORPCError Err smuggled past the types routes to the defect path", async () => {
+    // Through well-typed code this is unreachable (`TError extends
+    // AnyORPCError`); a widened caller must not have its error served as a
+    // SUCCESSFUL output, so it panics instead.
+    const smuggler = os.handler(handlerResult(() => Err("nope" as unknown as AnyORPCError)));
+    const result = await fromCall(call(smuggler, undefined));
+    expect(result).toBeDefect();
+    if (result.isDefect()) expect(result.cause).toBe("nope");
+  });
+});
+
+describe("the .result() builder extension", () => {
+  test("plain builder (no schema)", async () => {
+    const hello = os.result(() => Ok("hello"));
+    await expect(fromCall(call(hello, undefined))).toBeOkWith("hello");
+  });
+
+  test("with middlewares (context flows through)", async () => {
+    const mw = os.$context<{ user: string }>().middleware(({ context, next }) => {
+      return next({ context: { role: context.user === "ada" ? "admin" : "guest" } });
+    });
+    const who = os
+      .$context<{ user: string }>()
+      .use(mw)
+      .result(({ context }) => Ok(`${context.user}:${context.role}`));
+    await expect(fromCall(call(who, undefined, { context: { user: "ada" } }))).toBeOkWith(
+      "ada:admin",
+    );
+  });
+
+  test("with input schema", async () => {
+    const double = os.input(type<{ n: number }>()).result(({ input }) => Ok(input.n * 2));
+    await expect(fromCall(call(double, { n: 21 }))).toBeOkWith(42);
+  });
+
+  test("with output schema (and with both)", async () => {
+    const shout = os.output(type<string>()).result(() => Ok("LOUD"));
+    await expect(fromCall(call(shout, undefined))).toBeOkWith("LOUD");
+
+    const echo = os
+      .input(type<{ msg: string }>())
+      .output(type<string>())
+      .result(({ input }) => Ok(input.msg));
+    await expect(fromCall(call(echo, { msg: "hi" }))).toBeOkWith("hi");
+  });
+
+  test("errors + Err on the extension path", async () => {
+    const gated = os
+      .errors({ FORBIDDEN: {} })
+      .input(type<{ key: string }>())
+      .result(({ input, errors }) => (input.key === "sesame" ? Ok("in") : Err(errors.FORBIDDEN())));
+    await expect(fromCall(call(gated, { key: "sesame" }))).toBeOkWith("in");
+
+    const denied = await fromCall(call(gated, { key: "wrong" }));
+    expect(denied).toBeErr();
+    if (denied.isErr()) expect(denied.error.code).toBe("FORBIDDEN");
+  });
+
+  test("contract-first implementer", async () => {
+    const contract = oc
+      .input(type<{ id: number }>())
+      .output(type<string>())
+      .errors({ NOT_FOUND: {} });
+    const impl = implement(contract).result(({ input, errors }) =>
+      input.id === 1 ? Ok("Mars") : Err(errors.NOT_FOUND()),
+    );
+    await expect(fromCall(call(impl, { id: 1 }))).toBeOkWith("Mars");
+
+    const missing = await fromCall(call(impl, { id: 2 }));
+    expect(missing).toBeErr();
+    if (missing.isErr()) expect(missing.error.code).toBe("NOT_FOUND");
+  });
+});
+
+describe("createResultClient", () => {
+  test("wraps nested router segments recursively", async () => {
+    const nested = createResultClient(client.planet);
+    await expect(nested.find({ id: 1 })).toBeOkWith({ name: "Mars" });
+  });
+
+  test("results chain with combinators", async () => {
+    const greeting = await rc.planet
+      .find({ id: 1 })
+      .map((planet) => `Hello, ${planet.name}!`)
+      .match({
+        ok: (msg) => msg,
+        err: () => "not found",
+        defect: () => "bug",
+      });
+    expect(greeting).toBe("Hello, Mars!");
+  });
+
+  test("non-wrappable property values pass through the proxy untouched", () => {
+    const weird = Object.assign(() => Promise.resolve(1), { version: 3 });
+    const wrapped = createResultClient(weird as never) as unknown as { version: number };
+    expect(wrapped.version).toBe(3);
+  });
+
+  test("call options thread through to the handler (signal observed)", async () => {
+    const probe = os.result(({ signal }) => Ok(signal?.aborted ?? false));
+    const probeClient = createResultClient(createRouterClient({ probe }));
+    const controller = new AbortController();
+    controller.abort();
+    await expect(probeClient.probe(undefined, { signal: controller.signal })).toBeOkWith(true);
+    await expect(probeClient.probe(undefined)).toBeOkWith(false);
+  });
+});
+
+describe("through a real serialization round-trip (RPCHandler ↔ RPCLink)", () => {
+  // The link's `fetch` loops straight back into the handler: a genuine
+  // request/response cycle — JSON serialization, error collapsing, the
+  // `inferable` flag on the wire — without opening a socket.
+  const handler = new RPCHandler(router);
+  const link = new RPCLink({
+    url: "/rpc",
+    fetch: async (url, init) => {
+      const request = new Request(new URL(url, "http://in-memory.test"), init);
+      const { response } = await handler.handle(request, { prefix: "/rpc" });
+      return response ?? new Response("no procedure matched", { status: 404 });
+    },
+  });
+  const wire = createResultClient(createORPCClient<RouterClient<typeof router>>(link));
+
+  test("Ok round-trips", async () => {
+    await expect(wire.planet.find({ id: 1 })).toBeOkWith({ name: "Mars" });
+  });
+
+  test("a declared Err survives serialization as a typed Err", async () => {
+    const result = await wire.planet.find({ id: 999 });
+    expect(result).toBeErr();
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(ORPCError);
+      expect(result.error.code).toBe("NOT_FOUND");
+      expect(result.error.message).toBe("no such planet");
+    }
+  });
+
+  test("a returned, undeclared Err survives serialization — data intact", async () => {
+    const result = await wire.returned({ limit: 0 });
+    expect(result).toBeErr();
+    if (result.isErr()) expect(result.error.data).toEqual({ retryAfter: 60 });
+  });
+
+  test("a defect is collapsed to INTERNAL_SERVER_ERROR and stays a Defect", async () => {
+    const result = await wire.buggy();
+    expect(result).toBeDefect();
+    if (result.isDefect()) {
+      // Over the wire the raw cause must NOT leak; oRPC collapses it.
+      expect(result.cause).toBeInstanceOf(ORPCError);
+      expect((result.cause as ORPCError<string, unknown>).code).toBe("INTERNAL_SERVER_ERROR");
+      expect(isInferableError(result.cause)).toBe(false);
+    }
+  });
+});

--- a/packages/orpc/src/server.ts
+++ b/packages/orpc/src/server.ts
@@ -1,0 +1,106 @@
+// @unthrown/orpc/server — the server half of the oRPC bridge.
+//
+// oRPC v2 handlers can RETURN an `ORPCError` as a value and have it inferred
+// end-to-end (typed on the client, recognisable via `isInferableError`). That
+// makes eliminating a `Result` at the procedure boundary a straight
+// three-way mapping:
+//
+//   Ok(value)  → return value          (the procedure's output)
+//   Err(error) → return the ORPCError  (oRPC marks it inferable — typed E2E)
+//   Defect     → rethrow the cause     (oRPC collapses it to INTERNAL_SERVER_ERROR)
+//
+// The handler's `Err` channel is constrained to `ORPCError`: mapping a domain
+// error into one (`mapErr((e) => errors.NOT_FOUND({...}))`) is the explicit
+// triage point at the transport boundary (Thesis #3).
+
+import {
+  type AnyORPCError,
+  type Context,
+  type ErrorMap,
+  ORPCError,
+  type ORPCErrorConstructorMap,
+  type ProcedureHandler,
+  type ProcedureHandlerOptions,
+} from "@orpc/server";
+import type { AsyncResult, Result } from "unthrown";
+
+/**
+ * A procedure handler that speaks `Result`: same options as a plain oRPC
+ * handler (`input`, `context`, `errors`, …), returning a
+ * `Result<TOutput, TError>` — synchronous, promised, or as an
+ * `AsyncResult`.
+ *
+ * @category Server
+ */
+export type ResultHandler<
+  TCurrentContext extends Context,
+  TInput,
+  TOutput,
+  TError extends AnyORPCError,
+  TErrorMap extends ErrorMap,
+> = (
+  opts: ProcedureHandlerOptions<TCurrentContext, TInput, ORPCErrorConstructorMap<TErrorMap>>,
+  input: TInput,
+) => Result<TOutput, TError> | Promise<Result<TOutput, TError>> | AsyncResult<TOutput, TError>;
+
+/**
+ * Adapt a `Result`-returning handler into a plain oRPC procedure handler.
+ *
+ * @remarks
+ * The elimination boundary of the server half: `Ok` becomes the procedure's
+ * output; `Err` (constrained to `ORPCError` — build one with the injected
+ * `errors.CODE(...)` constructors, or map a domain error via `mapErr` first)
+ * is returned as a value, which oRPC marks *inferable* so the client sees it
+ * fully typed; a `Defect` rethrows its original cause, which oRPC collapses
+ * to `INTERNAL_SERVER_ERROR` — a bug stays a defect, never a typed error.
+ *
+ * Like `match` handlers, the callback may be `async` (an edge elimination is
+ * exempt from the no-thenable rule): a rejection or throw inside it cannot
+ * skip triage, because oRPC's own boundary already treats it as the defect
+ * path.
+ *
+ * @param handler - the `Result`-speaking handler to adapt.
+ *
+ * @category Server
+ *
+ * @example
+ * ```ts
+ * import { handlerResult } from "@unthrown/orpc/server";
+ *
+ * const find = os
+ *   .input(z.object({ id: z.string() }))
+ *   .errors({ NOT_FOUND: {} })
+ *   .handler(
+ *     handlerResult(({ input, errors }) =>
+ *       repo.findPlanet(input.id).mapErr(() => errors.NOT_FOUND()),
+ *     ),
+ *   );
+ * ```
+ */
+export function handlerResult<
+  TCurrentContext extends Context,
+  TInput,
+  TOutput,
+  TError extends AnyORPCError,
+  TErrorMap extends ErrorMap,
+>(
+  handler: ResultHandler<TCurrentContext, TInput, TOutput, TError, TErrorMap>,
+): ProcedureHandler<TCurrentContext, TInput, TOutput | TError, ORPCErrorConstructorMap<TErrorMap>> {
+  return async (opts, input) => {
+    const result = await handler(opts, input);
+    return result.match<TOutput | TError>({
+      ok: (value) => value,
+      err: (error) => {
+        // Unreachable through well-typed code (`TError extends AnyORPCError`);
+        // a widened or raw-JS caller's non-ORPCError `Err` must not be
+        // returned, or oRPC would serve it as a SUCCESSFUL output. Route it
+        // to the defect path instead (same defensive rule as `matchTags`).
+        if (error instanceof ORPCError) return error;
+        throw error;
+      },
+      defect: (cause) => {
+        throw cause;
+      },
+    });
+  };
+}

--- a/packages/orpc/src/types.test-d.ts
+++ b/packages/orpc/src/types.test-d.ts
@@ -1,0 +1,119 @@
+// Type-level tests, checked by the package's regular `tsc --noEmit` (the file
+// has no runtime — nothing imports it). They guard the claims the bridge is
+// built on: the error channel is EXACTLY the inferable `ORPCError` union
+// (declared via `.errors` or returned as a value) with everything else
+// subtracted into the defect channel, that inference survives
+// `.handler(handlerResult(...))` and every `.result()` builder state, and that
+// a non-`ORPCError` error channel is rejected at compile time. Assertions
+// accumulate in the exported `_Assertions` tuple (so nothing is an unused
+// local); `@ts-expect-error` guards the cases that must NOT compile.
+
+import { ORPCError } from "@orpc/client";
+import { oc } from "@orpc/contract";
+import { implement, os, type RouterClient, type } from "@orpc/server";
+import { type AsyncErrOf, type AsyncOkOf, Err, Ok } from "unthrown";
+
+import { createResultClient, fromCall, type ResultClient } from "./client.js";
+import "./extensions/result.js";
+import { handlerResult } from "./server.js";
+
+type Equal<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+declare const flip: boolean;
+
+// --- the error channel is the inferable union, deeply typed -------------------
+
+// Declared via `.errors({...})` …
+const find = os
+  .input(type<{ id: number }>())
+  .errors({ NOT_FOUND: {} })
+  .handler(
+    handlerResult(({ input, errors }) =>
+      input.id === 1 ? Ok({ name: "Mars" }) : Err(errors.NOT_FOUND()),
+    ),
+  );
+
+// …and RETURNED as a value with no declaration at all (the v2 mechanism).
+const returned = os.handler(
+  handlerResult(() =>
+    flip ? Ok(1) : Err(new ORPCError("RATE_LIMITED", { data: { retryAfter: 60 } })),
+  ),
+);
+
+declare const client: RouterClient<{ find: typeof find; returned: typeof returned }>;
+
+const found = fromCall(client.find({ id: 1 }));
+type FoundOk = Expect<Equal<AsyncOkOf<typeof found>, { name: string }>>;
+type FoundErrCode = Expect<Equal<AsyncErrOf<typeof found>["code"], "NOT_FOUND">>;
+
+const rated = fromCall(client.returned());
+type RatedOk = Expect<Equal<AsyncOkOf<typeof rated>, number>>;
+type RatedErr = Expect<
+  Equal<AsyncErrOf<typeof rated>, ORPCError<"RATE_LIMITED", { retryAfter: number }>>
+>;
+
+// The non-ORPCError arm (ThrowableError, network failures) is subtracted into
+// the defect channel — never `unknown`, never `Error`, in `E`.
+type NoThrowableInE = Expect<Equal<Extract<AsyncErrOf<typeof found>, { code?: never }>, never>>;
+
+// --- createResultClient maps the whole router ----------------------------------
+
+const rc = createResultClient(client);
+const viaClient = rc.find({ id: 1 });
+type ClientMirrorsFromCall = Expect<Equal<typeof viaClient, typeof found>>;
+type NestedShape = Expect<Equal<ReturnType<ResultClient<typeof client>["returned"]>, typeof rated>>;
+
+// --- .result() infers on every builder state -----------------------------------
+
+const viaExtension = os
+  .input(type<{ id: number }>())
+  .errors({ NOT_FOUND: {} })
+  .result(({ input, errors }) => (input.id === 1 ? Ok({ name: "Mars" }) : Err(errors.NOT_FOUND())));
+declare const extClient: RouterClient<{ find: typeof viaExtension }>;
+const extFound = fromCall(extClient.find({ id: 1 }));
+type ExtensionMirrorsHandlerResult = Expect<Equal<typeof extFound, typeof found>>;
+
+// With an output schema the Ok channel is constrained to the schema's input.
+const shout = os.output(type<string>()).result(() => Ok("LOUD"));
+declare const shoutClient: RouterClient<{ shout: typeof shout }>;
+type ShoutOk = Expect<
+  Equal<AsyncOkOf<ReturnType<ResultClient<typeof shoutClient>["shout"]>>, string>
+>;
+
+// Contract-first: the implementer takes the error map from the contract.
+const contract = oc.input(type<{ id: number }>()).output(type<string>()).errors({ GONE: {} });
+const impl = implement(contract).result(({ input, errors }) =>
+  input.id === 1 ? Ok("Mars") : Err(errors.GONE()),
+);
+declare const implClient: RouterClient<{ impl: typeof impl }>;
+const implCall = fromCall(implClient.impl({ id: 1 }));
+type ImplErrCode = Expect<Equal<AsyncErrOf<typeof implCall>["code"], "GONE">>;
+
+// --- must-NOT-compile ----------------------------------------------------------
+
+// @ts-expect-error — the Err channel must be ORPCError; map a domain error via `mapErr` first.
+handlerResult(() => Err("domain-error"));
+
+// @ts-expect-error — same constraint on the extension path.
+os.result(() => Err(new Error("nope")));
+
+// @ts-expect-error — the Ok channel must satisfy the output schema.
+os.output(type<string>()).result(() => Ok(42));
+
+// @ts-expect-error — the implementer's Ok channel must satisfy the contract's output.
+implement(contract).result(() => Ok(42));
+
+export type _Assertions = [
+  FoundOk,
+  FoundErrCode,
+  RatedOk,
+  RatedErr,
+  NoThrowableInE,
+  ClientMirrorsFromCall,
+  NestedShape,
+  ExtensionMirrorsHandlerResult,
+  ShoutOk,
+  ImplErrCode,
+];

--- a/packages/orpc/tsconfig.json
+++ b/packages/orpc/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@unthrown/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/orpc/typedoc.json
+++ b/packages/orpc/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@unthrown/typedoc/base.json",
+  "entryPoints": ["src/client.ts", "src/server.ts", "src/extensions/result.ts"],
+  "out": "docs"
+}

--- a/packages/orpc/vitest.config.ts
+++ b/packages/orpc/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.spec.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**"],
+      exclude: ["src/**/*.test-d.ts", "src/**/*.spec.ts"],
+      thresholds: {
+        statements: 100,
+        branches: 100,
+        functions: 100,
+        lines: 100,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,15 @@ catalogs:
     '@commitlint/config-conventional':
       specifier: 21.2.0
       version: 21.2.0
+    '@orpc/client':
+      specifier: 2.0.0-beta.14
+      version: 2.0.0-beta.14
+    '@orpc/contract':
+      specifier: 2.0.0-beta.14
+      version: 2.0.0-beta.14
+    '@orpc/server':
+      specifier: 2.0.0-beta.14
+      version: 2.0.0-beta.14
     '@prisma/adapter-better-sqlite3':
       specifier: 7.8.0
       version: 7.8.0
@@ -128,6 +137,9 @@ importers:
       '@unthrown/neverthrow':
         specifier: workspace:*
         version: link:../packages/neverthrow
+      '@unthrown/orpc':
+        specifier: workspace:*
+        version: link:../packages/orpc
       '@unthrown/pattern':
         specifier: workspace:*
         version: link:../packages/pattern
@@ -282,6 +294,52 @@ importers:
       neverthrow:
         specifier: 'catalog:'
         version: 8.2.0
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.3(oxc-resolver@11.21.3)(tsx@4.22.4)(typescript@6.0.3)
+      typedoc:
+        specifier: 'catalog:'
+        version: 0.28.19(typescript@6.0.3)
+      typedoc-plugin-markdown:
+        specifier: 'catalog:'
+        version: 4.12.0(typedoc@0.28.19(typescript@6.0.3))
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+
+  packages/orpc:
+    dependencies:
+      unthrown:
+        specifier: workspace:^
+        version: link:../core
+    devDependencies:
+      '@orpc/client':
+        specifier: 'catalog:'
+        version: 2.0.0-beta.14
+      '@orpc/contract':
+        specifier: 'catalog:'
+        version: 2.0.0-beta.14
+      '@orpc/server':
+        specifier: 'catalog:'
+        version: 2.0.0-beta.14
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.2
+      '@unthrown/tsconfig':
+        specifier: workspace:*
+        version: link:../../tools/tsconfig
+      '@unthrown/typedoc':
+        specifier: workspace:*
+        version: link:../../tools/typedoc
+      '@unthrown/vitest':
+        specifier: workspace:*
+        version: link:../vitest
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.9(vitest@4.1.9)
       tsdown:
         specifier: 'catalog:'
         version: 0.22.3(oxc-resolver@11.21.3)(tsx@4.22.4)(typescript@6.0.3)
@@ -1176,6 +1234,31 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@orpc/client@2.0.0-beta.14':
+    resolution: {integrity: sha512-bON0neFmoxZr0U0R1DosPAhbZoYnaBLX+LlL0OAjdiGjhLGY91SBoc63RSFDTHZgVBVzyAEQPOOmItupWoWweQ==}
+
+  '@orpc/contract@2.0.0-beta.14':
+    resolution: {integrity: sha512-sM6YT8RH+BqABSAkJN89i/V9GeJVwsUao+3UBwm87mvV6RcyUuj8yOZBTaMmQeZXZH6C3frFbv/TI/4TBe6A/w==}
+
+  '@orpc/interop@2.0.0-beta.14':
+    resolution: {integrity: sha512-Fm1wJeS9GEIhRN4zwriKNg8Gw30xE94mp6qUHn17FSsXg7jh35OKK7XB6QU+ruw3LamIbYfUUX4q7/EKvE7jzg==}
+
+  '@orpc/server@2.0.0-beta.14':
+    resolution: {integrity: sha512-Fxu0uZTvOANcYHpqHnIXDeUAMYoEe9axUwpn7qaslKvbX8hq+DMdxq0glFbWAtzVw0jJ9UJ8ugw3WqLOcBLang==}
+    peerDependencies:
+      crossws: '>=0.3.4'
+    peerDependenciesMeta:
+      crossws:
+        optional: true
+
+  '@orpc/shared@2.0.0-beta.14':
+    resolution: {integrity: sha512-Gqjfx4K2QD6bgomhdVETOcX5jNDwU16xnejchs/bY5nSCfJE+CbqEy1ZR79ojZa8+wKDAZVJNbDrwzykcp+Tbg==}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
 
   '@oxc-parser/binding-android-arm-eabi@0.137.0':
     resolution: {integrity: sha512-KDs+0VPdEmasOkpuJHW9V5WCF+cvYdMQv2Jd+aJXt+cxIx12NToRQRbXaRwUEDsZw+/jMk81Ve8ZFbjUkJTOwA==}
@@ -2088,6 +2171,21 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@standardserver/core@0.0.25':
+    resolution: {integrity: sha512-WIp2orfBhFIMfIqejN8O0UEP+dzcD1485J9nIURapD3tSo7jZ+ElgYhaLVc7Ilfmf6N9qIMrzSdLOTD7qjeL8w==}
+
+  '@standardserver/fetch@0.0.25':
+    resolution: {integrity: sha512-8VpXDUTdhoqngX/pE6vv60rqtvds6N+KdQgo7JlKTYULgJOYToxuU6Imc2tp6nl+QHierhoP0pxRlbrpwL6ATg==}
+
+  '@standardserver/node@0.0.25':
+    resolution: {integrity: sha512-pSgTBPw6eKzsHwYOXwjt5jZmWzd7ePiNCnfMS0jUZci5QLWyUvL951dDF+6ERuxqE11BKXX5HjPcw9aaKTH3ig==}
+
+  '@standardserver/peer@0.0.25':
+    resolution: {integrity: sha512-tTe9ZSdFTYdhMH5T7UlujWFCU033jL5e6OJ3CgwSyhJp4iOWGaxNtYPq6CDXD0cQRJJpdOcKfoQ8PkmOwxWU8Q==}
+
+  '@standardserver/shared@0.0.25':
+    resolution: {integrity: sha512-w7c+dXX9Si2Gi5OJFqe0Yh+hhn2EC2MV3q7AUtTQTUadOb7vZ4Yb/4jgz9O8aTiwjK1UPAk/xWINLC/Ip2j7TA==}
+
   '@turbo/darwin-64@2.10.2':
     resolution: {integrity: sha512-wBM3ObqOWnKUDmg7QfUFDkDHPFUAJmrYlYqmEM8jMPAPA/I6wRJIbWimeQUqhOiQ8xPKhzyWM+xaiUP0wz8FEQ==}
     cpu: [x64]
@@ -2457,6 +2555,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   copy-anything@4.0.5:
     resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
@@ -3338,6 +3440,10 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  radash@12.1.1:
+    resolution: {integrity: sha512-h36JMxKRqrAxVD8201FrCpyeNuUY9Y5zZwujr20fFO77tpUtGa6EZzfKw/3WaiBX95fq7+MpsuMLNdSnORAwSA==}
+    engines: {node: '>=14.18.0'}
+
   rc9@3.0.1:
     resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
 
@@ -3547,6 +3653,10 @@ packages:
   tabbable@6.5.0:
     resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tar-fs@2.1.5:
     resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
 
@@ -3639,6 +3749,10 @@ packages:
   turbo@2.10.2:
     resolution: {integrity: sha512-wTExrNrRjB8qzIcg+ZLm0A3GFNLDsWNwdS/RBXB0FPrBDyzk3i96Yx+TxWZC7a0k1SIreFB8ciUbxjmEqTH8IQ==}
     hasBin: true
+
+  type-fest@5.7.0:
+    resolution: {integrity: sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==}
+    engines: {node: '>=20'}
 
   typedoc-plugin-markdown@4.12.0:
     resolution: {integrity: sha512-eJDEMAfxCmede22c/Jw7d0FA13ggAQv+KkwQYKYCdqI02cin6Rc9QRwbG/7XvvHWinuFejySnZVUWDtvGk3Vbg==}
@@ -4603,6 +4717,45 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@orpc/client@2.0.0-beta.14':
+    dependencies:
+      '@orpc/shared': 2.0.0-beta.14
+      '@standardserver/core': 0.0.25
+      '@standardserver/fetch': 0.0.25
+      '@standardserver/peer': 0.0.25
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+
+  '@orpc/contract@2.0.0-beta.14':
+    dependencies:
+      '@orpc/client': 2.0.0-beta.14
+      '@orpc/shared': 2.0.0-beta.14
+      '@standard-schema/spec': 1.1.0
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+
+  '@orpc/interop@2.0.0-beta.14': {}
+
+  '@orpc/server@2.0.0-beta.14':
+    dependencies:
+      '@orpc/client': 2.0.0-beta.14
+      '@orpc/contract': 2.0.0-beta.14
+      '@orpc/interop': 2.0.0-beta.14
+      '@orpc/shared': 2.0.0-beta.14
+      '@standardserver/core': 0.0.25
+      '@standardserver/fetch': 0.0.25
+      '@standardserver/node': 0.0.25
+      '@standardserver/peer': 0.0.25
+      cookie: 1.1.1
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+
+  '@orpc/shared@2.0.0-beta.14':
+    dependencies:
+      '@standardserver/shared': 0.0.25
+      radash: 12.1.1
+      type-fest: 5.7.0
+
   '@oxc-parser/binding-android-arm-eabi@0.137.0':
     optional: true
 
@@ -5167,6 +5320,28 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@standardserver/core@0.0.25':
+    dependencies:
+      '@standardserver/shared': 0.0.25
+
+  '@standardserver/fetch@0.0.25':
+    dependencies:
+      '@standardserver/core': 0.0.25
+      '@standardserver/shared': 0.0.25
+
+  '@standardserver/node@0.0.25':
+    dependencies:
+      '@standardserver/core': 0.0.25
+      '@standardserver/fetch': 0.0.25
+      '@standardserver/shared': 0.0.25
+
+  '@standardserver/peer@0.0.25':
+    dependencies:
+      '@standardserver/core': 0.0.25
+      '@standardserver/shared': 0.0.25
+
+  '@standardserver/shared@0.0.25': {}
+
   '@turbo/darwin-64@2.10.2':
     optional: true
 
@@ -5554,6 +5729,8 @@ snapshots:
       meow: 14.1.0
 
   convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
 
   copy-anything@4.0.5:
     dependencies:
@@ -6445,6 +6622,8 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  radash@12.1.1: {}
+
   rc9@3.0.1:
     dependencies:
       defu: 6.1.7
@@ -6673,6 +6852,8 @@ snapshots:
 
   tabbable@6.5.0: {}
 
+  tagged-tag@1.0.0: {}
+
   tar-fs@2.1.5:
     dependencies:
       chownr: 1.1.4
@@ -6760,6 +6941,10 @@ snapshots:
       '@turbo/linux-arm64': 2.10.2
       '@turbo/windows-64': 2.10.2
       '@turbo/windows-arm64': 2.10.2
+
+  type-fest@5.7.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typedoc-plugin-markdown@4.12.0(typedoc@0.28.19(typescript@6.0.3)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,9 @@ catalog:
   "@prisma/client": 7.8.0
   "@standard-schema/spec": 1.1.0
   "@commitlint/config-conventional": 21.2.0
+  "@orpc/client": 2.0.0-beta.14
+  "@orpc/contract": 2.0.0-beta.14
+  "@orpc/server": 2.0.0-beta.14
   "@types/node": 24.13.2
   "@vitest/coverage-v8": 4.1.9
   better-sqlite3: 12.11.1


### PR DESCRIPTION
## What

A new package, **`@unthrown/orpc`** — a two-way bridge between [oRPC](https://orpc.dev) v2 and unthrown, built on v2's returned-`ORPCError` end-to-end inference. The mapping is exact in both directions:

| unthrown | oRPC v2 |
| --- | --- |
| `Ok(value)` | the procedure's output |
| `Err(error)` | a returned `ORPCError` — inferable, typed end-to-end |
| `Defect` | everything else (`INTERNAL_SERVER_ERROR`) |

Three entry points, no root export:

- **`@unthrown/orpc/server`** — `handlerResult(fn)` adapts a `Result`-returning procedure handler. The `Err` channel is constrained to `ORPCError` (the `mapErr` into `errors.CODE(...)` at the endpoint is the Thesis-#3 triage point); a `Defect` rethrows its cause; a non-`ORPCError` `Err` smuggled past the types routes to the defect path — it must never be served as a successful output.
- **`@unthrown/orpc/extensions/result`** — the opt-in `.result()` builder method via `declare module "@orpc/server"` augmentation + prototype patches on `Builder` and `ProcedureImplementer` (every builder state shares the `Builder` class at runtime). The package's **one** side-effectful entry, listed in a `sideEffects` array — the `@orpc/experimental-effect` packaging.
- **`@unthrown/orpc/client`** — `fromCall(promise)` lifts a single call (client call or server-side `call(...)`); `createResultClient(client)` recursively wraps a router (the `createSafeClient` mirror). `E` is the raw inferable `ORPCError` union discriminated by `code` — deliberately **not** re-wrapped into `TaggedError`; non-inferable failures are `Defect`s.

## Design decisions

- **Peers, not deps** (`^2.0.0-beta`): `isInferableError` is an `instanceof ORPCError` check — the same dual-copy hazard as core's `isResult`. `@orpc/server` is an optional peer so browser-only consumers skip it.
- **Outside the fixed version group** (like `@unthrown/prisma`): majors track oRPC's cadence. The catalog pins `2.0.0-beta.14` — the newest beta clearing the workspace's 7-day supply-chain maturity delay.
- **Streaming (event-iterator) procedures are out of scope** — a stream doesn't collapse to one `Result`; the raw client stays the escape hatch.

## Testing

- 21 runtime tests at **100% statement/branch/function/line coverage**, against real oRPC machinery: `createRouterClient` in-process **and** an `RPCHandler` ↔ `RPCLink` loop through a custom `fetch` — genuine JSON serialization, where the defect collapse to `INTERNAL_SERVER_ERROR` actually happens.
- `types.test-d.ts` guards the inference claims (exact `E` extraction, `.result()` on every builder state, contract-first implementers, four must-not-compile cases).
- The `declare module` augmentation is verified to survive into the built `.d.mts` / `.d.cts`.

## Also in this PR

- CLAUDE.md monorepo-spec registration, docs guide page (`/guide/orpc`), API-reference wiring, changeset.
- The root README package table gains the row for the new package — plus the `@unthrown/standard-schema` and `@unthrown/oxlint` rows it was missing.

Full gate green: `format --check`, `lint`, `typecheck`, `knip`, `test`, `build` (docs site included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)