### PR TITLE
fix(deps): clear new audit advisories blocking CI (fast-uri, @hono/node-server)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,7 +102,7 @@ overrides:
   js-yaml@3: 3.15.0
   vite@<6.4.3: 6.4.3
   '@hono/node-server@<2.0.10': 2.0.10
-  fast-uri@3: 3.1.4
+  fast-uri@<3.1.4: 3.1.4
 
 importers:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,7 +101,8 @@ overrides:
   brace-expansion@5: 5.0.7
   js-yaml@3: 3.15.0
   vite@<6.4.3: 6.4.3
-  '@hono/node-server@1': 1.19.13
+  '@hono/node-server@<2.0.10': 2.0.10
+  fast-uri@3: 3.1.4
 
 importers:
 
@@ -1185,9 +1186,9 @@ packages:
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
 
-  '@hono/node-server@1.19.13':
-    resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.0.10':
+    resolution: {integrity: sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==}
+    engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
 
@@ -2867,8 +2868,8 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
-  fast-uri@3.1.3:
-    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -4640,7 +4641,7 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@hono/node-server@1.19.13(hono@4.12.27)':
+  '@hono/node-server@2.0.10(hono@4.12.27)':
     dependencies:
       hono: 4.12.27
 
@@ -5026,7 +5027,7 @@ snapshots:
       '@electric-sql/pglite': 0.4.1
       '@electric-sql/pglite-socket': 0.1.1(@electric-sql/pglite@0.4.1)
       '@electric-sql/pglite-tools': 0.3.1(@electric-sql/pglite@0.4.1)
-      '@hono/node-server': 1.19.13(hono@4.12.27)
+      '@hono/node-server': 2.0.10(hono@4.12.27)
       '@prisma/get-platform': 7.2.0
       '@prisma/query-plan-executor': 7.2.0
       '@prisma/streams-local': 0.1.2
@@ -5624,7 +5625,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -5978,7 +5979,7 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
-  fast-uri@3.1.3: {}
+  fast-uri@3.1.4: {}
 
   fastq@1.20.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,10 +59,16 @@ overrides:
   # to 6.4.3 (the first fixed version) — the docs `vitepress build` is verified
   # against it. This also drags esbuild up to a patched 0.25.x.
   "vite@<6.4.3": "6.4.3"
-  # GHSA-92pp-h63x-v22m: @hono/node-server request smuggling in the 1.x line,
-  # pulled in by the `prisma` CLI's dev server (@prisma/dev). 1.19.13 is the
-  # patched 1.x release.
-  "@hono/node-server@1": "1.19.13"
+  # GHSA-92pp-h63x-v22m (request smuggling, 1.x) + GHSA-frvp-7c67-39w9 (Windows
+  # path traversal in `serve-static`, <2.0.5) + GHSA-9mqv-5hh9-4cgg (WebSocket
+  # DoS, <=2.0.9): @hono/node-server, pulled in by the `prisma` CLI's dev server
+  # (@prisma/dev). 2.0.10 is the first release patched for all three; the
+  # resolved hono 4.x satisfies its `hono: ^4` peer.
+  "@hono/node-server@<2.0.10": "2.0.10"
+  # GHSA-v2hh-gcrm-f6hx: fast-uri host confusion via literal backslash authority
+  # delimiter. Only the 3.x line is present (via ajv, under commitlint's config
+  # loading and the `prisma` CLI); 3.1.4 is the first patched release.
+  "fast-uri@3": "3.1.4"
 
 peerDependencyRules:
   ignoreMissing:
@@ -92,3 +98,7 @@ minimumReleaseAge: 10080
 minimumReleaseAgeStrict: true
 minimumReleaseAgeExclude:
   - "@btravstack/theme"
+  # Temporary security-patch exception: fast-uri 3.1.4 (the GHSA-v2hh-gcrm-f6hx
+  # fix forced by the override above) is younger than the cutoff. Remove this
+  # entry once 3.1.4 is 7 days old (published 2026-07-19).
+  - fast-uri

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -67,8 +67,9 @@ overrides:
   "@hono/node-server@<2.0.10": "2.0.10"
   # GHSA-v2hh-gcrm-f6hx: fast-uri host confusion via literal backslash authority
   # delimiter. Only the 3.x line is present (via ajv, under commitlint's config
-  # loading and the `prisma` CLI); 3.1.4 is the first patched release.
-  "fast-uri@3": "3.1.4"
+  # loading and the `prisma` CLI); 3.1.4 is the first patched release. Scoped to
+  # the vulnerable range so future patched 3.x releases resolve normally.
+  "fast-uri@<3.1.4": "3.1.4"
 
 peerDependencyRules:
   ignoreMissing:


### PR DESCRIPTION
## Summary

The Security Audit job (`pnpm audit --audit-level=high`) fails on every branch — including `main` — because fresh advisories landed upstream; this is what's blocking #100 and #101. Fixes, following the repo's version-scoped-override convention:

- **GHSA-v2hh-gcrm-f6hx (high, the CI blocker)**: `fast-uri` ≤3.1.3 host confusion, transitive via `ajv` (commitlint config loading + prisma CLI). Override `fast-uri@3` → `3.1.4`, plus a **temporary** `minimumReleaseAgeExclude` entry — 3.1.4 was published 2026-07-19, inside the 7-day supply-chain cutoff; the comment says to remove the exclusion once it ages out (≈2026-07-26).
- **GHSA-frvp-7c67-39w9 + GHSA-9mqv-5hh9-4cgg (moderate)**: the previously pinned `@hono/node-server@1.19.13` (our own earlier override) falls in both new ranges. Lifted to `2.0.10` — the first release patched for all three advisories on that package; the resolved `hono@4.12.27` satisfies its `^4` peer. Dev-only surface (`@prisma/dev` dev server). This also clears the Dependabot flag on the default branch.

## Test plan

- `pnpm audit` → **No known vulnerabilities found** (was: 1 high + 1 moderate)
- Full gate green locally: format / lint / typecheck / knip / test (19/19 turbo tasks, incl. the `@unthrown/prisma` suite against a real generated client — the canary for the hono major bump) / build

No changeset: overrides affect only this workspace's install, not any published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)