### PR TITLE
feat(core): add tapFailure cross-channel observer and FailureView type

### DIFF
--- a/.changeset/tap-failure-observer.md
+++ b/.changeset/tap-failure-observer.md
@@ -1,0 +1,5 @@
+---
+"unthrown": minor
+---
+
+Add `tapFailure` — the one cross-channel observer: it runs a side effect on either failure (`Err` **or** `Defect`) and passes the `Result` through unchanged, for the shared "it went KO" concern (logging, metrics, rollback) that would otherwise be duplicated across `tapErr` + `tapDefect`. The callback receives the new exported `FailureView<E, T>` type (`ErrView | DefectView` — the discriminated variant, so `E` stays typed and the callback narrows on `tag`). Available on both `Result` and `AsyncResult`; a throwing observer preserves the original failure in an `AggregateError` defect, like the other failure observers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,14 +63,16 @@ was planned).
   This is what lets an HTTP adapter do a single `match({ ok, err, defect })`
   with **no surrounding `try/catch`**.
 - **A `Defect` flows through every method untouched EXCEPT `match()`,
-  `recoverDefect()`, and `tapDefect()` (which observes it without consuming
-  it).** Therefore `getOr`, `getOrElse`, `getOrNull`, `getOrUndefined`
-  still **throw** on a `Defect` — they recover the modeled `Err`, never an
-  unmodeled defect (a defect is a bug, not an absent value).
+  `recoverDefect()`, and the observers `tapDefect()` / `tapFailure()` (which
+  observe it without consuming it).** Therefore `getOr`, `getOrElse`,
+  `getOrNull`, `getOrUndefined` still **throw** on a `Defect` — they recover
+  the modeled `Err`, never an unmodeled defect (a defect is a bug, not an
+  absent value).
 - **A failure-observer throw preserves the original failure.** A throw inside
-  `tapErr` / `tapDefect` / `flatTapErr` produces a `Defect` whose cause is an
-  `AggregateError([thrown, original])` — observing a failure never destroys it.
-  (A throw in the success-channel `tap`/`map` keeps the plain thrown cause.)
+  `tapErr` / `tapDefect` / `tapFailure` / `flatTapErr` produces a `Defect` whose
+  cause is an `AggregateError([thrown, original])` — observing a failure never
+  destroys it. (A throw in the success-channel `tap`/`map` keeps the plain
+  thrown cause.)
 - **Thenable callback returns are rejected at compile time.** Every combinator
   callback not already constrained to return a `Result` (`map`, `tap*`, `let`,
   `mapErr`, `recoverErr`) intersects its return with `NotThenable<R>` — an `async`
@@ -132,6 +134,15 @@ async work re-enters via `fromPromise` / `fromSafePromise` and composes with
   mirror of `flatTap` — runs a `Result`-returning effect on the error, keeps the
   original error, threads the effect's error)
 - defect: `recoverDefect`, `tapDefect`
