### PR TITLE
feat(core): add discard() — drop the Ok value, collapse the success type to void

### DIFF
--- a/.changeset/discard-operator.md
+++ b/.changeset/discard-operator.md
@@ -1,0 +1,8 @@
+---
+"unthrown": minor
+---
+
+Add `discard()` to `Result` and `AsyncResult` — drops the `Ok` value and
+collapses the success type to `void`. The named form of `map(() => undefined)`:
+unlike `as(undefined)`, which produces `Result<undefined, E>`, `discard()`
+produces `Result<void, E>`. `Err` and `Defect` pass through untouched.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,8 @@ async work re-enters via `fromPromise` / `fromSafePromise` and composes with
 
 - success: `map`, `flatMap`, `tap`, `flatTap` (a failable `tap` — runs a
   `Result`-returning effect, keeps the original value, threads the effect's
-  error), `as`
+  error), `as`, `discard` (drop the value — the success type collapses to
+  `void`; the named form of `map(() => undefined)`, distinct from `as`)
 - do-notation: `Do()` (entry — `Ok({})`, an empty object scope; capitalised
   because `do` is reserved) plus the methods `bind(name, f)` (sequence a
   `Result`-returning step, binding its value under `name` in an accumulating

--- a/docs/guide/choosing-a-combinator.md
+++ b/docs/guide/choosing-a-combinator.md
@@ -34,6 +34,7 @@ moves the channels: `flatMap` widens `E` to `E | E2`, `recoverErr` empties it to
 | run a **failable** side effect, keep the value | `flatTap`         | `(v: T) => Result<unknown, E2>` → `Result<T, E \| E2>`       | Ok      |
 | sequence steps into a named scope              | `Do`/`bind`/`let` | `bind(k, (scope) => Result<U, E2>)` → `Result<{…}, E \| E2>` | Ok      |
 | replace the value with a constant              | `as`              | `(value: U)` → `Result<U, E>`                                | Ok      |
+| drop the value (success type becomes `void`)   | `discard`         | `()` → `Result<void, E>`                                     | Ok      |
 | transform the error                            | `mapErr`          | `(e: E) => E2` → `Result<T, E2>`                             | Err     |
 | try a fallback that returns a `Result`         | `flatMapErr`      | `(e: E) => Result<U, E2>` → `Result<T \| U, E2>`             | Err     |
 | turn an error into a success value             | `recoverErr`      | `(e: E) => U` → `Result<T \| U, never>`                      | Err     |

--- a/docs/guide/core-concepts.md
+++ b/docs/guide/core-concepts.md
@@ -23,7 +23,7 @@ reachable once you've narrowed to a variant.
 
 Every `Result` shares one method surface, grouped by the channel it touches:
 
-- **success** (runs on `Ok`): `map`, `flatMap`, `tap`, `flatTap`, `as`
+- **success** (runs on `Ok`): `map`, `flatMap`, `tap`, `flatTap`, `as`, `discard`
 - **do-notation** (runs on `Ok`): `bind`, `let` — accumulate a named scope; see
   [Do Notation](./do-notation)
 - **error** (runs on `Err`): `mapErr`, `flatMapErr`, `recoverErr`, `tapErr`, `flatTapErr`

--- a/packages/core/src/async-result.spec.ts
+++ b/packages/core/src/async-result.spec.ts
@@ -136,6 +136,14 @@ describe("AsyncResult success channel", () => {
     if (r.isErr()) expect(r.error).toBe("e");
     expect((await asyncDefect().as("x")).isDefect()).toBe(true);
   });
+
+  it("discard drops the Ok value, and passes Err/Defect through", async () => {
+    expect((await asyncOk(1).discard()).get()).toBeUndefined();
+    const r = await asyncErr("e").discard();
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error).toBe("e");
+    expect((await asyncDefect().discard()).isDefect()).toBe(true);
+  });
 });
 
 describe("AsyncResult error channel", () => {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -598,6 +598,12 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
     );
   }
 
