### PR TITLE
chore: consume @btravstack shared config packages

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,8 +1,5 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "ignorePatterns": ["**/*.test-d.ts", "**/generated/**"],
-  "rules": {
-    "@typescript-eslint/no-explicit-any": "error",
-    "typescript/consistent-type-definitions": ["error", "type"]
-  }
+  "extends": ["./node_modules/@btravstack/oxlint/base.json"],
+  "ignorePatterns": ["**/*.test-d.ts", "**/generated/**"]
 }

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,1 @@
-export default { extends: ["@commitlint/config-conventional"] };
+export default { extends: ["@btravstack/commitlint"] };

--- a/knip.json
+++ b/knip.json
@@ -14,5 +14,10 @@
       "project": ["scripts/**/*.ts"]
     }
   },
-  "ignoreDependencies": ["typedoc-plugin-markdown", "@unthrown/typedoc"]
+  "ignoreDependencies": [
+    "typedoc-plugin-markdown",
+    "@unthrown/typedoc",
+    "@btravstack/typedoc",
+    "@btravstack/oxlint"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
     "version": "changeset version"
   },
   "devDependencies": {
+    "@btravstack/commitlint": "catalog:",
+    "@btravstack/oxlint": "catalog:",
     "@changesets/cli": "catalog:",
     "@commitlint/cli": "catalog:",
-    "@commitlint/config-conventional": "catalog:",
     "knip": "catalog:",
     "lefthook": "catalog:",
     "oxfmt": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,18 +9,27 @@ catalogs:
     '@bloodyowl/boxed':
       specifier: 3.4.0
       version: 3.4.0
+    '@btravstack/commitlint':
+      specifier: 0.1.0
+      version: 0.1.0
+    '@btravstack/oxlint':
+      specifier: 0.1.0
+      version: 0.1.0
     '@btravstack/theme':
       specifier: 1.7.0
       version: 1.7.0
+    '@btravstack/tsconfig':
+      specifier: 0.1.0
+      version: 0.1.0
+    '@btravstack/typedoc':
+      specifier: 0.1.0
+      version: 0.1.0
     '@changesets/cli':
       specifier: 2.31.0
       version: 2.31.0
     '@commitlint/cli':
       specifier: 21.2.1
       version: 21.2.1
-    '@commitlint/config-conventional':
-      specifier: 21.2.0
-      version: 21.2.0
     '@orpc/client':
       specifier: 2.0.0-beta.15
       version: 2.0.0-beta.15
@@ -108,15 +117,18 @@ importers:
 
   .:
     devDependencies:
+      '@btravstack/commitlint':
+        specifier: 'catalog:'
+        version: 0.1.0(@commitlint/cli@21.2.1(@types/node@26.1.1)(conventional-commits-parser@7.1.0)(typescript@6.0.3))
+      '@btravstack/oxlint':
+        specifier: 'catalog:'
+        version: 0.1.0(oxlint@1.73.0)
       '@changesets/cli':
         specifier: 'catalog:'
         version: 2.31.0(@types/node@26.1.1)
       '@commitlint/cli':
         specifier: 'catalog:'
         version: 21.2.1(@types/node@26.1.1)(conventional-commits-parser@7.1.0)(typescript@6.0.3)
-      '@commitlint/config-conventional':
-        specifier: 'catalog:'
-        version: 21.2.0
       knip:
         specifier: 'catalog:'
         version: 6.26.0
@@ -547,9 +559,20 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
-  tools/tsconfig: {}
+  tools/tsconfig:
+    dependencies:
+      '@btravstack/tsconfig':
+        specifier: 'catalog:'
+        version: 0.1.0
 
-  tools/typedoc: {}
+  tools/typedoc:
+    dependencies:
+      '@btravstack/typedoc':
+        specifier: 'catalog:'
+        version: 0.1.0(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))(typedoc@0.28.20(typescript@6.0.3))
+      typedoc-plugin-markdown:
+        specifier: 'catalog:'
+        version: 4.12.0(typedoc@0.28.20(typescript@6.0.3))
 
 packages:
 
@@ -666,6 +689,18 @@ packages:
       typescript:
         optional: true
 