+- failure (both KO channels): `tapFailure` — the one cross-channel combinator:
+  runs its observer on `Err` **or** `Defect`, passing the discriminated failure
+  variant (`FailureView<E, T>` = `ErrView | DefectView`; the variant, not a
+  payload, because `E | unknown` would collapse to `unknown` — the callback
+  narrows on `tag`). Observe-only by design: there is deliberately **no**
+  `recoverFailure` (frictionless defect recovery would erode the channel's
+  meaning — recovering stays the separate `recoverDefect`; handling both for
+  good is `match`), and no channel-moving operators (`Err`→`Defect` erases the
+  modeled type; `Defect`→`Err` would put `unknown` in `E`, violating Thesis #1)
 - eliminate: `match`, `get`/`getErr` (type-gated — `get` only compiles on
   `Result<T, never>`, `getErr` only on `Result<never, E>`; use `match` /
   `recoverErr` / `flatMapErr` to empty the opposite channel first), `getOr` (signature
@@ -161,7 +172,8 @@ async work re-enters via `fromPromise` / `fromSafePromise` and composes with
   plain `{ tag: "Ok" }` look-alike is not matched), for untyped boundaries.
 - types: `NotThenable<R>` — rejects a `PromiseLike` at the type level, so a
   combinator callback that returns one is a compile error instead of a silently
-  unqualified rejection.
+  unqualified rejection. `FailureView<E, T>` — the exported `ErrView | DefectView`
+  union a `tapFailure` callback receives (error-type-first, like `ErrView`).
 - constructors: `Ok` (a no-arg overload — `Ok()` — constructs a `void` success,
   `Result<void, never>`, sparing `Ok(undefined)`; `OkAsync()` mirrors it),
   `Err` (there is **no** `Defect` constructor — a defect-state

--- a/docs/guide/choosing-a-combinator.md
+++ b/docs/guide/choosing-a-combinator.md
@@ -26,32 +26,34 @@ The `→ Result<…>` half of each signature is the tell — it shows how the co
 moves the channels: `flatMap` widens `E` to `E | E2`, `recoverErr` empties it to
 `never`, `flatMapErr` widens the value to `T | U`.
 
-| I want to…                                     | use               | signature                                                    | channel |
-| ---------------------------------------------- | ----------------- | ------------------------------------------------------------ | ------- |
-| transform the success value                    | `map`             | `(v: T) => U` → `Result<U, E>`                               | Ok      |
-| chain a `Result`-returning step                | `flatMap`         | `(v: T) => Result<U, E2>` → `Result<U, E \| E2>`             | Ok      |
-| run a side effect, keep the value              | `tap`             | `(v: T) => void` → `Result<T, E>`                            | Ok      |
-| run a **failable** side effect, keep the value | `flatTap`         | `(v: T) => Result<unknown, E2>` → `Result<T, E \| E2>`       | Ok      |
-| sequence steps into a named scope              | `Do`/`bind`/`let` | `bind(k, (scope) => Result<U, E2>)` → `Result<{…}, E \| E2>` | Ok      |
-| replace the value with a constant              | `as`              | `(value: U)` → `Result<U, E>`                                | Ok      |
-| drop the value (success type becomes `void`)   | `discard`         | `()` → `Result<void, E>`                                     | Ok      |
-| transform the error                            | `mapErr`          | `(e: E) => E2` → `Result<T, E2>`                             | Err     |
-| try a fallback that returns a `Result`         | `flatMapErr`      | `(e: E) => Result<U, E2>` → `Result<T \| U, E2>`             | Err     |
-| turn an error into a success value             | `recoverErr`      | `(e: E) => U` → `Result<T \| U, never>`                      | Err     |
-| run a side effect on the error                 | `tapErr`          | `(e: E) => void` → `Result<T, E>`                            | Err     |
-| run a **failable** side effect on the error    | `flatTapErr`      | `(e: E) => Result<unknown, E2>` → `Result<T, E \| E2>`       | Err     |
-| recover from a defect (rare)                   | `recoverDefect`   | `(cause) => Result<U, E2>` → `Result<T \| U, E \| E2>`       | Defect  |
-| observe a defect, e.g. log it                  | `tapDefect`       | `(cause) => void` → `Result<T, E>`                           | Defect  |
-| handle all three channels at the edge          | `match`           | `{ ok, err, defect }` → `R`                                  | all     |
-| combine an array of `Result`s                  | `all`             | `Result<T, E>[]` → `Result<T[], E>`                          | —       |
-| combine a record of `Result`s                  | `allFromDict`     | `{ [k]: Result<T, E> }` → `Result<{ [k]: T }, E>`            | —       |
+| I want to…                                     | use               | signature                                                    | channel      |
+| ---------------------------------------------- | ----------------- | ------------------------------------------------------------ | ------------ |
+| transform the success value                    | `map`             | `(v: T) => U` → `Result<U, E>`                               | Ok           |
+| chain a `Result`-returning step                | `flatMap`         | `(v: T) => Result<U, E2>` → `Result<U, E \| E2>`             | Ok           |
+| run a side effect, keep the value              | `tap`             | `(v: T) => void` → `Result<T, E>`                            | Ok           |
+| run a **failable** side effect, keep the value | `flatTap`         | `(v: T) => Result<unknown, E2>` → `Result<T, E \| E2>`       | Ok           |
+| sequence steps into a named scope              | `Do`/`bind`/`let` | `bind(k, (scope) => Result<U, E2>)` → `Result<{…}, E \| E2>` | Ok           |
+| replace the value with a constant              | `as`              | `(value: U)` → `Result<U, E>`                                | Ok           |
+| drop the value (success type becomes `void`)   | `discard`         | `()` → `Result<void, E>`                                     | Ok           |
+| transform the error                            | `mapErr`          | `(e: E) => E2` → `Result<T, E2>`                             | Err          |
+| try a fallback that returns a `Result`         | `flatMapErr`      | `(e: E) => Result<U, E2>` → `Result<T \| U, E2>`             | Err          |
+| turn an error into a success value             | `recoverErr`      | `(e: E) => U` → `Result<T \| U, never>`                      | Err          |
+| run a side effect on the error                 | `tapErr`          | `(e: E) => void` → `Result<T, E>`                            | Err          |
+| run a **failable** side effect on the error    | `flatTapErr`      | `(e: E) => Result<unknown, E2>` → `Result<T, E \| E2>`       | Err          |
+| recover from a defect (rare)                   | `recoverDefect`   | `(cause) => Result<U, E2>` → `Result<T \| U, E \| E2>`       | Defect       |
+| observe a defect, e.g. log it                  | `tapDefect`       | `(cause) => void` → `Result<T, E>`                           | Defect       |
+| observe **any** failure (error _or_ defect)    | `tapFailure`      | `(f: FailureView<E>) => void` → `Result<T, E>`               | Err + Defect |
+| handle all three channels at the edge          | `match`           | `{ ok, err, defect }` → `R`                                  | all          |
+| combine an array of `Result`s                  | `all`             | `Result<T, E>[]` → `Result<T[], E>`                          | —            |
+| combine a record of `Result`s                  | `allFromDict`     | `{ [k]: Result<T, E> }` → `Result<{ [k]: T }, E>`            | —            |
 
 ## Behavior at a glance
 
 A combinator touches **only its own channel**; the other two flow through
-untouched. This grid is the whole story — notice the `Defect` column is
-"passes ▸" everywhere except `recoverDefect` and `match`, which is the one
-invariant to remember:
+untouched (`tapFailure` is the one combinator whose "own channel" spans both
+failures). This grid is the whole story — notice the `Defect` column is
+"passes ▸" everywhere except `recoverDefect`, the observers (`tapDefect` /
+`tapFailure`), and `match`, which is the one invariant to remember:
 
 | method                  | on `Ok`  | on `Err`        | on `Defect` | resulting `E`   |
 | ----------------------- | -------- | --------------- | ----------- | --------------- |
@@ -64,6 +66,7 @@ invariant to remember:
 | `tapErr` / `flatTapErr` | passes ▸ | runs `f`        | passes ▸    | `E` / `E \| E2` |
 | `recoverDefect`         | passes ▸ | passes ▸        | runs `f`    | `E \| E2`       |
 | `tapDefect`             | passes ▸ | passes ▸        | runs `f`    | `E`             |
+| `tapFailure`            | passes ▸ | runs `f`        | runs `f`    | `E`             |
 | `match`                 | `ok()`   | `err()`         | `defect()`  | —               |
 
 ::: tip `recoverErr`'s `never` under-describes the runtime
@@ -170,8 +173,17 @@ value (emptying the error channel to `never`); `flatMapErr` produces another `Re
 (which may still be an `Err`).
 
 **`recoverErr` vs `recoverDefect`** — `recoverErr` handles a modeled `Err`;
-`recoverDefect` is the **only** combinator that can touch a `Defect`. Neither is
+`recoverDefect` is the only combinator that can **consume** a `Defect`. Neither is
 the other's fallback — a defect flows past `recoverErr` untouched.
+
+**`tapErr` + `tapDefect` vs `tapFailure`** — when the _same_ effect applies to
+both failures (a shared logger, a metric, a rollback trigger), `tapFailure` runs
+it once for either. Its callback receives the discriminated **failure variant**
+(`FailureView<E>`, i.e. `ErrView | DefectView`) rather than a payload — a payload
+union `E | unknown` would collapse to `unknown` — so branch on `failure.tag` when
+you need the typed `error`, or treat it opaquely. It only _observes_: there is
+deliberately no `recoverFailure` — recovering a defect stays a separate, loud
+decision (`recoverDefect`), and handling both channels for good is `match`.
 
 ## When to leave the pipeline
 

--- a/docs/guide/the-defect-channel.md
+++ b/docs/guide/the-defect-channel.md
@@ -107,6 +107,11 @@ d.recoverDefect((cause) => (cause instanceof RangeError ? Err("out_of_range") : 
 ```
 
 Use `tapDefect` to observe a defect's cause (e.g. logging) without changing it.
+When the same observation applies to a modeled `Err` too — one logger, one
+rollback trigger for "it went KO" — `tapFailure` runs it on either failure,
+passing the discriminated variant (`ErrView | DefectView`) so you can still
+branch on `tag`. It observes without consuming; there is deliberately no
+`recoverFailure` — recovering a defect stays a separate, loud `recoverDefect`.
 
 Recovering a defect should feel awkward — usually you don't. You let it bubble
 to the edge, log it, and return a 500.

--- a/packages/core/src/async-result.spec.ts
+++ b/packages/core/src/async-result.spec.ts
@@ -83,6 +83,8 @@ describe("AsyncResult: a throw in any combinator becomes a Defect", () => {
     expect((await asyncErr("e").flatTapErr(t)).isDefect()).toBe(true);
     expect((await asyncDefect().recoverDefect(t)).isDefect()).toBe(true);
     expect((await asyncDefect().tapDefect(t)).isDefect()).toBe(true);
+    expect((await asyncErr("e").tapFailure(t)).isDefect()).toBe(true);
+    expect((await asyncDefect().tapFailure(t)).isDefect()).toBe(true);
   });
 });
 
