### PR TITLE
docs: record the two v5 generic-inference limitations + workarounds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -476,8 +476,9 @@ library can be "done".
      (fragile); duplicating the surface into each view is unmaintainable. The
      v4-clean equivalent worked only because there was no matcher then.
      **Workaround:** annotate the constructor — `Err<TheUnion>(x)`.
-  2. **`fromPromise` T-collapse on an inline `.then` chain.** `fromPromise(
-Promise.resolve().then(() => makeThing()), qualify)` infers `T = unknown`.
+  2. **`fromPromise` T-collapse on an inline `.then` chain.** Passing an inline
+     `Promise.resolve().then(() => makeThing())` to `fromPromise` infers
+     `T = unknown`.
      Root cause: TS contextual-typing circularity — `fromPromise`'s `Promise<T>`
      parameter contextually types the `.then` chain whose callback return _is_
      `T`, so `T` is inferred while it is still being resolved. Not the union

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -444,13 +444,48 @@ library can be "done".
   the declared `out` fast-path carries it. TS **verifies** the annotations
   (TS2636 if unprovable). Only aliases whose body is directly an object type may
   be annotated — the unions/intersections (`Result`, the views, `AsyncResult`)
-  inherit the fast path through them. **`ErrMatcher<E>` (ts-pattern's `Match`,
+  inherit the fast path through them for _concrete_ arguments, but **not** when
+  the target type argument is an unresolved generic union (see the known
+  limitation below — an intersection view's variance is then measured
+  structurally, where `E` is invariant). **`ErrMatcher<E>` (ts-pattern's `Match`,
   invariant in its input) must stay in a callback parameter position only**: it
   is contravariant there and harmless, but unioning an `M`-derived output with
   the class `E` in a covariant return re-invaded `E`'s variance and collapsed
   inference (`combine<T,E>(rs: AsyncResult<T,E>[])` inferring `unknown`) — which
   is exactly why `flatTapErr` infers a plain `E2` from the builder output and
   returns `E | E2` rather than `E | ErrOf<MatchOut<M>>`.
+- **Known type-system limitations (workarounds, not bugs to chase).** Two v5
+  inference gaps have no clean, safe fix and are handled at the call site with an
+  explicit type argument. Both were dead-ends after a full investigation
+  (documented so they are not re-litigated):
+  1. **Widening `Err(x)` into a _generic_ error union.** In generic code,
+     `return Err(concreteError)` where the function's declared error is an
+     unresolved union (e.g. `E | RuntimeError`, or a conditional like
+     `ContractErrorsOf<T> | …`) fails to compile — `Result<never, X>` won't
+     widen to `Result<T, ‹generic union›>`. Root cause: the `out E` fast-path is
+     honored on `ResultMethods` **directly**, but the variant **views**
+     (`OkView = ResultMethods<T,E> & { tag; value }`) are **intersections**, and
+     TS measures an intersection's variance _structurally_, ignoring the declared
+     `out E`. Structurally `E` is **invariant** (ts-pattern's `Match<E>` is
+     invariant; `FailureView<E,T>` and the `this`-gated `getErr` are
+     contravariant), so the views don't inherit the covariance. Every fix hits a
+     wall: intersections can't take an `out` annotation (TS2637); flattening the
+     views into annotated mapped types recurses infinitely (TS2589) through the
+     self-referential surface (`toAsync`/`flatMapErr`/`FailureView`); making
+     `ResultMethods` structurally covariant means defeating `Match`'s invariance
+     (fragile); duplicating the surface into each view is unmaintainable. The
+     v4-clean equivalent worked only because there was no matcher then.
+     **Workaround:** annotate the constructor — `Err<TheUnion>(x)`.
+  2. **`fromPromise` T-collapse on an inline `.then` chain.** `fromPromise(
+Promise.resolve().then(() => makeThing()), qualify)` infers `T = unknown`.
+     Root cause: TS contextual-typing circularity — `fromPromise`'s `Promise<T>`
+     parameter contextually types the `.then` chain whose callback return _is_
+     `T`, so `T` is inferred while it is still being resolved. Not the union
+     parameter (per-shape overloads don't help), and not fixable from the
+     signature. **Workaround:** bind a typed intermediate
+     (`const p: Promise<Thing> = …then(…); fromPromise(p, qualify)`), pass an
+     explicit `fromPromise<Thing, E>(…)`, or don't annotate the `.then` chain
+     inline.
 - **Error-matcher runtime.** All five error methods dispatch through one
   `runMatch` helper: `f(match(error), defect).run()` — build `match(error)`,
   hand it (plus `defect`) to the callback, and `.run()` the returned builder

--- a/docs/guide/async-results.md
+++ b/docs/guide/async-results.md
@@ -80,4 +80,40 @@ The extra `fromPromise` is not ceremony — it is the forced triage decision tha
 guarantees the failure becomes a modeled error or a defect, never an untyped
 `unknown`.
 
+## Two inference notes for generic code
+
+These only bite when you write **generic** wrappers over `Result` (a typed
+client, a framework adapter); ordinary application code never hits them. Both
+have a one-line workaround.
+
+**Widening `Err(x)` into a generic error union.** In a function whose declared
+error type is an unresolved union, returning a concrete `Err` doesn't widen:
+
+```ts
+function step<E>(): Result<Data, E | RuntimeError> {
+  // ❌ Result<never, RuntimeError> won't widen to Result<Data, E | RuntimeError>
+  // return Err(new RuntimeError());
+  return Err<E | RuntimeError>(new RuntimeError()); // ✅ annotate the constructor
+}
+```
+
+TypeScript can't prove `Result`'s error covariance when the target is an
+unresolved generic union (the variant views are intersections, whose variance is
+measured structurally). Naming the union on the constructor — `Err<TheUnion>(x)`
+— resolves it.
+
+**`fromPromise` with an inline `.then` chain.** Passing an inline
+`Promise.resolve().then(() => …)` collapses the value type to `unknown`:
+
+```ts
+// ❌ infers AsyncResult<unknown, E>
+// fromPromise(Promise.resolve().then(() => makeThing()), qualify)
+
+const p: Promise<Thing> = Promise.resolve().then(() => makeThing());
+const r = fromPromise(p, qualify); // ✅ AsyncResult<Thing, E>
+```
+
+Binding a typed intermediate (or `fromPromise<Thing, E>(…)`) breaks the
+contextual-typing cycle.
+
 → Continue to [Do Notation](./do-notation).


### PR DESCRIPTION
## Summary

Documents the two remaining v5 type-inference gaps that the `@amqp-contract` / `@temporal-contract` adoptions worked around. **Both were investigated fully and neither has a clean, safe core fix** — so this is docs-only (no code change, no release).

### 1. Widening `Err(x)` into a *generic* error union

`return Err(concreteError)` in generic code whose declared error is an unresolved union (`E | RuntimeError`, or a conditional) fails to compile. Root cause: `ResultMethods` honors its `out E` fast-path directly, but the variant **views** (`OkView = ResultMethods<T,E> & { tag; value }`) are **intersections**, whose variance TS measures *structurally* — and structurally `E` is invariant (ts-pattern's `Match<E>`, `FailureView`, the `this`-gated `getErr`). The views don't inherit the covariance.

Every fix hits a wall: intersections can't take `out` (TS2637); mapped-type flattening recurses infinitely (TS2589) through the self-referential surface; making `ResultMethods` structurally covariant means defeating `Match`'s invariance (fragile); duplicating the surface per-view is unmaintainable.

**Workaround:** `Err<TheUnion>(x)`.

### 2. `fromPromise` T-collapse on an inline `.then` chain

`fromPromise(Promise.resolve().then(() => makeThing()), qualify)` infers `T = unknown`. Root cause: TS contextual-typing circularity — the `Promise<T>` param contextually types the `.then` chain whose callback return *is* `T`. Not the union parameter (per-shape overloads don't help); not fixable from the signature.

**Workaround:** a typed intermediate (`const p: Promise<Thing> = …`) or `fromPromise<Thing, E>(…)`.

## Changes

- **CLAUDE.md** — root-cause + workaround under the variance internal-design notes (so this isn't re-litigated), and a correction to the earlier "views inherit the fast path" claim (true for concrete args, not generic-union targets).
- **docs/guide/async-results.md** — a practical "two inference notes for generic code" section.

## Verification

- [x] `pnpm format --check` clean · docs site builds clean

## Context

Follows the flatMap-inference fix (#120 → `5.0.0-beta.2`). The contract PRs (amqp #596, temporal #337) stay green on beta.2 with the idiomatic `Err<E>(...)` / typed-`fromPromise` workarounds these notes now document.