### PR TITLE
docs: remove the "Used by" section from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,17 +94,6 @@ defect, so the edge of your program needs a single `match` and no `try`/`catch`.
 | [`@unthrown/standard-schema`](./packages/standard-schema) | `fromSchema` / `fromSchemaAsync`: any Standard Schema validator into a `Result`.                    |
 | [`@unthrown/oxlint`](./packages/oxlint)                   | oxlint plugin: `no-ambiguous-error-type`, `prefer-async-result`, `no-unhandled-result`, `no-throw`. |
 
-## Used by
-
-unthrown runs in production at [**Emeria**](https://emeriagroup.com/fr/).
-
-<a href="https://emeriagroup.com/fr/">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="docs/public/emeria-dark.svg" />
-    <img src="docs/public/emeria-light.svg" alt="Emeria" height="28" />
-  </picture>
-</a>
-
 ## Contributing
 
 This is a pnpm + turbo monorepo. Common tasks:


### PR DESCRIPTION
## Summary

Removes the Emeria "Used by" section from the README (added in #118).

The adopter endorsement stays on the **docs homepage** (the inline lockup from #117) — this only drops it from the README. The shared `docs/public/emeria-{light,dark}.svg` assets are kept, since the homepage still references them.

## Verification

- [x] `pnpm format --check` clean
- [x] Diff is a clean 11-line deletion; Emeria assets retained (still used by `docs/index.md`)