### PR TITLE
chore(oxfmt): enable import sorting via correct sortImports key

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -6,8 +6,5 @@
     "docs/.vitepress/cache/**",
     "docs/.vitepress/dist/**"
   ],
-  "organizeImports": {
-    "sortImports": true,
-    "separateGroups": true
-  }
+  "sortImports": true
 }

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,4 +1,5 @@
 import Theme from "@btravstack/theme";
+
 import "./custom.css";
 
 export default Theme;

--- a/docs/scripts/copy-docs.ts
+++ b/docs/scripts/copy-docs.ts
@@ -18,7 +18,6 @@ import "@unthrown/prisma";
 // runtime. The `packages` list below still uses the bare package name: the
 // copy reads `node_modules/@unthrown/orpc/docs` directly, not an export.
 import "@unthrown/orpc/client";
-
 import { cp, mkdir, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/core/src/interop.ts
+++ b/packages/core/src/interop.ts
@@ -2,9 +2,9 @@
 // through `qualify`, which triages each cause into a modeled `E` or a `Defect`;
 // there is no path that yields `unknown` in `E`.
 
+import { Err, Ok } from "./constructors.js";
 import { AsyncRes, defectRes, errRes, okRes } from "./core.js";
 import { type Defect, defect, isDefectMarker } from "./defect.js";
-import { Err, Ok } from "./constructors.js";
 import type { AsyncErrOf, AsyncOkOf, AsyncResult, ErrOf, OkOf, Result } from "./types.js";
 
 /**

--- a/packages/oxlint/src/index.ts
+++ b/packages/oxlint/src/index.ts
@@ -9,13 +9,12 @@
 // package README.
 
 import { eslintCompatPlugin } from "@oxlint/plugins";
+import type { Plugin } from "@oxlint/plugins";
 import { defineConfig } from "oxlint";
+import type { OxlintConfig } from "oxlint";
 
 import { noAmbiguousErrorType } from "./rules/no-ambiguous-error-type.js";
 import { preferAsyncResult } from "./rules/prefer-async-result.js";
-
-import type { Plugin } from "@oxlint/plugins";
-import type { OxlintConfig } from "oxlint";
 
 type UnthrownPlugin = Plugin & { recommended: OxlintConfig };
 

--- a/packages/oxlint/src/rules/no-ambiguous-error-type.ts
+++ b/packages/oxlint/src/rules/no-ambiguous-error-type.ts
@@ -1,11 +1,10 @@
 import { defineRule } from "@oxlint/plugins";
+import type { ESTree, Scope } from "@oxlint/plugins";
 
 import { getImportSource } from "../helpers/get-import-source.js";
 import { hasTypeArguments } from "../helpers/has-type-arguments.js";
 import { isIdentifierTypeName } from "../helpers/is-identifier-type-name.js";
 import { isLocallyBound } from "../helpers/is-locally-bound.js";
-
-import type { ESTree, Scope } from "@oxlint/plugins";
 
 const MODULE = "unthrown";
 const RESULT_TYPES = ["Result", "AsyncResult"] as const;


### PR DESCRIPTION
## What

`.oxfmtrc.json` used `organizeImports { sortImports, separateGroups }` — a key that oxfmt 0.58's configuration schema **no longer recognizes**. oxfmt silently ignored it, so import sorting was effectively **off** (and `pnpm format` still passed, masking it).

This replaces it with the valid top-level key:

```diff
-  "organizeImports": {
-    "sortImports": true,
-    "separateGroups": true
-  }
+  "sortImports": true
```

## Effect

Enabling it (via `pnpm format`) reordered imports in 5 files — **pure import ordering, no behavior or API change**:

- `packages/core/src/interop.ts`
- `packages/oxlint/src/index.ts`
- `packages/oxlint/src/rules/no-ambiguous-error-type.ts`
- `docs/.vitepress/theme/index.ts`
- `docs/scripts/copy-docs.ts`

`type` imports are merged beside their same-module value imports; side-effect imports keep their relative order.

## Verification

`pnpm format --check`, `pnpm lint`, and `pnpm typecheck` (19/19) all pass.

Found while building the shared `@btravstack/oxfmt` config, which uses the correct `sortImports` key.