### PR TITLE
Apply the Beetroot Stack theme (1.6.0) + character logo

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -5,6 +5,13 @@
   --accent: #46b86c;
 }
 
+/* Hero name in the package accent — the BtravStack multi-accent rule: the
+ * canvas stays neutral, the product glows in its own color (AA via
+ * --text-accent, which darkens on light). */
+:root:root {
+  --vp-home-hero-name-color: var(--text-accent);
+}
+
 /* Home-hero background glyph — the project's motif behind the hero (an ok/err
  * railway split). Painted in --accent through a mask, so it always tracks the
  * accent token; the SVG is base64-encoded so no CSS minifier can mangle it. */
@@ -14,12 +21,6 @@
      defined once so the glow and glyph stay anchored to the same column. */
   --btv-col: 1152px;
   --btv-gutter: max(0px, calc((100% - var(--btv-col)) / 2));
-}
-/* Anchor the shared theme's hero glow to the content column instead of the
- * viewport edge, so it doesn't drift into a stray halo by the header on wide
- * screens (it still bleeds ~120px past the content, as before). */
-.VPHome::before {
-  right: calc(var(--btv-gutter) - 120px);
 }
 .VPHome::after {
   content: "";

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,8 @@ hero:
   text: "Explicit errors as values"
   tagline: A small, focused Result type with a separate defect channel for the unexpected — and qualification enforced at every boundary.
   image:
-    src: /logo.svg
+    light: /logo-light.svg
+    dark: /logo-dark.svg
     alt: unthrown
   actions:
     - theme: brand

--- a/docs/public/logo-dark.svg
+++ b/docs/public/logo-dark.svg
@@ -1,1 +1,26 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 150" width="150" height="150" fill="none"><g transform="translate(75,78) scale(0.58) translate(-50,-63)"><g transform="translate(50,34)"><g transform="rotate(-35)"><path d="M0,3 C-6,-7 -6,-18 0,-28 C6,-18 6,-7 0,3 Z" fill="#2C8B4E"></path></g><g transform="rotate(35)"><path d="M0,3 C-6,-7 -6,-18 0,-28 C6,-18 6,-7 0,3 Z" fill="#2C8B4E"></path></g><path d="M0,4 C-7,-8 -7,-20 0,-32 C7,-20 7,-8 0,4 Z" fill="#3DAE62"></path></g><path d="M50,32 C29,30 17,44 17,60 C17,79 37,99 50,107 Z" fill="#CE3D80"></path><path d="M50,32 C71,30 83,44 83,60 C83,79 63,99 50,107 Z" fill="#8E1A52"></path><path d="M31,48 C27,55 27.5,65 32,73" stroke="#EE9CC4" stroke-width="4" stroke-linecap="round" fill="none" opacity="0.55"></path><path d="M46.5,104 C46.5,112 44,118 39,124 C47,120 52.5,112 53.5,104 Z" fill="#8E1A52"></path></g><circle cx="75" cy="75" r="54" fill="none" stroke="#EFE7D8" stroke-width="9"></circle><line x1="37" y1="37" x2="113" y2="113" stroke="#EFE7D8" stroke-width="9" stroke-linecap="round"></line></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="44 44 112 112" width="108" height="108" fill="none">
+  <circle cx="100" cy="100" r="47" stroke="#46B86C" stroke-width="9.5" fill="none"/>
+  <g transform="translate(80,68) scale(0.40)"><g transform="rotate(0 50 68)">
+    <!-- springy leaves -->
+    <path d="M46,34 C44,26 44,18 47,10" stroke="#2C8B4E" stroke-width="3.6" stroke-linecap="round" fill="none"/>
+    <path d="M47,10 C40,7 37,-2 43,-6 C50,-10 56,-3 54,3 C53,7 51,9 47,10 Z" fill="#3DAE62"/>
+    <path d="M41,36 C34,31 26,30 21,34 C16,38 19,45 26,45 C32,45 38,41 41,36 Z" fill="#2C8B4E"/>
+    <path d="M57,34 C62,27 70,24 76,28 C81,32 78,39 71,40 C65,40 60,37 57,34 Z" fill="#3DAE62"/>
+    
+    <g transform="rotate(-52 16 62)"><rect x="2" y="58" width="20" height="9" rx="4.5" fill="#CE3D80"/></g>
+    <g transform="rotate(52 84 62)"><rect x="78" y="58" width="20" height="9" rx="4.5" fill="#8E1A52"/></g>
+    <!-- chubby body -->
+    <path d="M50,32 C28,31 14,45 14,62 C14,81 30,98 44,108 C47,111 48,114 50,116 C52,114 53,111 56,108 C70,98 86,81 86,62 C86,45 72,31 50,32 Z" fill="#CE3D80"/>
+    <path d="M63,35 C76,41 86,50 86,62 C86,79 73,94 58,106 C69,91 78,76 78,62 C78,51 72,42 63,35 Z" fill="#8E1A52" opacity="0.85"/>
+    <path d="M27,47 C23,53 22,61 24,68" stroke="#EE9CC4" stroke-width="3.4" stroke-linecap="round" fill="none" opacity="0.55"/>
+    <!-- face -->
+    
+    <path d="M32,59 Q38,65 44,59" stroke="#3A0D24" stroke-width="3.4" stroke-linecap="round" fill="none"/>
+    <path d="M57,59 Q63,65 69,59" stroke="#3A0D24" stroke-width="3.4" stroke-linecap="round" fill="none"/>
+    <path d="M41,71 Q50.5,80 60,71" stroke="#3A0D24" stroke-width="3.4" stroke-linecap="round" fill="none"/>
+    <circle cx="29" cy="69" r="4.2" fill="#EE9CC4" opacity="0.75"/>
+    <circle cx="72" cy="69" r="4.2" fill="#EE9CC4" opacity="0.75"/>
+    <!-- curly tail -->
+    <path d="M50,116 C49,121 52,124 49,129 C47,132 44,132 43,130" stroke="#8E1A52" stroke-width="2.8" stroke-linecap="round" fill="none"/>
+  </g></g>
+  <path d="M67,67 L133,133" stroke="#46B86C" stroke-width="9.5" stroke-linecap="round"/></svg>

--- a/docs/public/logo-light.svg
+++ b/docs/public/logo-light.svg
@@ -1,1 +1,26 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 150" width="150" height="150" fill="none"><g transform="translate(75,78) scale(0.58) translate(-50,-63)"><g transform="translate(50,34)"><g transform="rotate(-35)"><path d="M0,3 C-6,-7 -6,-18 0,-28 C6,-18 6,-7 0,3 Z" fill="#2C8B4E"></path></g><g transform="rotate(35)"><path d="M0,3 C-6,-7 -6,-18 0,-28 C6,-18 6,-7 0,3 Z" fill="#2C8B4E"></path></g><path d="M0,4 C-7,-8 -7,-20 0,-32 C7,-20 7,-8 0,4 Z" fill="#3DAE62"></path></g><path d="M50,32 C29,30 17,44 17,60 C17,79 37,99 50,107 Z" fill="#CE3D80"></path><path d="M50,32 C71,30 83,44 83,60 C83,79 63,99 50,107 Z" fill="#8E1A52"></path><path d="M31,48 C27,55 27.5,65 32,73" stroke="#EE9CC4" stroke-width="4" stroke-linecap="round" fill="none" opacity="0.55"></path><path d="M46.5,104 C46.5,112 44,118 39,124 C47,120 52.5,112 53.5,104 Z" fill="#8E1A52"></path></g><circle cx="75" cy="75" r="54" fill="none" stroke="#3E1E32" stroke-width="9"></circle><line x1="37" y1="37" x2="113" y2="113" stroke="#3E1E32" stroke-width="9" stroke-linecap="round"></line></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="44 44 112 112" width="108" height="108" fill="none">
+  <circle cx="100" cy="100" r="47" stroke="#348A51" stroke-width="9.5" fill="none"/>
+  <g transform="translate(80,68) scale(0.40)"><g transform="rotate(0 50 68)">
+    <!-- springy leaves -->
+    <path d="M46,34 C44,26 44,18 47,10" stroke="#2C8B4E" stroke-width="3.6" stroke-linecap="round" fill="none"/>
+    <path d="M47,10 C40,7 37,-2 43,-6 C50,-10 56,-3 54,3 C53,7 51,9 47,10 Z" fill="#3DAE62"/>
+    <path d="M41,36 C34,31 26,30 21,34 C16,38 19,45 26,45 C32,45 38,41 41,36 Z" fill="#2C8B4E"/>
+    <path d="M57,34 C62,27 70,24 76,28 C81,32 78,39 71,40 C65,40 60,37 57,34 Z" fill="#3DAE62"/>
+    
+    <g transform="rotate(-52 16 62)"><rect x="2" y="58" width="20" height="9" rx="4.5" fill="#CE3D80"/></g>
+    <g transform="rotate(52 84 62)"><rect x="78" y="58" width="20" height="9" rx="4.5" fill="#8E1A52"/></g>
+    <!-- chubby body -->
+    <path d="M50,32 C28,31 14,45 14,62 C14,81 30,98 44,108 C47,111 48,114 50,116 C52,114 53,111 56,108 C70,98 86,81 86,62 C86,45 72,31 50,32 Z" fill="#CE3D80"/>
+    <path d="M63,35 C76,41 86,50 86,62 C86,79 73,94 58,106 C69,91 78,76 78,62 C78,51 72,42 63,35 Z" fill="#8E1A52" opacity="0.85"/>
+    <path d="M27,47 C23,53 22,61 24,68" stroke="#EE9CC4" stroke-width="3.4" stroke-linecap="round" fill="none" opacity="0.55"/>
+    <!-- face -->
+    
+    <path d="M32,59 Q38,65 44,59" stroke="#3A0D24" stroke-width="3.4" stroke-linecap="round" fill="none"/>
+    <path d="M57,59 Q63,65 69,59" stroke="#3A0D24" stroke-width="3.4" stroke-linecap="round" fill="none"/>
+    <path d="M41,71 Q50.5,80 60,71" stroke="#3A0D24" stroke-width="3.4" stroke-linecap="round" fill="none"/>
+    <circle cx="29" cy="69" r="4.2" fill="#EE9CC4" opacity="0.75"/>
+    <circle cx="72" cy="69" r="4.2" fill="#EE9CC4" opacity="0.75"/>
+    <!-- curly tail -->
+    <path d="M50,116 C49,121 52,124 49,129 C47,132 44,132 43,130" stroke="#8E1A52" stroke-width="2.8" stroke-linecap="round" fill="none"/>
+  </g></g>
+  <path d="M67,67 L133,133" stroke="#348A51" stroke-width="9.5" stroke-linecap="round"/></svg>

--- a/docs/public/logo.svg
+++ b/docs/public/logo.svg
@@ -1,1 +1,26 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 150" width="64" height="64" fill="none"><style>.v-d{display:none}@media (prefers-color-scheme:dark){.v-l{display:none}.v-d{display:inline}}</style><g transform="translate(75,78) scale(0.58) translate(-50,-63)"><g transform="translate(50,34)"><g transform="rotate(-35)"><path d="M0,3 C-6,-7 -6,-18 0,-28 C6,-18 6,-7 0,3 Z" fill="#2C8B4E"></path></g><g transform="rotate(35)"><path d="M0,3 C-6,-7 -6,-18 0,-28 C6,-18 6,-7 0,3 Z" fill="#2C8B4E"></path></g><path d="M0,4 C-7,-8 -7,-20 0,-32 C7,-20 7,-8 0,4 Z" fill="#3DAE62"></path></g><path d="M50,32 C29,30 17,44 17,60 C17,79 37,99 50,107 Z" fill="#CE3D80"></path><path d="M50,32 C71,30 83,44 83,60 C83,79 63,99 50,107 Z" fill="#8E1A52"></path><path d="M31,48 C27,55 27.5,65 32,73" stroke="#EE9CC4" stroke-width="4" stroke-linecap="round" fill="none" opacity="0.55"></path><path d="M46.5,104 C46.5,112 44,118 39,124 C47,120 52.5,112 53.5,104 Z" fill="#8E1A52"></path></g><g class="v-l"><circle cx="75" cy="75" r="54" fill="none" stroke="#3E1E32" stroke-width="9"></circle><line x1="37" y1="37" x2="113" y2="113" stroke="#3E1E32" stroke-width="9" stroke-linecap="round"></line></g><g class="v-d"><circle cx="75" cy="75" r="54" fill="none" stroke="#EFE7D8" stroke-width="9"></circle><line x1="37" y1="37" x2="113" y2="113" stroke="#EFE7D8" stroke-width="9" stroke-linecap="round"></line></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="44 44 112 112" width="108" height="108" fill="none">
+  <circle cx="100" cy="100" r="47" stroke="#46B86C" stroke-width="9.5" fill="none"/>
+  <g transform="translate(80,68) scale(0.40)"><g transform="rotate(0 50 68)">
+    <!-- springy leaves -->
+    <path d="M46,34 C44,26 44,18 47,10" stroke="#2C8B4E" stroke-width="3.6" stroke-linecap="round" fill="none"/>
+    <path d="M47,10 C40,7 37,-2 43,-6 C50,-10 56,-3 54,3 C53,7 51,9 47,10 Z" fill="#3DAE62"/>
+    <path d="M41,36 C34,31 26,30 21,34 C16,38 19,45 26,45 C32,45 38,41 41,36 Z" fill="#2C8B4E"/>
+    <path d="M57,34 C62,27 70,24 76,28 C81,32 78,39 71,40 C65,40 60,37 57,34 Z" fill="#3DAE62"/>
+    
+    <g transform="rotate(-52 16 62)"><rect x="2" y="58" width="20" height="9" rx="4.5" fill="#CE3D80"/></g>
+    <g transform="rotate(52 84 62)"><rect x="78" y="58" width="20" height="9" rx="4.5" fill="#8E1A52"/></g>
+    <!-- chubby body -->
+    <path d="M50,32 C28,31 14,45 14,62 C14,81 30,98 44,108 C47,111 48,114 50,116 C52,114 53,111 56,108 C70,98 86,81 86,62 C86,45 72,31 50,32 Z" fill="#CE3D80"/>
+    <path d="M63,35 C76,41 86,50 86,62 C86,79 73,94 58,106 C69,91 78,76 78,62 C78,51 72,42 63,35 Z" fill="#8E1A52" opacity="0.85"/>
+    <path d="M27,47 C23,53 22,61 24,68" stroke="#EE9CC4" stroke-width="3.4" stroke-linecap="round" fill="none" opacity="0.55"/>
+    <!-- face -->
+    
+    <path d="M32,59 Q38,65 44,59" stroke="#3A0D24" stroke-width="3.4" stroke-linecap="round" fill="none"/>
+    <path d="M57,59 Q63,65 69,59" stroke="#3A0D24" stroke-width="3.4" stroke-linecap="round" fill="none"/>
+    <path d="M41,71 Q50.5,80 60,71" stroke="#3A0D24" stroke-width="3.4" stroke-linecap="round" fill="none"/>
+    <circle cx="29" cy="69" r="4.2" fill="#EE9CC4" opacity="0.75"/>
+    <circle cx="72" cy="69" r="4.2" fill="#EE9CC4" opacity="0.75"/>
+    <!-- curly tail -->
+    <path d="M50,116 C49,121 52,124 49,129 C47,132 44,132 43,130" stroke="#8E1A52" stroke-width="2.8" stroke-linecap="round" fill="none"/>
+  </g></g>
+  <path d="M67,67 L133,133" stroke="#46B86C" stroke-width="9.5" stroke-linecap="round"/></svg>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: 3.4.0
       version: 3.4.0
     '@btravstack/theme':
-      specifier: 1.5.0
-      version: 1.5.0
+      specifier: 1.6.0
+      version: 1.6.0
     '@changesets/cli':
       specifier: 2.31.0
       version: 2.31.0
@@ -158,7 +158,7 @@ importers:
     devDependencies:
       '@btravstack/theme':
         specifier: 'catalog:'
-        version: 1.5.0(vitepress@1.6.4(@algolia/client-search@5.55.1)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.16)(typescript@6.0.3))
+        version: 1.6.0(vitepress@1.6.4(@algolia/client-search@5.55.1)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.16)(typescript@6.0.3))(vue@3.5.38(typescript@6.0.3))
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
@@ -680,10 +680,14 @@ packages:
       typescript:
         optional: true
 