+  '@btravstack/commitlint@0.1.0':
+    resolution: {integrity: sha512-fFSIJJd35VQsToBooQ6vtXmJdkCERDL9eNAyya5r98DgzEPybfuzpmN32WdDkB8TaQ8lpVuiBQ7Qf+4z6FlkRw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@commitlint/cli': '>=21'
+
+  '@btravstack/oxlint@0.1.0':
+    resolution: {integrity: sha512-/UIfVydE3nEExRqE03vUoAAQSdPqVNOzZl0QSa9ikXftezoLQfNgJcFCKW6+D2cJnM180JR0o0W7dmkQHhLogQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      oxlint: '>=1'
+
   '@btravstack/theme@1.7.0':
     resolution: {integrity: sha512-EcBvQruZdsiL/zuNsu7Y1r2FeMDv0J5LZJx7ikO6cFvNRzKCc63A7582gVmfJNQlGJIg0cUCjQXB4Tm1YHtyug==}
     peerDependencies:
@@ -674,6 +709,17 @@ packages:
     peerDependenciesMeta:
       vue:
         optional: true
+
+  '@btravstack/tsconfig@0.1.0':
+    resolution: {integrity: sha512-xRkISG6jY5vLpaDJCptyOjvmUeyH6M/i6shhoE6WFGBc+JToc/dyO/511Zi6NPYVTHamNbxOG/e6dpclBWIz2A==}
+    engines: {node: '>=20'}
+
+  '@btravstack/typedoc@0.1.0':
+    resolution: {integrity: sha512-cAhj15iqJwPQ+Z+I/Kc1Bafu9HqfS2D/uaU7czPecaCgZpH5F8LUfNRmTZppkvnTMpDX0La+UrdIUyNHHLqtIg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      typedoc: '>=0.28'
+      typedoc-plugin-markdown: '>=4'
 
   '@changesets/apply-release-plan@7.1.1':
     resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
@@ -810,10 +856,6 @@ packages:
         optional: true
       conventional-commits-parser:
         optional: true
-
-  '@conventional-changelog/template@1.2.0':
-    resolution: {integrity: sha512-12qHxvlKjHmP0PQ+17EREgC7lWyLwbph1RKcZQZ7k7ZWGmrxfxC9gadHGfvzr0g0u8BhiBGg3tks93txodlyRQ==}
-    engines: {node: '>=22'}
 
   '@conventional-changelog/template@1.2.1':
     resolution: {integrity: sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==}
@@ -4148,11 +4190,27 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  '@btravstack/commitlint@0.1.0(@commitlint/cli@21.2.1(@types/node@26.1.1)(conventional-commits-parser@7.1.0)(typescript@6.0.3))':
+    dependencies:
+      '@commitlint/cli': 21.2.1(@types/node@26.1.1)(conventional-commits-parser@7.1.0)(typescript@6.0.3)
+      '@commitlint/config-conventional': 21.2.0
+
+  '@btravstack/oxlint@0.1.0(oxlint@1.73.0)':
+    dependencies:
+      oxlint: 1.73.0
+
   '@btravstack/theme@1.7.0(vitepress@1.6.4(@algolia/client-search@5.55.1)(@types/node@26.1.1)(jiti@2.7.0)(postcss@8.5.18)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))':
     dependencies:
       vitepress: 1.6.4(@algolia/client-search@5.55.1)(@types/node@26.1.1)(jiti@2.7.0)(postcss@8.5.18)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
     optionalDependencies:
       vue: 3.5.38(typescript@6.0.3)
+
+  '@btravstack/tsconfig@0.1.0': {}
+
+  '@btravstack/typedoc@0.1.0(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))(typedoc@0.28.20(typescript@6.0.3))':
+    dependencies:
+      typedoc: 0.28.20(typescript@6.0.3)
+      typedoc-plugin-markdown: 4.12.0(typedoc@0.28.20(typescript@6.0.3))
 
   '@changesets/apply-release-plan@7.1.1':
     dependencies:
@@ -4413,8 +4471,6 @@ snapshots:
       semver: 7.8.5
     optionalDependencies:
       conventional-commits-parser: 7.1.0
-
-  '@conventional-changelog/template@1.2.0': {}
 
   '@conventional-changelog/template@1.2.1': {}
 
@@ -5773,7 +5829,7 @@ snapshots:
 
   conventional-changelog-conventionalcommits@10.2.0:
     dependencies:
-      '@conventional-changelog/template': 1.2.0
+      '@conventional-changelog/template': 1.2.1
 
   conventional-commits-parser@7.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,10 +11,13 @@ packages:
 
 catalog:
   "@bloodyowl/boxed": 3.4.0
+  "@btravstack/commitlint": 0.1.0
+  "@btravstack/oxlint": 0.1.0
   "@btravstack/theme": 1.7.0
+  "@btravstack/tsconfig": 0.1.0
+  "@btravstack/typedoc": 0.1.0
   "@changesets/cli": 2.31.0
   "@commitlint/cli": 21.2.1
-  "@commitlint/config-conventional": 21.2.0
   "@orpc/client": 2.0.0-beta.15
   "@orpc/contract": 2.0.0-beta.15
   "@orpc/server": 2.0.0-beta.15
@@ -98,7 +101,12 @@ allowBuilds:
 minimumReleaseAge: 10080
 minimumReleaseAgeStrict: true
 minimumReleaseAgeExclude:
+  # First-party shared config (@btravstack scope): adopt immediately, skip the delay.
+  - "@btravstack/commitlint"
+  - "@btravstack/oxlint"
   - "@btravstack/theme"
+  - "@btravstack/tsconfig"
+  - "@btravstack/typedoc"
   # Temporary security-patch exception: fast-uri 3.1.4 (the GHSA-v2hh-gcrm-f6hx
   # fix forced by the override above) is younger than the cutoff. Remove this
   # entry once 3.1.4 is 7 days old (published 2026-07-19).

--- a/tools/tsconfig/base.json
+++ b/tools/tsconfig/base.json
@@ -1,34 +1,4 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-
-    "target": "ES2022",
-    "lib": ["ES2023"],
-    "types": ["node"],
-
-    "resolveJsonModule": true,
-    "allowJs": true,
-    "checkJs": false,
-    "noEmit": true,
-    "declaration": true,
-    "declarationMap": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "isolatedModules": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "allowUnusedLabels": false,
-    "allowUnreachableCode": false,
-    "exactOptionalPropertyTypes": true,
-    "noImplicitOverride": true,
-    "noImplicitReturns": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true
-  },
-  "exclude": ["node_modules", "dist"]
+  "extends": "@btravstack/tsconfig/base.json"
 }

--- a/tools/tsconfig/package.json
+++ b/tools/tsconfig/package.json
@@ -11,5 +11,8 @@
   "type": "module",
   "exports": {
     "./base.json": "./base.json"
+  },
+  "dependencies": {
+    "@btravstack/tsconfig": "catalog:"
   }
 }

