### PR TITLE
docs: sync CLAUDE.md with two audited surface drifts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,9 +278,11 @@ library can be "done".
   promise never rejects.
 - **Source layout** (`packages/core/src/`): `types.ts` (public types), `defect.ts`
   (the `Defect` marker), `core.ts` (the `Res`/`AsyncRes` engine + `UnwrapError`),
-  `constructors.ts` (`Ok`/`Err` + guards), `interop.ts` (`from*`/`qualify`/`all`),
-  `facade.ts` (the `Result` object), `tagged.ts` (`TaggedError`/`matchTags`), and
-  `index.ts` (the curated public re-exports — the one place the API is decided).
+  `constructors.ts` (`Ok`/`Err` + guards), `do.ts` (the `Do()` do-notation entry
+  — the `bind`/`let` steps themselves live on the method surface in `core.ts`),
+  `interop.ts` (`from*`/`qualify`/`all`), `facade.ts` (the `Result` object),
+  `tagged.ts` (`TaggedError`/`matchTags`), and `index.ts` (the curated public
+  re-exports — the one place the API is decided).
 
 ## Monorepo layout
 
@@ -406,9 +408,11 @@ channel?**
    a zero-dependency exhaustive fold whose handler object is
    `{ Ok, Defect } & { [K in E["_tag"]]: (e: Extract<E, {_tag: K}>) => R }`.
 3. ✅ **`packages/vitest`** — Done. Custom matchers `toBeOk`, `toBeOkWith`,
-   `toBeErr`, `toBeErrTagged` (optional second arg also matches the tagged
-   error's payload — exact for a plain object, partial for an asymmetric matcher
-   like `expect.objectContaining`), `toBeDefect`, registered via `expect.extend`
+   `toBeErr`, `toBeErrWith` (the error-value mirror of `toBeOkWith` — a deep
+   compare of the `Err` value), `toBeErrTagged` (optional second arg also matches
+   the tagged error's payload — exact for a plain object, partial for an
+   asymmetric matcher like `expect.objectContaining`), `toBeDefect`, registered
+   via `expect.extend`
    and augmenting Vitest's `Matchers` interface. They detect a thenable
    `AsyncResult` and await internally, so a test reads
    `await expect(asyncResult).toBeOk()` (the required `await` is documented loudly


### PR DESCRIPTION
## Summary

A full-project audit against `CLAUDE.md` (the authoritative spec) surfaced two **documentation-only** drifts where the code had moved ahead of the spec. No code changes — this brings the spec back in sync.

- **Source layout** omitted `packages/core/src/do.ts` (the `Do()` do-notation entry). Added it, noting the `bind`/`let` steps themselves live on the method surface in `core.ts`.
- **`@unthrown/vitest` matcher list** omitted `toBeErrWith`. Added it as the error-value mirror of `toBeOkWith` (a deep compare of the `Err` value), keeping the exact-vs-partial payload nuance scoped to `toBeErrTagged` where it actually applies.

## Audit result

The rest of the project was found fully conformant: the quality gate (`format --check`, `lint`, `typecheck`, `knip`, `test`, `build`) is green (20/20 turbo tasks), every load-bearing core invariant has a 1:1 guarding test, all eight satellite packages match their specs, and the manifests / CI / docs tooling check out. These two doc lines were the only drift.

## Test plan

- [x] `pnpm format --check`, `lint`, `typecheck`, `knip`, `test`, `build` — all green (pre-existing; unaffected by a docs edit)
- [x] lefthook pre-commit (format) + commit-msg (commitlint) passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)