@@ -251,6 +253,45 @@ describe("AsyncResult Defect channel", () => {
     const original = new Error("original-bug");
     const thrown = new Error("logger-failed");
     const r = await fromSafePromise(Promise.reject(original)).tapDefect(() => {
+      throw thrown;
+    });
+    expect(r.tag).toBe("Defect");
+    if (r.isDefect()) {
+      expect((r.cause as AggregateError).errors).toEqual([thrown, original]);
+    }
+  });
+});
+
+describe("AsyncResult.tapFailure (the cross-channel observer)", () => {
+  it("runs on Err and on Defect, receiving the failure variant, and passes each through", async () => {
+    const seen: unknown[] = [];
+    const observe = (f: { tag: string }) => seen.push(f.tag);
+    expect((await asyncErr("e").tapFailure(observe)).getErr()).toBe("e");
+    expect((await asyncDefect().tapFailure(observe)).isDefect()).toBe(true);
+    expect(seen).toEqual(["Err", "Defect"]);
+  });
+
+  it("does not run on Ok", async () => {
+    const f = vi.fn();
+    expect((await asyncOk(1).tapFailure(f)).get()).toBe(1);
+    expect(f).not.toHaveBeenCalled();
+  });
+
+  it("a throwing callback preserves the original error in an AggregateError", async () => {
+    const thrown = new Error("logger-failed");
+    const r = await asyncErr("original").tapFailure(() => {
+      throw thrown;
+    });
+    expect(r.tag).toBe("Defect");
+    if (r.isDefect()) {
+      expect((r.cause as AggregateError).errors).toEqual([thrown, "original"]);
+    }
+  });
+
+  it("a throwing callback preserves the original cause in an AggregateError", async () => {
+    const original = new Error("original-bug");
+    const thrown = new Error("logger-failed");
+    const r = await fromSafePromise(Promise.reject(original)).tapFailure(() => {
       throw thrown;
     });
     expect(r.tag).toBe("Defect");

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -19,6 +19,7 @@ import type {
   Bound,
   DefectView,
   ErrView,
+  FailureView,
   NotThenable,
   OkView,
   Result,
@@ -232,6 +233,19 @@ class Res<T, E> {
       return this;
     } catch (cause) {
       return observerThrowToDefect(cause, this.cause);
+    }
+  }
+
+  tapFailure<R>(
+    this: Result<T, E>,
+    f: (failure: FailureView<E, T>) => R & NotThenable<R>,
+  ): Result<T, E> {
+    if (this.tag === "Ok") return this;
+    try {
+      f(this);
+      return this;
+    } catch (cause) {
+      return observerThrowToDefect(cause, this.tag === "Err" ? this.error : this.cause);
     }
   }
 
@@ -709,6 +723,20 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
           return r;
         } catch (cause) {
           return observerThrowToDefect<T, E>(cause, r.cause);
+        }
+      }),
+    );
+  }
+
+  tapFailure<R>(f: (failure: FailureView<E, T>) => R & NotThenable<R>): AsyncResult<T, E> {
+    return new AsyncRes<T, E>(
+      this.promise.then((r) => {
+        if (r.tag === "Ok") return r;
+        try {
+          f(r);
+          return r;
+        } catch (cause) {
+          return observerThrowToDefect<T, E>(cause, r.tag === "Err" ? r.error : r.cause);
         }
       }),
     );

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,6 +24,7 @@ export type {
   DefectView,
   ErrOf,
   ErrView,
+  FailureView,
   NotThenable,
   OkOf,
   OkView,

--- a/packages/core/src/invariants.spec.ts
+++ b/packages/core/src/invariants.spec.ts
@@ -31,6 +31,8 @@ describe("Invariant 1: throw inside any combinator becomes a Defect", () => {
     expect(Err("e").flatTapErr(t).isDefect()).toBe(true);
     expect(defectOf(boom).recoverDefect(t).isDefect()).toBe(true);
     expect(defectOf(boom).tapDefect(t).isDefect()).toBe(true);
+    expect(Err("e").tapFailure(t).isDefect()).toBe(true);
+    expect(defectOf(boom).tapFailure(t).isDefect()).toBe(true);
   });
 });
 
