### PR TITLE
feat(core): add fromSafeThrowable — the sync counterpart to fromSafePromise

### DIFF
--- a/.changeset/from-safe-throwable.md
+++ b/.changeset/from-safe-throwable.md
@@ -1,0 +1,10 @@
+---
+"unthrown": minor
+---
+
+Add `fromSafeThrowable` — the synchronous counterpart to `fromSafePromise`:
+wrap a throwing function asserted not to fail in any modeled way, so every
+throw becomes a `Defect` and the error channel is `never`, with no `qualify`
+callback. The explicit, named form of the
+`fromThrowable(fn, (cause, defect) => defect(cause))` boilerplate. Also
+exposed as `Result.fromSafeThrowable` on the companion object.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,10 @@ async work re-enters via `fromPromise` / `fromSafePromise` and composes with
   `Async` **suffix** the async free functions use (`allAsync`); the `AsyncResult`
   companion aliases them as `AsyncResult.Ok` / `AsyncResult.Err` (suffix dropped,
   same rule as `AsyncResult.all`)
-- interop: `fromNullable`, `fromThrowable`, `fromPromise`, `fromSafePromise`
+- interop: `fromNullable`, `fromThrowable`, `fromSafeThrowable` (the sync
+  mirror of `fromSafePromise` — every throw a `Defect`, `E = never`, no
+  `qualify`; the named form of the `(c, d) => d(c)` boilerplate, an explicit
+  "everything here is a defect" decision), `fromPromise`, `fromSafePromise`
 - aggregate: `all` / `allAsync` take a **tuple/array** (a fixed tuple keeps
   positional types; a dynamic `Result<T, E>[]` / `AsyncResult<T, E>[]` collapses
   to `Result<T[], E>` / `AsyncResult<T[], E>`), while `allFromDict` /
@@ -184,7 +187,7 @@ async work re-enters via `fromPromise` / `fromSafePromise` and composes with
 - facade: two companion objects alias the standalone entry points, **grouped by
   what they return** so a static lives in exactly one namespace. `Result.*` holds
   the `Result`-producing ones
