### PR TITLE
fix(core): async flatMap/flatTap/bind preserve callback types (no unknown collapse)

### DIFF
--- a/.changeset/fix-async-flatmap-inference.md
+++ b/.changeset/fix-async-flatmap-inference.md
@@ -1,0 +1,23 @@
+---
+"unthrown": patch
+---
+
+**Fix: async `flatMap` / `flatTap` / `bind` no longer collapse the callback's
+types to `unknown`.**
+
+When an `AsyncResult` combinator's callback returned a value typed as the opaque
+`AsyncResult<U, E2>` alias — e.g. `client.start(...).flatMap((h) => h.result())`,
+where `h.result()` is `AsyncResult<Out, Err>` — the success type `U` (and, for
+`flatTap`, the threaded error `E2`) inferred as `unknown` instead of being
+preserved. The signatures destructured `U`/`E2` through the `AsyncResult<U, E2>`
+union member, doing structural inference over the whole async method surface,
+which yields junk candidates.
+
+The async branch of those callbacks is now typed
+`Awaitable<Result<U, E2>> & { flatMap: unknown }`: inference goes through the
+`Awaitable` then-channel (junk-free, so `U`/`E2` stay precise), while the
+`{ flatMap: unknown }` marker keeps a bare `Promise<Result>` out — a raw
+rejection still can't bypass qualification. Freshly-minted results (`Ok`,
+`fromPromise`, `OkAsync`, …) were unaffected and still infer as before.
+
+Guarded by new `types.test-d.ts` regression assertions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -464,7 +464,20 @@ library can be "done".
   re-imposed `this` gate. `AsyncOkOf`/`AsyncErrOf` infer through the `Awaitable` `then`
   channel only (`R extends Awaitable<infer Res>`), NOT `R extends
 AsyncResult<infer T, …>` — structural inference over the whole method surface
