### PR TITLE
docs: rework the Emeria adopter strip into an inline lockup

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -56,27 +56,51 @@
   }
 }
 
-/* "Used in production at" strip — a subtle, centered adopter logo below the
- * At-a-glance example. The light/dark logo pair mirrors the hero's own
- * logo-light/logo-dark swap (VitePress toggles `html.dark`); the shipped
+/* "Used in production at" strip — a single-adopter endorsement, closing the
+ * homepage. Composed as one inline lockup (label · hairline · logo) rather
+ * than a "logo wall of one", and set off from the content with a hairline top
+ * rule in the site's own divider language, so it reads as a deliberate closing
+ * band instead of a floating island. The light/dark logo pair mirrors the
+ * hero's logo-light/logo-dark swap (VitePress toggles `html.dark`); the shipped
  * Emeria SVGs share one geometry, recoloured navy (light) / white (dark). */
 .used-by {
-  margin: 4rem auto 1.5rem;
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.1rem;
+  max-width: 640px;
+  margin: 4.5rem auto 1rem;
+  padding-top: 2.5rem;
+  border-top: 1px solid var(--vp-c-divider);
 }
 .used-by__label {
-  margin: 0 0 1rem;
   font-size: 12px;
   font-weight: 600;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--vp-c-text-3);
+  white-space: nowrap;
+}
+/* Thin lockup divider between the label and the logo — the hairline again, so
+ * the two sit as one object rather than two centred fragments. */
+.used-by__label::after {
+  content: "";
+  display: inline-block;
+  width: 1px;
+  height: 0.95em;
+  margin-left: 1.1rem;
+  vertical-align: -0.12em;
+  background: var(--vp-c-divider);
+}
+.used-by__link {
+  display: inline-flex;
+  align-items: center;
 }
 .used-by__logo {
-  height: 30px;
+  height: 22px;
   width: auto;
-  opacity: 0.75;
-  transition: opacity 0.25s;
+  opacity: 0.72;
+  transition: opacity 0.25s ease;
 }
 .used-by__link:hover .used-by__logo {
   opacity: 1;
@@ -89,4 +113,16 @@
 }
 .dark .used-by__logo--dark {
   display: inline-block;
+}
+/* Narrow screens: stack the lockup and drop the inline divider so the label
+ * and logo never crowd on one line. */
+@media (max-width: 480px) {
+  .used-by {
+    flex-direction: column;
+    gap: 0.9rem;
+    padding-top: 2rem;
+  }
+  .used-by__label::after {
+    display: none;
+  }
 }

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -67,7 +67,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 1.1rem;
+  /* No container gap on wide screens — the divider pseudo-element owns the
+   * spacing on both sides (see `.used-by__label::after`). The column layout
+   * below re-introduces a gap once the divider is hidden. */
   max-width: 640px;
   margin: 4.5rem auto 1rem;
   padding-top: 2.5rem;
@@ -88,7 +90,9 @@
   display: inline-block;
   width: 1px;
   height: 0.95em;
-  margin-left: 1.1rem;
+  /* Owns the full label↔logo spacing: 1.1rem on each side of the bar, so the
+   * lockup is symmetric with one knob and no container gap. */
+  margin: 0 1.1rem;
   vertical-align: -0.12em;
   background: var(--vp-c-divider);
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,7 +73,7 @@ import { withBase } from "vitepress";
 
 <div class="used-by">
   <span class="used-by__label">Used in production at</span>
-  <a class="used-by__link" href="https://emeriagroup.com/fr/" target="_blank" rel="noopener" aria-label="Emeria">
+  <a class="used-by__link" href="https://emeriagroup.com/fr/" target="_blank" rel="noopener noreferrer" aria-label="Emeria">
     <img :src="withBase('/emeria-light.svg')" alt="Emeria" class="used-by__logo used-by__logo--light" />
     <img :src="withBase('/emeria-dark.svg')" alt="Emeria" class="used-by__logo used-by__logo--dark" />
   </a>

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,7 +72,7 @@ import { withBase } from "vitepress";
 </script>
 
 <div class="used-by">
-  <p class="used-by__label">Used in production at</p>
+  <span class="used-by__label">Used in production at</span>
   <a class="used-by__link" href="https://emeriagroup.com/fr/" target="_blank" rel="noopener" aria-label="Emeria">
     <img :src="withBase('/emeria-light.svg')" alt="Emeria" class="used-by__logo used-by__logo--light" />
     <img :src="withBase('/emeria-dark.svg')" alt="Emeria" class="used-by__logo used-by__logo--dark" />


### PR DESCRIPTION
## Summary

Polishes the "Used in production at" strip added in #116 — it read as a floating "logo-wall-of-one" at the bottom of the homepage. Recomposed as a single deliberate endorsement lockup within the existing design system (no theme/token/route changes, hero mark untouched).

**What changed**
- **Inline lockup** — label · hairline · logo on one centered row (`Used in production at │ Emeria`), so the two read as a single object instead of two centered fragments.
- **Hairline top rule** (`--vp-c-divider`, the site's own divider language) sets the strip off as a deliberate closing band, removing the orphaned-island feel.
- **Optical sizing** — the Emeria wordmark drops 30px → 22px to match the 12px label's cap-height; a thin hairline divider sits between them.
- **Responsive** — stacks and drops the inline divider below 480px so label + logo never crowd.
- Light/dark logo swap and the green accent are preserved.

## Verification

- [x] `pnpm --filter @unthrown/docs build` passes; markup renders (`class="used-by__label"`)
- [x] `pnpm format --check` clean

Note: not visually screenshotted (the browser extension wasn't connected and `vitepress preview` wouldn't start in the sandbox) — reasoned from the shipped code. Merging redeploys the docs via `deploy-docs.yml`.

## Not in scope

If "the logo" feedback also referred to the unthrown hero mark (from `@btravstack/theme`), that's a separate change and was left untouched.