-  (`Result.Ok`/`Err`/`Do`/`fromNullable`/`fromThrowable`/`all`/`allFromDict`/`is*`);
+  (`Result.Ok`/`Err`/`Do`/`fromNullable`/`fromThrowable`/`fromSafeThrowable`/`all`/`allFromDict`/`is*`);
   `AsyncResult.*` holds the `AsyncResult`-producing ones
   (`AsyncResult.Ok`/`Err`/`fromPromise`/`fromSafePromise`/`all`/`allFromDict` — the
   pre-lifted constructors and aggregates drop the `Async` suffix the free functions

--- a/docs/guide/boundaries.md
+++ b/docs/guide/boundaries.md
@@ -69,7 +69,7 @@ that returns _only_ `defect(cause)` gives `AsyncResult<T, never>`, not
 `AsyncResult<T, Defect>` — a defect stays out-of-band. (When _every_ rejection is
 a defect, reach for `fromSafePromise` below.)
 
-## `fromSafePromise` — when any rejection is a bug
+## `fromSafePromise` / `fromSafeThrowable` — when any failure is a bug
 
 If a promise should never fail in a _modeled_ way — its rejection would be a bug,
 not an anticipated outcome — use `fromSafePromise`. Its error channel is `never`;
@@ -80,6 +80,23 @@ import { fromSafePromise } from "unthrown";
 
 const config = fromSafePromise(loadTrustedConfig());
 ```
+
+`fromSafeThrowable` is the synchronous counterpart, for a throwing function
+whose every throw is a bug — the explicit, named form of the
+`(cause, defect) => defect(cause)` qualify you would otherwise spell out:
+
+```ts
+import { fromSafeThrowable } from "unthrown";
+
+// The row came from our own schema; a decode throw is a bug, not an outcome.
+const decode = fromSafeThrowable((row: Row) => userSchema.parse(row));
+
+decode(row); // Result<User, never> — a throw becomes a defect
+```
+
+Both are deliberate escape hatches from qualification, not shortcuts: reach for
+them only when "everything here is a defect" is a **decision**, and keep
+`fromThrowable` / `fromPromise` wherever some failures are anticipated.
 
 ## The payoff: one handler at the edge
 

--- a/packages/core/src/facade.spec.ts
+++ b/packages/core/src/facade.spec.ts
@@ -11,6 +11,7 @@ import {
   fromNullable,
   fromPromise,
   fromSafePromise,
+  fromSafeThrowable,
   fromThrowable,
   isDefect,
   isErr,
@@ -49,6 +50,7 @@ describe("Result facade mirrors the free functions", () => {
   it("exposes the sync interop and aggregate entry points", () => {
     expect(Result.fromNullable).toBe(fromNullable);
     expect(Result.fromThrowable).toBe(fromThrowable);
+    expect(Result.fromSafeThrowable).toBe(fromSafeThrowable);
     expect(Result.Do).toBe(Do);
     expect(Result.all).toBe(all);
     expect(Result.allFromDict).toBe(allFromDict);

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -15,6 +15,7 @@ import {
   fromNullable,
   fromPromise,
   fromSafePromise,
+  fromSafeThrowable,
   fromThrowable,
 } from "./interop.js";
 import type { AsyncResult as AsyncResultType, Result as ResultType } from "./types.js";
@@ -23,8 +24,9 @@ import type { AsyncResult as AsyncResultType, Result as ResultType } from "./typ
  * Companion object grouping the **`Result`-producing** entry points under a
  * single, discoverable namespace: {@link Result.Ok}, {@link Result.Err},
  * {@link Result.Do}, {@link Result.fromNullable}, {@link Result.fromThrowable},
- * {@link Result.all}, {@link Result.allFromDict}, {@link Result.isOk},
- * {@link Result.isErr}, {@link Result.isDefect}, {@link Result.isResult}.
+ * {@link Result.fromSafeThrowable}, {@link Result.all},
+ * {@link Result.allFromDict}, {@link Result.isOk}, {@link Result.isErr},
+ * {@link Result.isDefect}, {@link Result.isResult}.
  *
  * @remarks
  * Purely additive sugar — each member **is** the corresponding free function.
@@ -50,6 +52,7 @@ export const Result = {
   Do,
   fromNullable,
   fromThrowable,
+  fromSafeThrowable,
   all,
   allFromDict,
   isOk,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,7 @@ export {
   fromNullable,
   fromPromise,
   fromSafePromise,
+  fromSafeThrowable,
   fromThrowable,
 } from "./interop.js";
 export { matchTags, TaggedError } from "./tagged.js";

--- a/packages/core/src/interop.spec.ts
+++ b/packages/core/src/interop.spec.ts
@@ -5,6 +5,7 @@ import {
   fromNullable,
   fromPromise,
   fromSafePromise,
+  fromSafeThrowable,
   fromThrowable,
   Ok,
   type Result,
@@ -113,6 +114,42 @@ describe("fromThrowable", () => {
     const r: Result<number, "known"> = fn();
     expect(r.isOk()).toBe(true);
     if (r.isOk()) expect(r.value).toBe(1);
+  });
+});
+
+describe("fromSafeThrowable", () => {
+  it("wraps a successful call as Ok and forwards arguments", () => {
+    const add = fromSafeThrowable((a: number, b: number) => a + b);
+    const r = add(2, 3);
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) expect(r.value).toBe(5);
+  });
+
+  it("turns every throw into a Defect with the original cause — never an Err", () => {
+    const fn = fromSafeThrowable(() => {
+      throw boom;
+    });
+    const r = fn();
+    expect(r.isDefect()).toBe(true);
+    expect(r.isErr()).toBe(false);
+    if (r.isDefect()) expect(r.cause).toBe(boom);
+  });
+
+  it("types the error channel as never (the sync mirror of fromSafePromise)", () => {
+    const fn = fromSafeThrowable((): number => 1);
+    // Compiles only if `E` is `never` — `get()` is gated on Result<T, never>.
+    const r: Result<number, never> = fn();
+    expect(r.get()).toBe(1);
+  });
+
+  it("preserves a non-Error thrown value as the Defect cause", () => {
+    const fn = fromSafeThrowable(() => {
+      // oxlint-disable-next-line no-throw-literal -- the raw-value throw IS the case under test
+      throw "nope";
+    });
+    const r = fn();
+    expect(r.isDefect()).toBe(true);
+    if (r.isDefect()) expect(r.cause).toBe("nope");
   });
 });
 

--- a/packages/core/src/interop.ts
+++ b/packages/core/src/interop.ts
@@ -53,7 +53,7 @@ export function fromNullable<T, E>(
  * `qualify`'s return is **subtracted** from `E`, never inferred into it. So a
  * `qualify` that returns *only* `defect(cause)` yields `E = never` (a Defect is
  * out-of-band and must not pollute the error channel); reach for
- * {@link fromSafePromise} when every failure is a Defect.
+ * {@link fromSafeThrowable} when every throw is a Defect.
  *
  * @typeParam A - the wrapped function's argument tuple.
  * @typeParam T - the wrapped function's return type.
@@ -92,6 +92,47 @@ export function fromThrowable<A extends unknown[], T, R>(
       return Ok(fn(...args)) as Result<T, E>;
     } catch (cause) {
       return qualifyToResult<T, E>(cause, triage);
+    }
+  };
+}
+
+/**
+ * Wrap a throwing synchronous function asserted **not** to fail in any modeled
+ * way: any throw becomes a `Defect`.
+ *
+ * @remarks
+ * The synchronous counterpart of {@link fromSafePromise}. Use it only when a
+ * throw genuinely indicates a bug rather than an anticipated outcome — the
+ * error channel is `never`, so there is nothing to triage; there is no
+ * `qualify`. When some throws *are* anticipated, reach for
+ * {@link fromThrowable} and triage them.
+ *
+ * @typeParam A - the wrapped function's argument tuple.
+ * @typeParam T - the wrapped function's return type.
+ * @param fn - the throwing function to wrap.
+ * @returns a function with the same arguments returning `Result<T, never>`.
+ *
+ * @category Interop
+ *
+ * @example
+ * ```ts
+ * import { fromSafeThrowable } from "unthrown";
+ *
+ * // A decode failure here is a bug (the row came from our own schema), so
+ * // every throw is a defect — no throwaway `(cause, defect) => defect(cause)`.
+ * const decode = fromSafeThrowable((row: Row) => userSchema.parse(row));
+ *
+ * decode(row); // => Result<User, never> — a throw becomes a Defect
+ * ```
+ */
+export function fromSafeThrowable<A extends unknown[], T>(
+  fn: (...args: A) => T,
+): (...args: A) => Result<T, never> {
+  return (...args: A): Result<T, never> => {
+    try {
+      return Ok(fn(...args));
+    } catch (cause) {
+      return defectRes<T, never>(cause);
     }
   };
 }
@@ -157,7 +198,8 @@ export function fromPromise<T, R>(
  * @remarks
  * Use this only when a rejection genuinely indicates a bug rather than an
  * anticipated outcome — the error channel is `never`, so there is nothing to
- * triage. (`await`-ing still yields a `Result`; it never throws.)
+ * triage. (`await`-ing still yields a `Result`; it never throws.) The
+ * synchronous counterpart is {@link fromSafeThrowable}.
  *
  * @typeParam T - the resolved value type.
  * @param promise - the promise, or a thunk returning one.

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -20,6 +20,7 @@ import {
   ErrAsync,
   type ErrView,
   fromPromise,
+  fromSafeThrowable,
   fromThrowable,
   isDefect,
   isErr,
@@ -104,6 +105,12 @@ const throwable = fromThrowable(
   (c, defect) => defect(c),
 );
 type _throwable = Expect<Equal<ReturnType<typeof throwable>, Result<number, never>>>;
+
+// `fromSafeThrowable` needs no qualify at all: E is never, arguments preserved
+const safeThrowable = fromSafeThrowable((s: string, radix: number) => Number.parseInt(s, radix));
+type _safeThrowable = Expect<
+  Equal<typeof safeThrowable, (s: string, radix: number) => Result<number, never>>
+>;
 
 // qualify is mandatory — there is no one-arg boundary
 // @ts-expect-error - the qualify argument is required


### PR DESCRIPTION
Closes #76.

## What

`fromSafeThrowable(fn)` — wrap a throwing **synchronous** function asserted not to fail in any modeled way. Every throw becomes a `Defect` with its original cause, the error channel is `never`, and there is no `qualify` callback:

```ts
const parse = fromSafeThrowable((text: string) => JSON.parse(text) as unknown);
parse('{"ok":true}'); // Ok({ ok: true })
parse("nope");        // Defect(SyntaxError) — never a modeled Err
```

It closes the asymmetry the issue documents:

| direction | "all failures are defects" helper |
| --- | --- |
| async | `fromSafePromise(promise)` |
| sync | `fromSafeThrowable(fn)` *(new)* |

…and replaces the `fromThrowable(fn, (cause, defect) => defect(cause))` incantation. Qualification stays mandatory on the general `fromThrowable`; this is the explicit, named "I've decided everything here is a defect" escape hatch, exactly as `fromSafePromise` is for promises.

## Details

- Same "returns a wrapped function you then call" shape as `fromThrowable`, argument tuple preserved.
- Aliased as `Result.fromSafeThrowable` on the companion object (it's `Result`-producing, so it lives in the `Result.*` namespace).
- `fromThrowable`'s docs now point defect-only qualifies here (previously they pointed at `fromSafePromise`, which is the wrong direction for sync code); `fromSafePromise` cross-links back.
- Runtime tests (Ok + argument passthrough, throw → `Defect` with the original cause — including a non-`Error` thrown value, never an `Err`), type-level assertions (`E = never`, argument tuple preserved), facade identity test, Boundaries guide section, CLAUDE.md registration, changeset (minor for the fixed group).

Full gate green: `format --check`, `lint`, `typecheck` (incl. `tsconfig.test-d.json`), `knip`, `test` (coverage thresholds hold), `build`, warning-free typedoc.

Related: #77 — `fromSafeThrowable(...).toAsync()` also shortens the workaround discussed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)