### PR TITLE
chore: adopt @btravstack config 0.2.x

### DIFF
--- a/.changeset/adopt-btravstack-0.2.md
+++ b/.changeset/adopt-btravstack-0.2.md
@@ -1,0 +1,7 @@
+---
+"unthrown": patch
+"@unthrown/prisma": patch
+"@unthrown/orpc": patch
+---
+
+Adopt @btravstack/tsconfig@0.2.0 (verbatimModuleSyntax), @btravstack/oxlint@0.2.1 (consistent-type-imports), and @btravstack/lefthook.

--- a/knip.json
+++ b/knip.json
@@ -17,6 +17,7 @@
   "ignoreDependencies": [
     "typedoc-plugin-markdown",
     "@btravstack/typedoc",
-    "@btravstack/oxlint"
+    "@btravstack/oxlint",
+    "@btravstack/lefthook"
   ]
 }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,33 +1,15 @@
+# Shared hooks come from @btravstack/lefthook (format + lint + commit-msg).
+extends:
+  - node_modules/@btravstack/lefthook/lefthook.yml
+
 pre-commit:
-  parallel: true
   commands:
     format:
-      # `*.x` (not `**/*.x`): lefthook's `*` spans `/`, so this matches files at
-      # ANY depth including the repo root. `**/*.x` requires a leading directory,
-      # so root files (`CLAUDE.md`, `README.md`, root `*.json`) silently never
-      # matched and were never formatted on commit.
-      glob: "*.{ts,tsx,js,jsx,json,yaml,yml,md}"
-      # Mirror oxfmt's `ignorePatterns` (generated docs/api + vitepress output):
-      # handing oxfmt ONLY ignored files makes it exit non-zero, which would fail
-      # a commit touching only those. Excluding them here skips the step instead.
       exclude:
         - "pnpm-lock.yaml"
         - "docs/api/*"
         - "docs/.vitepress/cache/*"
         - "docs/.vitepress/dist/*"
-      run: pnpm oxfmt {staged_files}
-      stage_fixed: true
     lint:
-      glob: "*.{ts,tsx,js,jsx}"
-      # Mirror oxlint's `ignorePatterns` (type-only test files): handing oxlint
-      # ONLY ignored files makes it exit non-zero ("No files found to lint"),
-      # which would fail a commit touching only those. Exclude them here so the
-      # step is skipped instead.
       exclude:
         - "*.test-d.ts"
-      run: pnpm oxlint {staged_files}
-
-commit-msg:
-  commands:
-    commitlint:
-      run: pnpm exec commitlint --edit {1}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@btravstack/commitlint": "catalog:",
+    "@btravstack/lefthook": "catalog:",
     "@btravstack/oxlint": "catalog:",
     "@changesets/cli": "catalog:",
     "@commitlint/cli": "catalog:",

--- a/packages/boxed/tsconfig.json
+++ b/packages/boxed/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "@btravstack/tsconfig/base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    // @btravstack/tsconfig@0.2.0 dropped `types: ["node"]` from the base;
+    // re-declare it here for the Node globals used in source/tests.
+    "types": ["node"]
   },
   "include": ["src/**/*"]
 }

--- a/packages/orpc/tsconfig.json
+++ b/packages/orpc/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "@btravstack/tsconfig/base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    // @btravstack/tsconfig@0.2.0 dropped `types: ["node"]` from the base;
+    // re-declare it here for the Node globals used in source/tests.
+    "types": ["node"]
   },
   "include": ["src/**/*"]
 }

--- a/packages/prisma/tsconfig.json
+++ b/packages/prisma/tsconfig.json
@@ -6,7 +6,10 @@
     // The generated test client (src/generated, gitignored) imports its own
     // files with explicit `.ts` extensions; `noEmit` in the base config makes
     // this legal.
-    "allowImportingTsExtensions": true
+    "allowImportingTsExtensions": true,
+    // @btravstack/tsconfig@0.2.0 dropped `types: ["node"]` from the base;
+    // re-declare it here for the Node globals used in source/tests.
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "src/generated"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,15 +12,18 @@ catalogs:
     '@btravstack/commitlint':
       specifier: 0.1.0
       version: 0.1.0
+    '@btravstack/lefthook':
+      specifier: 0.1.1
+      version: 0.1.1
     '@btravstack/oxlint':
-      specifier: 0.1.0
-      version: 0.1.0
+      specifier: 0.2.1
+      version: 0.2.1
     '@btravstack/theme':
       specifier: 1.7.0
       version: 1.7.0
     '@btravstack/tsconfig':
-      specifier: 0.1.0
-      version: 0.1.0
+      specifier: 0.2.0
+      version: 0.2.0
     '@btravstack/typedoc':
       specifier: 0.1.0
       version: 0.1.0
@@ -120,9 +123,12 @@ importers:
       '@btravstack/commitlint':
         specifier: 'catalog:'
         version: 0.1.0(@commitlint/cli@21.2.1(@types/node@26.1.1)(conventional-commits-parser@7.1.0)(typescript@6.0.3))