--- a/tools/typedoc/base.json
+++ b/tools/typedoc/base.json
@@ -1,21 +1,4 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "plugin": ["typedoc-plugin-markdown"],
-  "outputFileStrategy": "modules",
-  "flattenOutputFiles": true,
-  "entryFileName": "index.md",
-  "hideGenerator": true,
-  "excludePrivate": true,
-  "excludeProtected": true,
-  "excludeInternal": true,
-  "readme": "none",
-  "githubPages": false,
-  "useCodeBlocks": true,
-  "useHTMLEncodedBrackets": true,
-  "sanitizeComments": true,
-  "parametersFormat": "table",
-  "propertiesFormat": "table",
-  "enumMembersFormat": "table",
-  "typeDeclarationFormat": "table",
-  "skipErrorChecking": true
+  "extends": "@btravstack/typedoc/base.json"
 }

--- a/tools/typedoc/package.json
+++ b/tools/typedoc/package.json
@@ -11,5 +11,9 @@
   "type": "module",
   "exports": {
     "./base.json": "./base.json"
+  },
+  "dependencies": {
+    "@btravstack/typedoc": "catalog:",
+    "typedoc-plugin-markdown": "catalog:"
   }
 }


### PR DESCRIPTION
Migrates unthrown to consume the published `@btravstack/*` shared config packages (resolves btravstack/amqp-contract#555 for this repo). This is the **reference migration** for the pattern that will be replicated across the other btravstack repos.

## What migrated (all verified)

| Aspect | Before | After |
|---|---|---|
| **tsconfig** | `tools/tsconfig/base.json` duplicated the full strict config | thin `extends: "@btravstack/tsconfig/base.json"` (consumer packages still extend `@unthrown/tsconfig` — local override seam kept per #555) |
| **typedoc** | `tools/typedoc/base.json` duplicated the full config | thin `extends: "@btravstack/typedoc/base.json"` |
| **oxlint** | inline `rules` | `extends: ["./node_modules/@btravstack/oxlint/base.json"]` (repo-specific `ignorePatterns` stay local) |
| **commitlint** | `extends: ["@commitlint/config-conventional"]` | `extends: ["@btravstack/commitlint"]` (drops the direct `@commitlint/config-conventional` devDep — now transitive) |

Plus: catalog entries + `minimumReleaseAgeExclude` for the first-party `@btravstack` scope, and `knip.json` ignores for the two config-file-consumed deps (`@btravstack/typedoc`, `@btravstack/oxlint`) that static analysis can't see.

## Deliberately NOT migrated

- **oxfmt** — oxfmt has no `extends`; the shared config can only be a copy-template. (unthrown's `.oxfmtrc.json` is separately fixed in the `sortImports` PR.)
- **lefthook** — lefthook's `extends` makes the *shared* file override the *local* one for overlapping keys, so a repo can't layer its own `format.exclude` on top of the base. The shared `@btravstack/lefthook` needs a redesign (drop excludes from the base so repos supply their own) + republish before it's usable here. Tracked as follow-up.

## Verification

`pnpm install` (supply-chain policy passes via the exclude), then **build, typecheck, lint, format --check, knip, test (19/19), and `build:docs`** all green. The docs build confirms typedoc resolves the markdown plugin through the `@unthrown/typedoc → @btravstack/typedoc` extends chain.