### PR TITLE
feat(core): no-arg Ok()/OkAsync() overloads for void successes

### DIFF
--- a/.changeset/ok-void-overload.md
+++ b/.changeset/ok-void-overload.md
@@ -1,0 +1,9 @@
+---
+"unthrown": minor
+---
+
+Add no-arg overloads `Ok()` and `OkAsync()` — construct a `void` success
+(`Result<void, never>` / `AsyncResult<void, never>`) without writing
+`Ok(undefined)`, and with the success channel typed `void`, not `undefined`.
+The 1-arg forms are unchanged. The companions pick the overload up unchanged
+(`Result.Ok()` / `AsyncResult.Ok()`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,9 @@ async work re-enters via `fromPromise` / `fromSafePromise` and composes with
 - types: `NotThenable<R>` — rejects a `PromiseLike` at the type level, so a
   combinator callback that returns one is a compile error instead of a silently
   unqualified rejection.
-- constructors: `Ok`, `Err` (there is **no** `Defect` constructor — a defect-state
+- constructors: `Ok` (a no-arg overload — `Ok()` — constructs a `void` success,
+  `Result<void, never>`, sparing `Ok(undefined)`; `OkAsync()` mirrors it),
+  `Err` (there is **no** `Defect` constructor — a defect-state
   `Result` arises only at boundaries; the qualify-time `defect` marker helper is
   injected, not exported), plus the **pre-lifted async** constructors `OkAsync` /
   `ErrAsync` — `Ok(v).toAsync()` / `Err(e).toAsync()` without the boilerplate, for

--- a/packages/core/src/async-result.spec.ts
+++ b/packages/core/src/async-result.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { type AsyncResult, Err, fromPromise, fromSafePromise, Ok } from "./index.js";
+import { type AsyncResult, Err, fromPromise, fromSafePromise, Ok, OkAsync } from "./index.js";
 
 const boom = new Error("boom");
 const asyncOk = <T>(v: T): AsyncResult<T, never> => Ok(v).toAsync();
@@ -11,6 +11,14 @@ const asyncDefect = (): AsyncResult<number, never> =>
     .map<number>(() => {
       throw boom;
     });
+
+describe("OkAsync() with no argument", () => {
+  it("constructs a void success", async () => {
+    const r = await OkAsync();
+    expect(r.isOk()).toBe(true);
+    expect(r.get()).toBeUndefined();
+  });
+});
 
 describe("AsyncResult is awaitable and never rejects", () => {
   it("await yields a Result for each channel and never throws", async () => {

--- a/packages/core/src/constructors.ts
+++ b/packages/core/src/constructors.ts
@@ -6,12 +6,11 @@ import type { AsyncResult, DefectView, ErrView, OkView, Result } from "./types.j
 /**
  * Construct a successful {@link Result}.
  *
- * With no argument, constructs a `void` success — `Result<void, never>` —
- * sparing you `Ok(undefined)` and typing the success channel `void`, not
- * `undefined`.
+ * Pass a value to wrap it as `Result<T, never>`, or call with no argument to
+ * construct a `void` success — `Result<void, never>` — sparing you `Ok(undefined)`
+ * and typing the success channel `void`, not `undefined`.
  *
  * @typeParam T - the success value type.
- * @param value - the success value to wrap; omit it for a `void` success.
  *
  * @example
  * ```ts
@@ -57,6 +56,9 @@ export function Err<E>(error: E): Result<never, E> {
  * Construct a successful {@link AsyncResult} from a pure value — the pre-lifted
  * form of {@link Ok}, sparing you `Ok(value).toAsync()`.
  *
+ * Pass a value to wrap it as `AsyncResult<T, never>`, or call with no argument
+ * to construct a `void` success — `AsyncResult<void, never>`.
+ *
  * @remarks
  * Reach for this on the synchronous/early branch of an `AsyncResult`-returning
  * function, so both branches share one return type without a trailing
@@ -65,7 +67,6 @@ export function Err<E>(error: E): Result<never, E> {
  * as `AsyncResult.Ok` (the namespace already says "async", so the suffix drops).
  *
  * @typeParam T - the success value type.
- * @param value - the success value to wrap; omit it for a `void` success.
  *
  * @example
  * ```ts

--- a/packages/core/src/constructors.ts
+++ b/packages/core/src/constructors.ts
@@ -4,13 +4,25 @@ import { errRes, okRes } from "./core.js";
 import type { AsyncResult, DefectView, ErrView, OkView, Result } from "./types.js";
 
 /**
+ * Construct a successful `void` {@link Result} — `Result<void, never>` —
+ * sparing you `Ok(undefined)` and typing the success channel `void`, not
+ * `undefined`.
+ *
+ * @example
+ * ```ts
+ * import { Ok } from "unthrown";
+ *
+ * Ok(); // => a void success: Result<void, never>
+ * ```
+ *
+ * @category Constructors
+ */
+export function Ok(): Result<void, never>;
+/**
  * Construct a successful {@link Result}.
  *
- * Pass a value to wrap it as `Result<T, never>`, or call with no argument to
- * construct a `void` success — `Result<void, never>` — sparing you `Ok(undefined)`
- * and typing the success channel `void`, not `undefined`.
- *
  * @typeParam T - the success value type.
+ * @param value - the success value to wrap.
  *
  * @example
  * ```ts
@@ -18,12 +30,10 @@ import type { AsyncResult, DefectView, ErrView, OkView, Result } from "./types.j
  *
  * Ok(2).map((n) => n + 1); // => Ok(3)
  * Ok(42).get(); // => 42
- * Ok(); // => a void success: Result<void, never>
  * ```
  *
  * @category Constructors
  */
-export function Ok(): Result<void, never>;
 export function Ok<T>(value: T): Result<T, never>;
 export function Ok<T>(value?: T): Result<T, never> {
   // The only way in with no argument is the no-arg overload, which fixes the
@@ -53,11 +63,23 @@ export function Err<E>(error: E): Result<never, E> {
 }
 
 /**
+ * Construct a successful `void` {@link AsyncResult} — `AsyncResult<void, never>`
+ * — the pre-lifted form of the no-arg {@link Ok}, sparing you
+ * `Ok(undefined).toAsync()`.
+ *
+ * @example
+ * ```ts
+ * import { OkAsync } from "unthrown";
+ *
+ * OkAsync(); // => a void success: AsyncResult<void, never>
+ * ```
+ *
+ * @category Constructors
+ */
+export function OkAsync(): AsyncResult<void, never>;
+/**
  * Construct a successful {@link AsyncResult} from a pure value — the pre-lifted
  * form of {@link Ok}, sparing you `Ok(value).toAsync()`.
- *
- * Pass a value to wrap it as `AsyncResult<T, never>`, or call with no argument
- * to construct a `void` success — `AsyncResult<void, never>`.
  *
  * @remarks
  * Reach for this on the synchronous/early branch of an `AsyncResult`-returning
@@ -67,6 +89,7 @@ export function Err<E>(error: E): Result<never, E> {
  * as `AsyncResult.Ok` (the namespace already says "async", so the suffix drops).
  *
  * @typeParam T - the success value type.
+ * @param value - the success value to wrap.
  *
  * @example
  * ```ts
@@ -76,12 +99,10 @@ export function Err<E>(error: E): Result<never, E> {
  *   if (ids.length === 0) return OkAsync([]); // no more Ok([]).toAsync()
  *   return itemRepository.load(ids);
  * }
- * OkAsync(); // => a void success: AsyncResult<void, never>
  * ```
  *
  * @category Constructors
  */
-export function OkAsync(): AsyncResult<void, never>;
 export function OkAsync<T>(value: T): AsyncResult<T, never>;
 export function OkAsync<T>(value?: T): AsyncResult<T, never> {
   // Same deliberate cast as `Ok` above: argument-less means the no-arg

--- a/packages/core/src/constructors.ts
+++ b/packages/core/src/constructors.ts
@@ -6,8 +6,12 @@ import type { AsyncResult, DefectView, ErrView, OkView, Result } from "./types.j
 /**
  * Construct a successful {@link Result}.
  *
+ * With no argument, constructs a `void` success — `Result<void, never>` —
+ * sparing you `Ok(undefined)` and typing the success channel `void`, not
+ * `undefined`.
+ *
  * @typeParam T - the success value type.
- * @param value - the success value to wrap.
+ * @param value - the success value to wrap; omit it for a `void` success.
  *
  * @example
  * ```ts
@@ -15,12 +19,18 @@ import type { AsyncResult, DefectView, ErrView, OkView, Result } from "./types.j
  *
  * Ok(2).map((n) => n + 1); // => Ok(3)
  * Ok(42).get(); // => 42
+ * Ok(); // => a void success: Result<void, never>
  * ```
  *
  * @category Constructors
  */
-export function Ok<T>(value: T): Result<T, never> {
-  return okRes(value);
+export function Ok(): Result<void, never>;
+export function Ok<T>(value: T): Result<T, never>;
+export function Ok<T>(value?: T): Result<T, never> {
+  // `value as T`: the only argument-less path in is the no-arg overload, which
+  // fixes the result type to `void` — exactly what the omitted `undefined`
+  // inhabits. Invisible to callers.
+  return okRes(value as T);
 }
 
 /**
@@ -55,7 +65,7 @@ export function Err<E>(error: E): Result<never, E> {
  * as `AsyncResult.Ok` (the namespace already says "async", so the suffix drops).
  *
  * @typeParam T - the success value type.
- * @param value - the success value to wrap.
+ * @param value - the success value to wrap; omit it for a `void` success.
  *
  * @example
  * ```ts
@@ -65,12 +75,17 @@ export function Err<E>(error: E): Result<never, E> {
  *   if (ids.length === 0) return OkAsync([]); // no more Ok([]).toAsync()
  *   return itemRepository.load(ids);
  * }
+ * OkAsync(); // => a void success: AsyncResult<void, never>
  * ```
  *
  * @category Constructors
  */
-export function OkAsync<T>(value: T): AsyncResult<T, never> {
-  return Ok(value).toAsync();
+export function OkAsync(): AsyncResult<void, never>;
+export function OkAsync<T>(value: T): AsyncResult<T, never>;
+export function OkAsync<T>(value?: T): AsyncResult<T, never> {
+  // Same deliberate cast as `Ok` above: argument-less means the no-arg
+  // overload already fixed the type to `void`.
+  return Ok(value as T).toAsync();
 }
 
 /**

--- a/packages/core/src/constructors.ts
+++ b/packages/core/src/constructors.ts
@@ -26,9 +26,9 @@ import type { AsyncResult, DefectView, ErrView, OkView, Result } from "./types.j
 export function Ok(): Result<void, never>;
 export function Ok<T>(value: T): Result<T, never>;
 export function Ok<T>(value?: T): Result<T, never> {
-  // `value as T`: the only argument-less path in is the no-arg overload, which
-  // fixes the result type to `void` — exactly what the omitted `undefined`
-  // inhabits. Invisible to callers.
+  // The only way in with no argument is the no-arg overload, which fixes the
+  // result type to void — exactly what the omitted undefined inhabits.
+  // Invisible to callers.
   return okRes(value as T);
 }
 

--- a/packages/core/src/result.spec.ts
+++ b/packages/core/src/result.spec.ts
@@ -8,6 +8,13 @@ const defectOf = (cause: unknown): Result<number, never> =>
     throw cause;
   });
 
+describe("Ok() with no argument", () => {
+  it("constructs a void success", () => {
+    expect(Ok().isOk()).toBe(true);
+    expect(Ok().get()).toBeUndefined();
+  });
+});
+
 describe("Result.map", () => {
   it("maps the Ok value", () => {
     expect(

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -56,6 +56,13 @@ type _okAsync = Expect<Equal<typeof okAsyncV, AsyncResult<number, never>>>;
 const errAsyncV = ErrAsync<string>("e");
 type _errAsync = Expect<Equal<typeof errAsyncV, AsyncResult<never, string>>>;
 
+// no-arg overloads construct a `void` success (not `undefined`); the existing
+// _ok/_okAsync assertions above pin that 1-arg inference is unchanged
+const okVoidV = Ok();
+type _okVoid = Expect<Equal<typeof okVoidV, Result<void, never>>>;
+const okAsyncVoidV = OkAsync();
+type _okAsyncVoid = Expect<Equal<typeof okAsyncVoidV, AsyncResult<void, never>>>;
+
 // --- aggregation: `all` keeps positional tuple types -------------------------
 
 const tuple = all([Ok(1), Ok("x"), Ok(true)]);


### PR DESCRIPTION
## Summary

Adds no-arg overloads to the success constructors — the origin-side companion to `discard()` (#100):

- `Ok(): Result<void, never>` and `OkAsync(): AsyncResult<void, never>` — a `void` success without writing `Ok(undefined)`, with the channel typed `void`, not `undefined`
- Same concept at a different arity, not a new name; the companions (`Result.Ok()` / `AsyncResult.Ok()`) inherit the overload with no facade change
- The generic 1-arg signature stays **last**, so contextual typing of a bare `Ok` reference is unchanged (verified: no in-repo higher-order use either)
- The only casts are `value as T` in the implementation signatures — invisible to callers, commented in place
- `Err`/`ErrAsync` deliberately get no overload (a void error has no use case); no new exports; changeset: **minor** on `unthrown`

## Test plan

- Runtime tests for `Ok()` / `OkAsync()` on both spec files (RED was a compile error — the old 1-arg signatures reject the no-arg calls)
- Type-level assertions pin `Result<void, never>` / `AsyncResult<void, never>` (the `Equal` helper distinguishes `void` from `undefined`); existing `_ok`/`_okAsync` assertions pin 1-arg inference unchanged
- Full gate green: format / lint / typecheck (incl. test-d) / knip / test / build + typedoc warning-free (one disclosed follow-on: pruned the shared TSDoc `@param` that the no-arg overload made warn)

Spec'd, implemented task-by-task with per-task review, and passed a final whole-branch review (verdict: ready to merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)