### PR TITLE
ci: run tests on the primary + engines-floor Node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,5 @@ concurrency:
 jobs:
   ci:
     uses: btravstack/config/.github/workflows/ci-reusable.yml@workflows-v1
+    with:
+      node-versions: '["", "22.19"]'


### PR DESCRIPTION
Add `node-versions: '["", "22.19"]'` so the reusable `test` job runs on both the `.node-version` primary and the engines floor (`ci / Tests` + `ci / Tests (Node 22.19)`).