### PR TITLE
ci: use shared @btravstack reusable CI workflow (proof)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,123 +12,20 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
-  format:
-    name: Format
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Check formatting
-        run: pnpm format --check
-
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Run linter
-        run: pnpm lint
-
-  typecheck:
-    name: Type Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Run type check
-        run: pnpm typecheck
-
-  knip:
-    name: Knip
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Run knip
-        run: pnpm exec knip --reporter github-actions
-
-  test:
-    name: Tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Run tests
-        run: pnpm test -- --coverage --reporter=default --reporter=github-actions
-
-      - name: Upload Coverage Report
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: coverage-report
-          path: ./**/coverage/
-          retention-days: 30
-
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Run build
-        run: pnpm build
-
-  security-audit:
-    name: Security Audit
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Run security audit
-        run: pnpm audit --audit-level=high
+  ci:
+    uses: btravstack/config/.github/workflows/ci-reusable.yml@main
+    with:
+      test-command: "pnpm test -- --coverage --reporter=default --reporter=github-actions"
 
   bundle-size:
     name: Bundle Size
+    needs: ci
     runs-on: ubuntu-latest
-    needs: build
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Build packages
-        run: pnpm build
-
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup
+      - run: pnpm build
       - name: Report bundle sizes
         run: |
           echo "## Bundle Sizes" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,28 +14,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: btravstack/config/.github/workflows/ci-reusable.yml@main
+    uses: btravstack/config/.github/workflows/ci-reusable.yml@workflows-v1
     with:
+      bundle-size: true
       test-command: "pnpm test -- --coverage --reporter=default --reporter=github-actions"
-
-  bundle-size:
-    name: Bundle Size
-    needs: ci
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/setup
-      - run: pnpm build
-      - name: Report bundle sizes
-        run: |
-          echo "## Bundle Sizes" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Package | Size |" >> $GITHUB_STEP_SUMMARY
-          echo "|---------|------|" >> $GITHUB_STEP_SUMMARY
-          for pkg in packages/*/dist; do
-            if [ -d "$pkg" ]; then
-              size=$(du -sh "$pkg" 2>/dev/null | cut -f1)
-              name=$(basename $(dirname "$pkg"))
-              echo "| $name | $size |" >> $GITHUB_STEP_SUMMARY
-            fi
-          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,3 @@ concurrency:
 jobs:
   ci:
     uses: btravstack/config/.github/workflows/ci-reusable.yml@workflows-v1
-    with:
-      bundle-size: true
-      test-command: "pnpm test -- --coverage --reporter=default --reporter=github-actions"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,55 +10,9 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   release:
-    name: Release
-    runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    permissions:
-      contents: write
-      pull-requests: write
-      id-token: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          # PAT so the git remote is configured with PAT credentials; the bare
-          # GITHUB_TOKEN push checkout normally sets up is treated as a bot
-          # event and would not fire `pull_request` workflows on the resulting
-          # branch — defeating the point of a PAT release.
-          token: ${{ secrets.RELEASE_PAT }}
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Build
-        run: pnpm build
-
-      - name: Create Release Pull Request or Publish to npm
-        id: changesets
-        uses: changesets/action@v1
-        with:
-          # Use `pnpm run …` so we invoke the package.json scripts. Bare
-          # `pnpm version` collides with pnpm's built-in `version` command and
-          # silently prints `process.versions` instead of running the changeset
-          # version script.
-          version: pnpm run version
-          publish: pnpm run release
-          commit: "chore: release packages"
-          title: "chore: release packages"
-        env:
-          # PAT rather than GITHUB_TOKEN: events triggered by GITHUB_TOKEN do
-          # not start new workflow runs (anti-recursion safeguard), so the
-          # "Version Packages" PR would otherwise skip CI. Required repo secret:
-          # RELEASE_PAT (classic PAT with `repo`, or fine-grained with
-          # Contents + Pull requests read/write on this repo).
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
-          # NPM_TOKEN intentionally absent — npm Trusted Publishing uses the
-          # OIDC token minted via `id-token: write`. Each package must have a
-          # Trusted Publisher configured on npmjs.com pointing at this repo +
-          # workflow file (.github/workflows/release.yml).
+    uses: btravstack/config/.github/workflows/release-reusable.yml@main
+    secrets:
+      RELEASE_PAT: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    uses: btravstack/config/.github/workflows/release-reusable.yml@main
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    uses: btravstack/config/.github/workflows/release-reusable.yml@workflows-v1
     secrets:
       RELEASE_PAT: ${{ secrets.RELEASE_PAT }}


### PR DESCRIPTION
Proof-of-concept: replace the common CI jobs with a call to the shared `btravstack/config/.github/workflows/ci-reusable.yml`, keeping the bespoke `bundle-size` job. Testing that the cross-repo reusable workflow runs.