+  discard(): AsyncResult<void, E> {
+    return new AsyncRes<void, E>(
+      this.promise.then((r) => (r.tag === "Ok" ? okRes<void, E>(undefined) : passThrough(r))),
+    );
+  }
+
   mapErr<E2>(f: (error: E) => E2 & NotThenable<E2>): AsyncResult<T, E2> {
     return new AsyncRes<T, E2>(
       this.promise.then((r) => {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -151,6 +151,7 @@ class Res<T, E> {
 
   discard(this: Result<T, E>): Result<void, E> {
     if (this.tag !== "Ok") return passThrough(this);
+    // explicit <void, E>: inference from the argument would land on undefined, not void
     return okRes<void, E>(undefined);
   }
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -149,6 +149,11 @@ class Res<T, E> {
     return okRes(value);
   }
 
+  discard(this: Result<T, E>): Result<void, E> {
+    if (this.tag !== "Ok") return passThrough(this);
+    return okRes<void, E>(undefined);
+  }
+
   mapErr<E2>(this: Result<T, E>, f: (error: E) => E2 & NotThenable<E2>): Result<T, E2> {
     if (this.tag !== "Err") return passThrough(this);
     try {

--- a/packages/core/src/invariants.spec.ts
+++ b/packages/core/src/invariants.spec.ts
@@ -45,6 +45,7 @@ describe("Invariant 2: a Defect flows through every method except match() and re
       defectOf(boom).bind("a", f),
       defectOf(boom).let("a", f),
       defectOf(boom).as(1),
+      defectOf(boom).discard(),
       defectOf(boom).mapErr(f),
       defectOf(boom).flatMapErr(f),
       defectOf(boom).recoverErr(f),

--- a/packages/core/src/result.spec.ts
+++ b/packages/core/src/result.spec.ts
@@ -162,6 +162,19 @@ describe("Result.as", () => {
   });
 });
 
+describe("Result.discard", () => {
+  it("drops the Ok value", () => {
+    expect(Ok(1).discard().get()).toBeUndefined();
+  });
+
+  it("passes Err and Defect through", () => {
+    const r = Err("e").discard();
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error).toBe("e");
+    expect(defectOf(boom).discard().isDefect()).toBe(true);
+  });
+});
+
 describe("Result.mapErr", () => {
   it("maps the Err value", () => {
     expect(

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -152,6 +152,9 @@ type _recovered = Expect<Equal<typeof recovered, Result<number, never>>>;
 const discarded = r1.discard();
 type _discarded = Expect<Equal<typeof discarded, Result<void, "e1">>>;
 
+const discardedAsync = ar.discard();
+type _discardedAsync = Expect<Equal<typeof discardedAsync, AsyncResult<void, "e">>>;
+
 // map changes the value type; mapErr changes the error type
 const mapped = r1.map((n) => `${n}`);
 type _mapped = Expect<Equal<typeof mapped, Result<string, "e1">>>;

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -148,7 +148,7 @@ type _flatTapErred = Expect<Equal<typeof flatTapErred, Result<number, "e1" | "e2
 const recovered = r1.recoverErr(() => 0);
 type _recovered = Expect<Equal<typeof recovered, Result<number, never>>>;
 
-// discard collapses the success type to `void` (not `undefined`)
+// discard collapses the success type to `void` (not `undefined`) — and the async mirror
 const discarded = r1.discard();
 type _discarded = Expect<Equal<typeof discarded, Result<void, "e1">>>;
 

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -148,6 +148,10 @@ type _flatTapErred = Expect<Equal<typeof flatTapErred, Result<number, "e1" | "e2
 const recovered = r1.recoverErr(() => 0);
 type _recovered = Expect<Equal<typeof recovered, Result<number, never>>>;
 
+// discard collapses the success type to `void` (not `undefined`)
+const discarded = r1.discard();
+type _discarded = Expect<Equal<typeof discarded, Result<void, "e1">>>;
+
 // map changes the value type; mapErr changes the error type
 const mapped = r1.map((n) => `${n}`);
 type _mapped = Expect<Equal<typeof mapped, Result<string, "e1">>>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -161,6 +161,15 @@ export type ResultMethods<T, E> = {
    * @typeParam U - the replacement value type.
    */
   as<U>(value: U): Result<U, E>;
+  /**
+   * Drop the success value, collapsing the success type to `void`.
+   *
+   * The named form of `map(() => undefined)`. Runs only on `Ok` (the value is
+   * replaced with `undefined`); `Err` and `Defect` pass through. Unlike
+   * `as(undefined)` — which produces `Result<undefined, E>` — the success type
+   * is `void`: the value's story ends here.
+   */
+  discard(): Result<void, E>;
 
   /**
    * Transform the modeled error with `f`.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -630,6 +630,8 @@ export type AsyncResultMethods<T, E> = {
   ): AsyncResult<Bound<T, K, U>, E>;
   /** Asynchronous {@link ResultMethods.as | as}: replaces the value with `value`. */
   as<U>(value: U): AsyncResult<U, E>;
+  /** Asynchronous {@link ResultMethods.discard | discard}: drops the value, collapsing the success type to `void`. */
+  discard(): AsyncResult<void, E>;
 
   /**
    * Asynchronous {@link ResultMethods.mapErr | mapErr}. `f` is synchronous; a


### PR DESCRIPTION
## Summary

Adds a `discard()` combinator to `Result` and `AsyncResult` — the named replacement for the recurring `.map(() => undefined)` pattern.

- **Sync**: `discard(): Result<void, E>` — `Ok(v)` → frozen `Ok(undefined)` typed `void`; `Err`/`Defect` pass through untouched via `passThrough` (no allocation, no new cast sites)
- **Async mirror**: `discard(): AsyncResult<void, E>`
- Deliberately **not** an alias of `as`: `as(undefined)` infers `Result<undefined, E>`; `discard()` produces `Result<void, E>` — the type says what is meant
- No callback ⇒ no throw→defect path, no `NotThenable` intersection; the simplest operator on the surface
- No new exports; `index.ts` untouched; changeset: **minor** on `unthrown`

## Docs

- New row in the choosing-a-combinator guide table; success-surface lists in core-concepts and CLAUDE.md updated
- Full TSDoc on both method surfaces (sync canonical, async links back)

## Test plan

- Runtime tests for all three variants on both surfaces (result.spec, async-result.spec)
- `discard` added to the Invariant-2 defect-pass-through sweep (invariants.spec)
- Type-level assertions pin `Result<void, "e">` / `AsyncResult<void, "e">` — the `Equal` helper verified to distinguish `void` from `undefined`
- Full gate green: format / lint / typecheck (incl. test-d) / knip / test (219 passing, 100% line+function coverage) / build + typedoc warning-free

Spec'd, implemented task-by-task with per-task review, and passed a final whole-branch review (verdict: ready to merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)