-  would pick up junk candidates.
+  would pick up junk candidates. The **plain async binds** (`flatMap` / `flatTap`
+  / `bind`) hit the same hazard from the other direction: destructuring `U`/`E2`
+  through an `AsyncResult<U, E2>` union member in the callback-return position
+  collapsed them to `unknown` when the callback returned a value typed as the
+  opaque `AsyncResult` alias. So their async branch is spelled
+  `Awaitable<Result<U, E2>> & { flatMap: unknown }` — inference runs through the
+  `Awaitable` then-channel (junk-free), and the `{ flatMap: unknown }` marker
+  keeps a bare `Promise<Result>` out (a Promise has no `flatMap`, so a raw
+  rejection still can't bypass qualification). The error channel stays a **plain**
+  `E | E2` — deriving it as `E | ErrOf<R> | AsyncErrOf<R>` re-invaded `E`'s
+  variance (the same `out E` collapse `flatTapErr` avoids), so `flatMap` keeps
+  the plain `E2`. Keeping the `<U, E2>` shape (rather than inferring a whole
+  `R`) also means the precise `AsyncRes` impl signatures conform to the public
+  type unchanged — no loosening needed for these three.
 - "Check before you access" is enforced by the union: `result.value` only
   type-checks on the `Ok` variant. `AsyncRes` operates purely on the public
   `Result` union (wraps a `Promise<Result>`, branches on `r.tag`), never on `Res`

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -146,6 +146,31 @@ declare const ar: AsyncResult<number, "e">;
 // @ts-expect-error - a raw Promise callback return is not assignable
 ar.flatMap((n) => Promise.resolve(Ok(n)));
 
+// REGRESSION GUARD: chaining a callback that returns a value typed as the
+// opaque `AsyncResult<U, E2>` alias (not a freshly-minted Ok/fromPromise) must
+// preserve `U` and `E2` — not collapse them to `unknown`. Inferring through the
+// full `AsyncResult` method surface junks them; inferring through the
+// `Awaitable` then-channel keeps them precise (see the async binds in types.ts).
+declare const aliasedAsync: () => AsyncResult<void, Error>;
+// flatMap: the success type survives (was collapsing to `unknown`)
+const chained = ar.flatMap(() => aliasedAsync());
+type _chained = Expect<Equal<typeof chained, AsyncResult<void, "e" | Error>>>;
+// flatTap: the threaded error survives (value kept as `number`)
+const flatTappedAsyncAlias = ar.flatTap(() => aliasedAsync());
+type _flatTappedAsyncAlias = Expect<
+  Equal<typeof flatTappedAsyncAlias, AsyncResult<number, "e" | Error>>
+>;
+// bind: the callback's error survives on the accumulated error channel
+declare const arScope: AsyncResult<{ a: number }, "e">;
+const boundAsyncAlias = arScope.bind("v", () => aliasedAsync());
+type _boundAsyncErr = Expect<Equal<AsyncErrOf<typeof boundAsyncAlias>, "e" | Error>>;
+type _boundAsyncOk = Expect<
+  Equal<AsyncOkOf<typeof boundAsyncAlias>, { a: number; readonly v: void }>
+>;
+// a sync `Result`-returning callback keeps its channels too (no `unknown` leak)
+const chainedSync = ar.flatMap((n) => Ok(n * 2));
+type _chainedSync = Expect<Equal<typeof chainedSync, AsyncResult<number, "e">>>;
+
 // ErrView's parameter order is <E, T> (error first) — the reverse of OkView /
 // DefectView / Result — because `Result<T, E>` narrows to `ErrView<E, T>`.
 type _errViewErr = Expect<Equal<ErrView<"boom", number>["error"], "boom">>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -727,15 +727,17 @@ export type AsyncResultMethods<out T, out E> = {
    * Asynchronous {@link ResultMethods.flatMap | flatMap}. Unlike the sync form,
    * `f` may return a `Result` **or** an `AsyncResult` (never a raw `Promise`); a
    * throw becomes a `Defect`.
+   *
+   * @remarks
+   * The async branch of `f`'s return type is spelled `Awaitable<Result<U, E2>> &
+   * { flatMap: unknown }` rather than `AsyncResult<U, E2>`: this is what you get
+   * by returning an `AsyncResult` (it satisfies both), but inference runs through
+   * the `Awaitable` then-channel so `U`/`E2` stay precise instead of collapsing
+   * to `unknown`, while the `{ flatMap: unknown }` marker still rejects a bare
+   * `Promise` (it has no `flatMap`). Just return a `Result` or an `AsyncResult`.
    */
   flatMap<U, E2>(
-    // The async branch is written `Awaitable<Result<U, E2>> & { flatMap: unknown }`
-    // rather than `AsyncResult<U, E2>` deliberately: inferring `U`/`E2` through
-    // the `Awaitable` then-channel is junk-free, whereas inferring them through
-    // the full `AsyncResult` method surface collapses `U` to `unknown` when the
-    // callback returns a value typed as the opaque `AsyncResult` alias. The
-    // `& { flatMap: unknown }` marker keeps a bare `Promise<Result>` out (a
-    // Promise has no `flatMap`), so a raw rejection still can't bypass triage.
+    // async branch spelled `Awaitable & { flatMap }` for junk-free inference — see @remarks
     f: (value: T) => Result<U, E2> | (Awaitable<Result<U, E2>> & { flatMap: unknown }),
   ): AsyncResult<U, E | E2>;
   /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -728,7 +728,16 @@ export type AsyncResultMethods<out T, out E> = {
    * `f` may return a `Result` **or** an `AsyncResult` (never a raw `Promise`); a
    * throw becomes a `Defect`.
    */
-  flatMap<U, E2>(f: (value: T) => Result<U, E2> | AsyncResult<U, E2>): AsyncResult<U, E | E2>;
+  flatMap<U, E2>(
+    // The async branch is written `Awaitable<Result<U, E2>> & { flatMap: unknown }`
+    // rather than `AsyncResult<U, E2>` deliberately: inferring `U`/`E2` through
+    // the `Awaitable` then-channel is junk-free, whereas inferring them through
+    // the full `AsyncResult` method surface collapses `U` to `unknown` when the
+    // callback returns a value typed as the opaque `AsyncResult` alias. The
+    // `& { flatMap: unknown }` marker keeps a bare `Promise<Result>` out (a
+    // Promise has no `flatMap`), so a raw rejection still can't bypass triage.
+    f: (value: T) => Result<U, E2> | (Awaitable<Result<U, E2>> & { flatMap: unknown }),
+  ): AsyncResult<U, E | E2>;
   /**
    * Asynchronous {@link ResultMethods.tap | tap}. `f` is synchronous; a throw
    * becomes a `Defect`. An async callback is rejected at compile time
@@ -747,7 +756,9 @@ export type AsyncResultMethods<out T, out E> = {
    * becomes a `Defect`.
    */
   flatTap<E2>(
-    f: (value: T) => Result<unknown, E2> | AsyncResult<unknown, E2>,
+    // See `flatMap` above for why the async branch is `Awaitable<…> & { flatMap }`
+    // rather than `AsyncResult<…>` (junk-free `E2` inference; excludes raw Promises).
+    f: (value: T) => Result<unknown, E2> | (Awaitable<Result<unknown, E2>> & { flatMap: unknown }),
   ): AsyncResult<T, E | E2>;
   /**
    * Asynchronous {@link ResultMethods.bind | bind} (do-notation). `f` may return
@@ -756,7 +767,9 @@ export type AsyncResultMethods<out T, out E> = {
    */
   bind<K extends string, U, E2>(
     name: K,
-    f: (scope: T) => Result<U, E2> | AsyncResult<U, E2>,
+    // See `flatMap` above for why the async branch is `Awaitable<…> & { flatMap }`
+    // rather than `AsyncResult<…>` (junk-free `U`/`E2` inference; excludes raw Promises).
+    f: (scope: T) => Result<U, E2> | (Awaitable<Result<U, E2>> & { flatMap: unknown }),
   ): AsyncResult<Bound<T, K, U>, E | E2>;
   /**
    * Asynchronous {@link ResultMethods.let | let} (do-notation). `f` returns a


### PR DESCRIPTION
## Summary

Fixes a v5-beta.1 type-inference regression: an `AsyncResult` combinator callback that returns a value typed as the **opaque `AsyncResult<U, E2>` alias** collapsed the inferred success type `U` (and, for `flatTap`, the threaded error `E2`) to `unknown`.

```ts
// before: AsyncResult<unknown, Err>   ·   after: AsyncResult<Out, Err>
client.startWorkflow(...).flatMap((h) => h.result())
```

Root cause: the async `flatMap`/`flatTap`/`bind` signatures destructured `U`/`E2` through the `AsyncResult<U, E2>` union member, doing structural inference over the whole async method surface → junk `unknown` candidates. Freshly-minted results (`Ok`, `fromPromise`, `OkAsync`, …) were unaffected because they infer concretely — only the opaque-alias case regressed.

## The fix

The async branch of those callbacks is now `Awaitable<Result<U, E2>> & { flatMap: unknown }`:

- Inference runs through the **`Awaitable` then-channel** — junk-free, so `U`/`E2` stay precise (the same principle `AsyncOkOf`/`AsyncErrOf` already use for the error combinators).
- The `{ flatMap: unknown }` marker keeps a bare **`Promise<Result>`** out (a Promise has no `flatMap`), so a raw rejection still can't bypass qualification — the `@ts-expect-error` guard for that stays green.
- The error channel stays a **plain `E | E2`**: deriving it as `E | ErrOf<R> | AsyncErrOf<R>` re-invades `E`'s `out`-variance (the same collapse `flatTapErr` documents avoiding), which cascaded into `Result`'s covariance. Keeping `<U, E2>` also means the **class impl is unchanged** — it conforms to the new interface with no loosening.

## Verification

- [x] New `types.test-d.ts` regression guards (flatMap/flatTap/bind with an aliased `AsyncResult` return; sync `Result` return; raw-Promise still rejected)
- [x] `pnpm typecheck` (all 17 packages) · `pnpm test` (263, core 100% fn/line) · `pnpm lint` · `pnpm knip` · `pnpm format --check` · `pnpm build` (18) — all green
- [x] CLAUDE.md internal-design note updated

Publishes **`unthrown@5.0.0-beta.2`** on merge (beta pre-mode). Unblocks the `@amqp-contract` / `@temporal-contract` v5 adoptions.

## Known follow-up (separate)

The `@temporal-contract` migration also surfaced a **second**, narrower regression — a generic-conditional `E` union defeating the `out E` fast-path on some `Err(...)` widening returns, which has a clean behavior-preserving consumer workaround (explicit `Err<E>(...)` type args). Not addressed here (no minimal repro yet); tracked for a later beta.