-  '@btravstack/theme@1.5.0':
-    resolution: {integrity: sha512-tTTWDNarS0GOSeHk3GZ+GtrNfAFacZNvYMzG+X/gpyUa8irPGB8MT4f+uCbloJ2UFG6JNLNXnMF7KuAVtMaoAA==}
+  '@btravstack/theme@1.6.0':
+    resolution: {integrity: sha512-MwesCcWGhsPZSHjsoWE0gib7HqUAp5oGQEnKdZshRjnqg0xDh72TvrtY7f/YioimLKAx1RAagMlb53fexNjFFg==}
     peerDependencies:
       vitepress: ^1.6.0
+      vue: ^3.3.0
+    peerDependenciesMeta:
+      vue:
+        optional: true
 
   '@changesets/apply-release-plan@7.1.1':
     resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
@@ -4164,9 +4168,11 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@btravstack/theme@1.5.0(vitepress@1.6.4(@algolia/client-search@5.55.1)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.16)(typescript@6.0.3))':
+  '@btravstack/theme@1.6.0(vitepress@1.6.4(@algolia/client-search@5.55.1)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.16)(typescript@6.0.3))(vue@3.5.38(typescript@6.0.3))':
     dependencies:
       vitepress: 1.6.4(@algolia/client-search@5.55.1)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.16)(typescript@6.0.3)
+    optionalDependencies:
+      vue: 3.5.38(typescript@6.0.3)
 
   '@changesets/apply-release-plan@7.1.1':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,7 @@ catalog:
   "@changesets/cli": 2.31.0
   "@commitlint/cli": 21.2.0
   "@bloodyowl/boxed": 3.4.0
-  "@btravstack/theme": 1.5.0
+  "@btravstack/theme": 1.6.0
   "@prisma/adapter-better-sqlite3": 7.8.0
   "@prisma/client": 7.8.0
   "@standard-schema/spec": 1.1.0


### PR DESCRIPTION
Rolls out the new BtravStack design system (btravstack/btravstack.github.io#30, published as @btravstack/theme 1.6.0): near-black canvas, Geist typography, the package accent driving everything via the one-knob contract, and the new playful character mark — the relieved beet — arms up, safe inside the no-throw ring — in unthrown green — as scheme-aware hero + nav logo. Hero name now wears the package accent. Docs build verified locally.