+      '@btravstack/lefthook':
+        specifier: 'catalog:'
+        version: 0.1.1(lefthook@2.1.10)
       '@btravstack/oxlint':
         specifier: 'catalog:'
-        version: 0.1.0(oxlint@1.73.0)
+        version: 0.2.1(oxlint@1.73.0)
       '@changesets/cli':
         specifier: 'catalog:'
         version: 2.31.0(@types/node@26.1.1)
@@ -199,7 +205,7 @@ importers:
         version: 3.4.0(typescript@6.0.3)
       '@btravstack/tsconfig':
         specifier: 'catalog:'
-        version: 0.1.0
+        version: 0.2.0
       '@btravstack/typedoc':
         specifier: 'catalog:'
         version: 0.1.0(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))(typedoc@0.28.20(typescript@6.0.3))
@@ -229,7 +235,7 @@ importers:
     devDependencies:
       '@btravstack/tsconfig':
         specifier: 'catalog:'
-        version: 0.1.0
+        version: 0.2.0
       '@btravstack/typedoc':
         specifier: 'catalog:'
         version: 0.1.0(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))(typedoc@0.28.20(typescript@6.0.3))
@@ -263,7 +269,7 @@ importers:
     devDependencies:
       '@btravstack/tsconfig':
         specifier: 'catalog:'
-        version: 0.1.0
+        version: 0.2.0
       '@btravstack/typedoc':
         specifier: 'catalog:'
         version: 0.1.0(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))(typedoc@0.28.20(typescript@6.0.3))
@@ -300,7 +306,7 @@ importers:
     devDependencies:
       '@btravstack/tsconfig':
         specifier: 'catalog:'
-        version: 0.1.0
+        version: 0.2.0
       '@btravstack/typedoc':
         specifier: 'catalog:'
         version: 0.1.0(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))(typedoc@0.28.20(typescript@6.0.3))
@@ -337,7 +343,7 @@ importers:
     devDependencies:
       '@btravstack/tsconfig':
         specifier: 'catalog:'
-        version: 0.1.0
+        version: 0.2.0
       '@btravstack/typedoc':
         specifier: 'catalog:'
         version: 0.1.0(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))(typedoc@0.28.20(typescript@6.0.3))
@@ -383,7 +389,7 @@ importers:
     devDependencies:
       '@btravstack/tsconfig':
         specifier: 'catalog:'
-        version: 0.1.0
+        version: 0.2.0
       '@types/node':
         specifier: 'catalog:'
         version: 26.1.1
@@ -411,7 +417,7 @@ importers:
     devDependencies:
       '@btravstack/tsconfig':
         specifier: 'catalog:'
-        version: 0.1.0
+        version: 0.2.0
       '@btravstack/typedoc':
         specifier: 'catalog:'
         version: 0.1.0(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))(typedoc@0.28.20(typescript@6.0.3))
@@ -448,7 +454,7 @@ importers:
     devDependencies:
       '@btravstack/tsconfig':
         specifier: 'catalog:'
-        version: 0.1.0
+        version: 0.2.0
       '@btravstack/typedoc':
         specifier: 'catalog:'
         version: 0.1.0(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))(typedoc@0.28.20(typescript@6.0.3))
@@ -500,7 +506,7 @@ importers:
     devDependencies:
       '@btravstack/tsconfig':
         specifier: 'catalog:'
-        version: 0.1.0
+        version: 0.2.0
       '@btravstack/typedoc':
         specifier: 'catalog:'
         version: 0.1.0(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))(typedoc@0.28.20(typescript@6.0.3))
@@ -530,7 +536,7 @@ importers:
     devDependencies:
       '@btravstack/tsconfig':
         specifier: 'catalog:'
-        version: 0.1.0
+        version: 0.2.0
       '@btravstack/typedoc':
         specifier: 'catalog:'
         version: 0.1.0(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))(typedoc@0.28.20(typescript@6.0.3))
@@ -680,8 +686,14 @@ packages:
     peerDependencies:
       '@commitlint/cli': '>=21'
 
