### PR TITLE
docs: record the deliberate-defect decision — throw is the constructor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,20 +163,20 @@ async work re-enters via `fromPromise` / `fromSafePromise` and composes with
   unqualified rejection.
 - constructors: `Ok`, `Err` (there is **no** `Defect` constructor — a defect-state
   `Result` arises only at boundaries; the qualify-time `defect` marker helper is
-  injected, not exported. A **deliberate** defect uses `throw`: inside a
-  pipeline, a combinator-callback `throw` IS the sanctioned syntax (the
-  throw → defect invariant is that syntax, not just a safety net); a
-  known-technical precondition throws in a plain helper wrapped once at its
-  origin with `fromSafeThrowable`. A minting helper was weighed and **rejected**
-  in #77 — frictionless minting would let unmodeled-by-laziness failures erode
-  the defect channel's meaning; the friction forces either a modeled `Err` or a
-  throw at the true origin. Documented in the defect-channel guide), plus the
-  **pre-lifted async** constructors `OkAsync` /
+  injected, not exported), plus the **pre-lifted async** constructors `OkAsync` /
   `ErrAsync` — `Ok(v).toAsync()` / `Err(e).toAsync()` without the boilerplate, for
   the synchronous branch of an `AsyncResult`-returning function. They carry the
   `Async` **suffix** the async free functions use (`allAsync`); the `AsyncResult`
   companion aliases them as `AsyncResult.Ok` / `AsyncResult.Err` (suffix dropped,
-  same rule as `AsyncResult.all`)
+  same rule as `AsyncResult.all`). A **deliberate** defect needs no constructor
+  either — the syntax is `throw`: inside a pipeline, a combinator-callback
+  `throw` IS the sanctioned form (the throw → defect invariant is that syntax,
+  not just a safety net); a known-technical precondition throws in a plain
+  helper wrapped once at its origin with `fromSafeThrowable`. A minting helper
+  was weighed and **rejected** in #77 — frictionless minting would let
+  unmodeled-by-laziness failures erode the defect channel's meaning; the
+  friction forces either a modeled `Err` or a throw at the true origin.
+  Documented in the defect-channel guide.
 - interop: `fromNullable`, `fromThrowable`, `fromSafeThrowable` (the sync
   mirror of `fromSafePromise` — every throw a `Defect`, `E = never`, no
   `qualify`; the named form of the `(c, d) => d(c)` boilerplate, an explicit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,15 @@ async work re-enters via `fromPromise` / `fromSafePromise` and composes with
   unqualified rejection.
 - constructors: `Ok`, `Err` (there is **no** `Defect` constructor — a defect-state
   `Result` arises only at boundaries; the qualify-time `defect` marker helper is
-  injected, not exported), plus the **pre-lifted async** constructors `OkAsync` /
+  injected, not exported. A **deliberate** defect uses `throw`: inside a
+  pipeline, a combinator-callback `throw` IS the sanctioned syntax (the
+  throw → defect invariant is that syntax, not just a safety net); a
+  known-technical precondition throws in a plain helper wrapped once at its
+  origin with `fromSafeThrowable`. A minting helper was weighed and **rejected**
+  in #77 — frictionless minting would let unmodeled-by-laziness failures erode
+  the defect channel's meaning; the friction forces either a modeled `Err` or a
+  throw at the true origin. Documented in the defect-channel guide), plus the
+  **pre-lifted async** constructors `OkAsync` /
   `ErrAsync` — `Ok(v).toAsync()` / `Err(e).toAsync()` without the boilerplate, for
   the synchronous branch of an `AsyncResult`-returning function. They carry the
   `Async` **suffix** the async free functions use (`allAsync`); the `AsyncResult`

--- a/docs/guide/the-defect-channel.md
+++ b/docs/guide/the-defect-channel.md
@@ -111,4 +111,53 @@ Use `tapDefect` to observe a defect's cause (e.g. logging) without changing it.
 Recovering a defect should feel awkward — usually you don't. You let it bubble
 to the edge, log it, and return a 500.
 
+## Producing a defect on purpose
+
+Sometimes a condition is _anticipated_ but still not a domain outcome — a
+required config value is missing, a "can't happen" branch is reached. You want
+the defect channel (the edge's 500), not an `Err` that every caller must
+thread through `E`.
+
+There is deliberately **no** `Defect(...)` constructor for this. The primitive
+already exists — it is `throw`. The throw → defect rule at the top of this page
+is not merely a safety net for accidental bugs; it is the _sanctioned syntax_
+for declaring one:
+
+```ts
+// Inside a pipeline: just throw. The combinator converts it.
+pipeline.tap(() => {
+  if (!config.apiKey) throw new MissingConfigError();
+});
+```
+
+And if you find yourself wanting to _mint_ a defect mid-chain, the failure
+usually happened somewhere earlier — put the boundary at its origin instead:
+
+```ts
+// An ordinary function that throws on a bug — perfectly idiomatic JS.
+function requireConfig(key: string): string {
+  const value = process.env[key];
+  if (value === undefined) throw new MissingConfigError(key);
+  return value;
+}
+
+// Wrapped ONCE at its boundary: every throw is a defect, by decision.
+const readConfig = fromSafeThrowable(requireConfig);
+
+readConfig("API_KEY").toAsync().flatMap(callTheApi);
+```
+
+For the residual case — you hold a cause in hand and need to _start_ a chain in
+defect state — the documented idiom is
+`fromSafeThrowable(() => { throw cause })()` (add `.toAsync()` for an
+`AsyncResult`).
+
+::: info Why no constructor?
+Once minting a defect is one frictionless call, "I don't feel like modeling
+this error" starts flowing into the defect channel — and the discipline that
+makes `E` trustworthy erodes. The friction is a forcing function: either model
+the failure as an `Err`, or throw at its true origin. This was weighed and
+decided in [#77](https://github.com/btravstack/unthrown/issues/77).
+:::
+
 → Continue to [Boundaries & Qualification](./boundaries).


### PR DESCRIPTION
Closes #77.

Resolves the design question as a **documented decision** (option 1 + option 3 from the issue), with a sharper framing: the deliberate-defect primitive already exists, and it is `throw`.

## What

A new **"Producing a defect on purpose"** section in the defect-channel guide, blessing two idioms:

1. **Inside a pipeline — just `throw`.** The throw → defect invariant is not merely a safety net for accidental bugs; it is the *sanctioned syntax* for declaring one.
2. **At the failure's origin — a plain throwing helper, wrapped once with `fromSafeThrowable`** (#76 / #88). The awkward ceremony in the issue's motivating example was a symptom of minting the defect at the wrong place: "required config value is missing" fails at the config read, not in the HTTP handler — put the boundary there and the ceremony dissolves. For the residual chain-start-with-a-cause-in-hand case, the documented idiom is `fromSafeThrowable(() => { throw cause })()` (+ `.toAsync()`).

And an explicit **rejection of a defect-minting helper**, with the reasoning recorded in both the guide and CLAUDE.md's no-`Defect`-constructor rule: once minting a defect is one frictionless call, "I don't feel like modeling this error" starts flowing into the defect channel, and the discipline that makes `E` trustworthy erodes. The friction is a forcing function — either model the failure as an `Err`, or throw at its true origin. (The `@unthrown/effect` `fromExit` precedent stays what it is: replaying a failure that *actually occurred*, not creating one from nothing.)

Docs-only — no package changes, no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)