@@ -64,13 +66,20 @@ describe("Invariant 2: a Defect flows through every method except match() and re
     expect(() => d.getOrUndefined()).toThrow();
   });
 
-  it("only match() and recoverDefect() observe the Defect", () => {
+  it("only match(), recoverDefect(), and the defect observers see the Defect", () => {
     expect(defectOf(boom).match({ ok: () => "o", err: () => "e", defect: () => "d" })).toBe("d");
     expect(
       defectOf(boom)
         .recoverDefect(() => Ok("handled"))
         .get(),
     ).toBe("handled");
+    // tapDefect / tapFailure observe WITHOUT consuming — the Defect flows on.
+    const observed: string[] = [];
+    const d = defectOf(boom)
+      .tapDefect(() => observed.push("tapDefect"))
+      .tapFailure((f) => observed.push(f.tag));
+    expect(observed).toEqual(["tapDefect", "Defect"]);
+    expect(d.isDefect()).toBe(true);
   });
 });
 

--- a/packages/core/src/result.spec.ts
+++ b/packages/core/src/result.spec.ts
@@ -399,6 +399,39 @@ describe("Result.tapDefect", () => {
   });
 });
 
+describe("Result.tapFailure (the cross-channel observer)", () => {
+  it("runs on Err, receiving the Err variant, and passes the error through", () => {
+    const seen: string[] = [];
+    const r = Err("e").tapFailure((f) => {
+      if (f.tag === "Err") seen.push(f.error);
+    });
+    expect(seen).toEqual(["e"]);
+    expect(r.getErr()).toBe("e");
+  });
+
+  it("runs on a Defect, receiving the Defect variant, and passes it through", () => {
+    const seen: unknown[] = [];
+    const r = defectOf(boom).tapFailure((f) => {
+      if (f.tag === "Defect") seen.push(f.cause);
+    });
+    expect(seen).toEqual([boom]);
+    expect(r.isDefect()).toBe(true);
+  });
+
+  it("does not run on Ok", () => {
+    const f = vi.fn();
+    expect(Ok(1).tapFailure(f).get()).toBe(1);
+    expect(f).not.toHaveBeenCalled();
+  });
+
+  it("observes without consuming: the failure is the same frozen instance", () => {
+    const err = Err("e");
+    expect(err.tapFailure(() => "ignored")).toBe(err);
+    const defect = defectOf(boom);
+    expect(defect.tapFailure(() => "ignored")).toBe(defect);
+  });
+});
+
 describe("failure-observer throws preserve the original failure", () => {
   it("tapErr: a throwing callback yields a Defect aggregating [thrown, original]", () => {
     const boom = new Error("boom");
@@ -433,6 +466,29 @@ describe("failure-observer throws preserve the original failure", () => {
     expect(r.tag).toBe("Defect");
     if (r.isDefect()) {
       expect((r.cause as AggregateError).errors).toEqual([boom, "original"]);
+    }
+  });
+
+  it("tapFailure on Err: a throwing callback yields a Defect aggregating [thrown, original error]", () => {
+    const boom = new Error("boom");
+    const r = Err("original").tapFailure(() => {
+      throw boom;
+    });
+    expect(r.tag).toBe("Defect");
+    if (r.isDefect()) {
+      expect((r.cause as AggregateError).errors).toEqual([boom, "original"]);
+    }
+  });
+
+  it("tapFailure on a Defect: a throwing callback yields a Defect aggregating [thrown, original cause]", () => {
+    const original = new Error("original-bug");
+    const boom = new Error("logger-failed");
+    const r = defectOf(original).tapFailure(() => {
+      throw boom;
+    });
+    expect(r.tag).toBe("Defect");
+    if (r.isDefect()) {
+      expect((r.cause as AggregateError).errors).toEqual([boom, original]);
     }
   });
 

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -19,6 +19,7 @@ import {
   Err,
   ErrAsync,
   type ErrView,
+  type FailureView,
   fromPromise,
   fromSafeThrowable,
   fromThrowable,
@@ -338,6 +339,8 @@ new WithMsg({ ticketId: "t1" });
   r.tapErr(async () => {});
   // @ts-expect-error — async tapDefect callback is banned
   r.tapDefect(async () => {});
+  // @ts-expect-error — async tapFailure callback is banned
+  r.tapFailure(async () => {});
   // @ts-expect-error — async let callback is banned
   Ok({}).let("x", async () => 1);
 
@@ -353,6 +356,8 @@ new WithMsg({ ticketId: "t1" });
   ar.tapErr(async () => {});
   // @ts-expect-error — async tapDefect callback is banned (async surface)
   ar.tapDefect(async () => {});
+  // @ts-expect-error — async tapFailure callback is banned (async surface)
+  ar.tapFailure(async () => {});
   const emptyAsync = Ok({}).toAsync();
   // @ts-expect-error — async let callback is banned (async surface)
   emptyAsync.let("x", async () => 1);
@@ -369,6 +374,27 @@ new WithMsg({ ticketId: "t1" });
     err: async (e) => e.length,
     defect: async () => 0,
   });
+}
+
+// --- tapFailure: the callback receives the discriminated failure variant ----
+// (a payload union `E | unknown` would collapse to `unknown`; the variant keeps
+// `E` reachable by narrowing on `tag`)
+
+{
+  const r = Ok(1) as Result<number, "e">;
+  r.tapFailure((f) => {
+    type _IsFailureView = Expect<Equal<typeof f, FailureView<"e", number>>>;
+    if (f.tag === "Err") {
+      type _ErrPayloadTyped = Expect<Equal<typeof f.error, "e">>;
+    } else {
+      type _DefectPayload = Expect<Equal<typeof f.cause, unknown>>;
+    }
+  });
+  const kept = r.tapFailure(() => {});
+  type _TapFailureKeeps = Expect<Equal<typeof kept, Result<number, "e">>>;
+
+  const keptAsync = r.toAsync().tapFailure(() => {});
+  type _TapFailureKeepsAsync = Expect<Equal<typeof keptAsync, AsyncResult<number, "e">>>;
 }
 
 // --- getOr widens: the fallback may be a different type ----

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -296,6 +296,32 @@ export type ResultMethods<T, E> = {
   tapDefect<R>(f: (cause: unknown) => R & NotThenable<R>): Result<T, E>;
 
   /**
+   * Run a side effect on **any failure** — `Err` or `Defect` — and pass the
+   * `Result` through unchanged. The one cross-channel observer, for the shared
+   * "it went KO" concern (logging, metrics, rollback) that would otherwise be
+   * duplicated across {@link ResultMethods.tapErr | tapErr} and
+   * {@link ResultMethods.tapDefect | tapDefect}.
+   *
+   * @remarks
+   * `f` receives the narrowed **failure variant** ({@link FailureView}), not a
+   * payload — the payload union `E | unknown` would collapse to `unknown` and
+   * lose `E`'s typing. Branch on `failure.tag` to reach the typed payload
+   * (`"Err"` → `failure.error: E`, `"Defect"` → `failure.cause: unknown`), or
+   * treat it opaquely for a shared logger. Runs on `Err` and `Defect`; `Ok`
+   * passes through. It **observes without consuming**: the failure flows on
+   * unchanged — to also recover, use
+   * {@link ResultMethods.recoverErr | recoverErr} /
+   * {@link ResultMethods.recoverDefect | recoverDefect} (deliberately separate
+   * acts) or {@link ResultMethods.match | match} at the edge. If `f` throws, the
+   * result is a `Defect` whose cause is an `AggregateError` of `[thrown,
+   * original failure]` — observing a failure never destroys it. An async
+   * callback is rejected at compile time ({@link NotThenable}).
+   *
+   * @param f - the side effect over the failure variant (its return value is ignored).
+   */
+  tapFailure<R>(f: (failure: FailureView<E, T>) => R & NotThenable<R>): Result<T, E>;
+
+  /**
    * Exhaustively fold all three runtime states into a single value of type `R`.
    *
    * @remarks
@@ -497,6 +523,31 @@ export type DefectView<T = never, E = never> = ResultMethods<T, E> & {
 };
 
 /**
+ * A failure variant of a {@link Result}: an {@link ErrView} **or** a
+ * {@link DefectView}. This is what a `tapFailure` callback receives — the
+ * discriminated variant rather than a payload, because the payload union
+ * `E | unknown` would collapse to `unknown` and lose `E`'s typing. Branch on
+ * `tag` to narrow (`"Err"` → `.error: E`, `"Defect"` → `.cause: unknown`).
+ *
+ * @remarks
+ * Like {@link ErrView}, the error type comes **first** (`FailureView<E, T>`) —
+ * the error is the payload you are usually here for, and a shared observer can
+ * spell just `FailureView<MyError>`.
+ *
+ * @example
+ * ```ts
+ * const logKo = (f: FailureView<ApiError>) =>
+ *   f.tag === "Err" ? logger.warn(f.error) : logger.error(f.cause);
+ * result.tapFailure(logKo);
+ * ```
+ *
+ * @typeParam E - the modeled error type.
+ * @typeParam T - the success value type (phantom here; a failure carries none).
+ * @category Types
+ */
+export type FailureView<E, T = never> = ErrView<E, T> | DefectView<T, E>;
+
+/**
  * The core type of the library: a computation that has either succeeded with a
  * value of type `T` or failed with a *modeled* error of type `E`.
  *
@@ -696,6 +747,16 @@ export type AsyncResultMethods<T, E> = {
    * callback is rejected at compile time ({@link NotThenable}).
    */
   tapDefect<R>(f: (cause: unknown) => R & NotThenable<R>): AsyncResult<T, E>;
+
+  /**
+   * Asynchronous {@link ResultMethods.tapFailure | tapFailure} — the
+   * cross-channel observer. `f` receives the narrowed failure variant
+   * ({@link FailureView}); if it throws, the result is a `Defect` whose cause
+   * is an `AggregateError` of `[thrown, original failure]` — observing a
+   * failure never destroys it. An async callback is rejected at compile time
+   * ({@link NotThenable}).
+   */
+  tapFailure<R>(f: (failure: FailureView<E, T>) => R & NotThenable<R>): AsyncResult<T, E>;
 
   /**
    * Asynchronous {@link ResultMethods.match | match}. Handlers are synchronous;


### PR DESCRIPTION
## Summary

Adds **`tapFailure`** — the one cross-channel observer — to both `Result` and `AsyncResult`, plus the exported **`FailureView<E, T>`** type its callback receives.

The motivating pattern: a shared "it went KO" concern (logging, metrics, a rollback trigger) that applies to a modeled `Err` *and* a `Defect` previously had to be duplicated as `.tapErr(f).tapDefect(f)`. Channel-moving was rejected as an alternative in both directions (`Err`→`Defect` erases the modeled type; `Defect`→`Err` would put `unknown` in `E`, violating Thesis #1).

## Design

- The callback receives the **discriminated failure variant** (`FailureView<E, T>` = `ErrView<E, T> | DefectView<T, E>`), not a payload — the payload union `E | unknown` would collapse to `unknown`. Branch on `failure.tag` to reach the typed `error`, or treat it opaquely for a shared logger.
- **Observe-only by design.** There is deliberately no `recoverFailure` — frictionless dual recovery would erode the defect channel's meaning. Recovery stays the separate, loud `recoverDefect`; handling both channels for good is `match`.
- Follows the failure-observer invariant: a throwing callback yields a `Defect` wrapping `AggregateError([thrown, original error/cause])` — observing a failure never destroys it.
- `Ok` passes through untouched (same frozen instance); async callbacks are rejected at compile time via `NotThenable`.

```ts
const logKo = (f: FailureView<ApiError>) =>
  f.tag === "Err" ? logger.warn(f.error) : logger.error(f.cause);

result.tapFailure(logKo); // previously: .tapErr(logKo).tapDefect(logKo)
```

## Changes

- `packages/core/src/types.ts` — `FailureView<E, T>` (error-type-first, like `ErrView`) + `tapFailure` on `ResultMethods` and `AsyncResultMethods`, fully TSDoc'd
- `packages/core/src/core.ts` — implementations on `Res` and `AsyncRes`
- `packages/core/src/index.ts` — export `FailureView`
- Tests: three-channel behavior, identity pass-through, both `AggregateError` branches (sync + async), invariant-list extensions in `invariants.spec.ts`, and type-level assertions (variant type, tag-narrowing, unchanged channels, `NotThenable` ban)
- Docs: `choosing-a-combinator.md` (tables + a new confusion-pair entry), `the-defect-channel.md`, CLAUDE.md spec (invariants + new "failure" surface bullet)
- Changeset: minor for `unthrown`

## Verification

Full gate green: `format --check`, `lint`, `typecheck` (incl. `types.test-d.ts`), `knip`, `test` (all 19 tasks), `build`, and `build:docs` (TypeDoc warning-free). Core coverage stays at 100% lines/functions.