-  '@btravstack/oxlint@0.1.0':
-    resolution: {integrity: sha512-/UIfVydE3nEExRqE03vUoAAQSdPqVNOzZl0QSa9ikXftezoLQfNgJcFCKW6+D2cJnM180JR0o0W7dmkQHhLogQ==}
+  '@btravstack/lefthook@0.1.1':
+    resolution: {integrity: sha512-5KFOHHrJzHm5xqtxVtsVWfm862h7ivAlRGWngtSteEZxn3aNdEwIxchts0NBX1ICg+TNL5XcIRmiPIRCyOOOvQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      lefthook: '>=2'
+
+  '@btravstack/oxlint@0.2.1':
+    resolution: {integrity: sha512-BflvYgQL67f0SVlgorKCC9tAZMor0vBpN0wkuO/SSsNsiOYMXlFEVJuUaL/ULwZYsDbeoSrzBblg1LLaIAMnHA==}
     engines: {node: '>=20'}
     peerDependencies:
       oxlint: '>=1'
@@ -695,8 +707,8 @@ packages:
       vue:
         optional: true
 
-  '@btravstack/tsconfig@0.1.0':
-    resolution: {integrity: sha512-xRkISG6jY5vLpaDJCptyOjvmUeyH6M/i6shhoE6WFGBc+JToc/dyO/511Zi6NPYVTHamNbxOG/e6dpclBWIz2A==}
+  '@btravstack/tsconfig@0.2.0':
+    resolution: {integrity: sha512-0VZt4DNJlY+XgAeCS4HybgsG0kdWDGjRwBiDdQZ6pYPUo1ayjM4AIH1oPatL5+YQvICTqrSaXTHSa8DnP+GXbg==}
     engines: {node: '>=20'}
 
   '@btravstack/typedoc@0.1.0':
@@ -4180,7 +4192,11 @@ snapshots:
       '@commitlint/cli': 21.2.1(@types/node@26.1.1)(conventional-commits-parser@7.1.0)(typescript@6.0.3)
       '@commitlint/config-conventional': 21.2.0
 
-  '@btravstack/oxlint@0.1.0(oxlint@1.73.0)':
+  '@btravstack/lefthook@0.1.1(lefthook@2.1.10)':
+    dependencies:
+      lefthook: 2.1.10
+
+  '@btravstack/oxlint@0.2.1(oxlint@1.73.0)':
     dependencies:
       oxlint: 1.73.0
 
@@ -4190,7 +4206,7 @@ snapshots:
     optionalDependencies:
       vue: 3.5.38(typescript@6.0.3)
 
-  '@btravstack/tsconfig@0.1.0': {}
+  '@btravstack/tsconfig@0.2.0': {}
 
   '@btravstack/typedoc@0.1.0(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))(typedoc@0.28.20(typescript@6.0.3))':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,9 +11,10 @@ packages:
 catalog:
   "@bloodyowl/boxed": 3.4.0
   "@btravstack/commitlint": 0.1.0
-  "@btravstack/oxlint": 0.1.0
+  "@btravstack/lefthook": 0.1.1
+  "@btravstack/oxlint": 0.2.1
   "@btravstack/theme": 1.7.0
-  "@btravstack/tsconfig": 0.1.0
+  "@btravstack/tsconfig": 0.2.0
   "@btravstack/typedoc": 0.1.0
   "@changesets/cli": 2.31.0
   "@commitlint/cli": 21.2.1
@@ -102,6 +103,7 @@ minimumReleaseAgeStrict: true
 minimumReleaseAgeExclude:
   # First-party shared config (@btravstack scope): adopt immediately, skip the delay.
   - "@btravstack/commitlint"
+  - "@btravstack/lefthook"
   - "@btravstack/oxlint"
   - "@btravstack/theme"
   - "@btravstack/tsconfig"


### PR DESCRIPTION
## What changed

Adopts the latest `@btravstack` shared config across the monorepo.

**Config bumps (`pnpm-workspace.yaml` catalog):**
- `@btravstack/tsconfig` 0.1.0 → **0.2.0** (adds `verbatimModuleSyntax`; **drops `types: ["node"]` from the base**)
- `@btravstack/oxlint` 0.1.0 → **0.2.1** (adds `consistent-type-imports`)
- **new** `@btravstack/lefthook` 0.1.1 — `lefthook.yml` now `extends` the shared base (format + lint + commit-msg), preserving the existing `format`/`lint` excludes

**Supporting edits:**
- Root `package.json` devDeps: add `@btravstack/lefthook`
- `pnpm-workspace.yaml` `minimumReleaseAgeExclude`: add `@btravstack/lefthook`
- `knip.json` `ignoreDependencies`: add `@btravstack/lefthook`
- `oxfmt`: skipped — `.oxfmtrc.json` already uses `sortImports`

**Fallout fix — `types: ["node"]`:**
The new tsconfig base no longer implies `@types/node`. Three packages use Node globals in source/tests and now declare `"types": ["node"]` themselves:
- `packages/boxed` (`queueMicrotask`, `process`, `setTimeout`, `globalThis` index)
- `packages/prisma` (`setTimeout`)
- `packages/orpc` (`AbortController`, `Request`, `Response`, `URL`)

No `verbatimModuleSyntax` / `consistent-type-imports` fixes were needed — `oxlint --fix` made no source changes (existing type-only imports were already correct).

## Gate results (all green)

| Check | Result |
|---|---|
| `pnpm build` | ✅ 20/20 tasks |
| `pnpm typecheck` | ✅ 19/19 tasks |
| `pnpm lint` | ✅ clean |
| `pnpm format --check` | ✅ clean |
| `pnpm knip` | ✅ clean |
| `pnpm audit --audit-level=high` | ✅ no vulnerabilities |
| `pnpm test` | ✅ all passing |

## Changeset

`.changeset/adopt-btravstack-0.2.md` — patch to `unthrown` (bumps the whole fixed core group) plus `@unthrown/prisma` and `@unthrown/orpc` (independently versioned, both in the changed-packages list). `changeset status --since=origin/main` exits 0.