### PR TITLE
fix(core): restore generic-union widening and fromPromise inline-.then inference

### DIFF
--- a/.changeset/fix-variance-and-frompromise-inference.md
+++ b/.changeset/fix-variance-and-frompromise-inference.md
@@ -1,0 +1,24 @@
+---
+"unthrown": patch
+---
+
+**Fix: two v5 inference regressions — generic-union error widening, and
+`fromPromise` with an inline `.then` chain.** No runtime change; no consumer
+workarounds needed anymore.
+
+- **A concrete `Err`/`Ok` again widens into a generic error union.** In generic
+  code, `return Err(concreteError)` where the declared error is an unresolved
+  union (`G | RuntimeError`, a conditional, …) failed to compile on v5 — the
+  variant views and `AsyncResult` were intersection aliases, whose variance TS
+  measures structurally (where the exhaustive matcher makes `E` invariant),
+  silently losing the declared `out` covariance. They are now
+  `interface … extends` types carrying **verified** `out T, out E` annotations,
+  restoring the v4 behavior (`Err<TheUnion>(x)` workarounds can be removed).
+- **`fromPromise(Promise.resolve().then(() => x), qualify)` again infers `T`.**
+  The async-qualify ban's `R & NotThenable<R>` on qualify's return made TS defer
+  inference and collapse `T` to `unknown` for an inline `.then` chain argument.
+  The ban is now a phantom rest-tuple guard — an async qualify still fails to
+  compile (with the message), an always-throwing qualify stays legal, and `T`
+  infers normally.
+
+Both guarded by new `types.test-d.ts` regression assertions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -436,57 +436,41 @@ library can be "done".
   the `bind`/`let` scope merge (a computed key widens to an index signature, so it
   can't be spelled at the type level), the builder construction noted above, and
   the error-matcher internals noted below.
-- **`ResultMethods` / `AsyncResultMethods` / `Awaitable` carry `out` variance
-  annotations, and they must verify.** `Result<T, E>`'s covariance in both
-  params is what lets generic engine and user code widen (`Result<U, E2>` →
-  `Result<U, E | E2>`); with the matcher signatures, TypeScript can no longer
-  _measure_ that covariance structurally across unresolved type parameters, so
-  the declared `out` fast-path carries it. TS **verifies** the annotations
-  (TS2636 if unprovable). Only aliases whose body is directly an object type may
-  be annotated — the unions/intersections (`Result`, the views, `AsyncResult`)
-  inherit the fast path through them for _concrete_ arguments, but **not** when
-  the target type argument is an unresolved generic union (see the known
-  limitation below — an intersection view's variance is then measured
-  structurally, where `E` is invariant). **`ErrMatcher<E>` (ts-pattern's `Match`,
+- **Declared variance is load-bearing at every layer: `ResultMethods` /
+  `AsyncResultMethods` / `Awaitable` carry `out` annotations, and the variant
+  views (`OkView`/`ErrView`/`DefectView`) plus `AsyncResult` are
+  `interface … extends` — NOT intersection aliases — precisely so they can carry
+  verified `out T, out E` annotations of their own** (the one sanctioned use of
+  `interface` in core, each with a targeted oxlint-disable). An intersection
+  can't be annotated (TS2637) and gets its variance measured _structurally_ —
+  where the matcher signatures make `E` invariant — so the intersection form
+  silently loses the covariance for unresolved-generic targets: a concrete
+  `Err(x)` then fails to widen into a generic error union
+  (`Result<T, G | RuntimeError>`), which is exactly the v5-beta regression this
+  shape fixed. v4 didn't need any of this: its plain `(e: E) => …` callbacks sat
+  in bivariantly-compared method-parameter positions (the same reason
+  neverthrow's class surface widens without annotations); the exhaustive matcher
+  is what made declared variance mandatory. TS **verifies** every annotation
+  (TS2636 if unprovable); `Result` (a union of the annotated views) inherits the
+  fast path. **`ErrMatcher<E>` (ts-pattern's `Match`,
   invariant in its input) must stay in a callback parameter position only**: it
   is contravariant there and harmless, but unioning an `M`-derived output with
   the class `E` in a covariant return re-invaded `E`'s variance and collapsed
   inference (`combine<T,E>(rs: AsyncResult<T,E>[])` inferring `unknown`) — which
   is exactly why `flatTapErr` infers a plain `E2` from the builder output and
   returns `E | E2` rather than `E | ErrOf<MatchOut<M>>`.
-- **Known type-system limitations (workarounds, not bugs to chase).** Two v5
-  inference gaps have no clean, safe fix and are handled at the call site with an
-  explicit type argument. Both were dead-ends after a full investigation
-  (documented so they are not re-litigated):
-  1. **Widening `Err(x)` into a _generic_ error union.** In generic code,
-     `return Err(concreteError)` where the function's declared error is an
-     unresolved union (e.g. `E | RuntimeError`, or a conditional like
-     `ContractErrorsOf<T> | …`) fails to compile — `Result<never, X>` won't
-     widen to `Result<T, ‹generic union›>`. Root cause: the `out E` fast-path is
-     honored on `ResultMethods` **directly**, but the variant **views**
-     (`OkView = ResultMethods<T,E> & { tag; value }`) are **intersections**, and
-     TS measures an intersection's variance _structurally_, ignoring the declared
-     `out E`. Structurally `E` is **invariant** (ts-pattern's `Match<E>` is
-     invariant; `FailureView<E,T>` and the `this`-gated `getErr` are
-     contravariant), so the views don't inherit the covariance. Every fix hits a
-     wall: intersections can't take an `out` annotation (TS2637); flattening the
-     views into annotated mapped types recurses infinitely (TS2589) through the
-     self-referential surface (`toAsync`/`flatMapErr`/`FailureView`); making
-     `ResultMethods` structurally covariant means defeating `Match`'s invariance
-     (fragile); duplicating the surface into each view is unmaintainable. The
-     v4-clean equivalent worked only because there was no matcher then.
-     **Workaround:** annotate the constructor — `Err<TheUnion>(x)`.
-  2. **`fromPromise` T-collapse on an inline `.then` chain.** Passing an inline
-     `Promise.resolve().then(() => makeThing())` to `fromPromise` infers
-     `T = unknown`.
-     Root cause: TS contextual-typing circularity — `fromPromise`'s `Promise<T>`
-     parameter contextually types the `.then` chain whose callback return _is_
-     `T`, so `T` is inferred while it is still being resolved. Not the union
-     parameter (per-shape overloads don't help), and not fixable from the
-     signature. **Workaround:** bind a typed intermediate
-     (`const p: Promise<Thing> = …then(…); fromPromise(p, qualify)`), pass an
-     explicit `fromPromise<Thing, E>(…)`, or don't annotate the `.then` chain
-     inline.
+- **Inference-bearing parameters stay free of conditional types.** The
+  async-qualify ban on `fromPromise` is a **phantom rest-tuple guard** (an async
+  qualify demands an impossible extra argument carrying the message; a
+  `[R] extends [never]` carve-out keeps an always-throwing qualify legal) — NOT
+  `R & NotThenable<R>` on the qualify's return: that conditional made TS defer
+  qualify's inference and collapse `T` to `unknown` when the promise argument
+  was an inline `.then(…)` chain (a v5-beta regression; v4's identical
+  union-parameter signature was fine without the conditional). `fromThrowable`
+  keeps `NotThenable` on its qualify — its `T` infers directly from `fn`, so
+  nothing is disturbed. General rule: a conditional-type constraint may sit on a
+  parameter only if no _other_ parameter's inference can be deflected by it;
+  otherwise encode it as a trailing phantom guard.
 - **Error-matcher runtime.** All five error methods dispatch through one
   `runMatch` helper: `f(match(error), defect).run()` — build `match(error)`,
   hand it (plus `defect`) to the callback, and `.run()` the returned builder

--- a/docs/guide/async-results.md
+++ b/docs/guide/async-results.md
@@ -80,40 +80,4 @@ The extra `fromPromise` is not ceremony — it is the forced triage decision tha
 guarantees the failure becomes a modeled error or a defect, never an untyped
 `unknown`.
 
-## Two inference notes for generic code
-
-These only bite when you write **generic** wrappers over `Result` (a typed
-client, a framework adapter); ordinary application code never hits them. Both
-have a one-line workaround.
-
-**Widening `Err(x)` into a generic error union.** In a function whose declared
-error type is an unresolved union, returning a concrete `Err` doesn't widen:
-
-```ts
-function step<E>(): Result<Data, E | RuntimeError> {
-  // ❌ Result<never, RuntimeError> won't widen to Result<Data, E | RuntimeError>
-  // return Err(new RuntimeError());
-  return Err<E | RuntimeError>(new RuntimeError()); // ✅ annotate the constructor
-}
-```
-
-TypeScript can't prove `Result`'s error covariance when the target is an
-unresolved generic union (the variant views are intersections, whose variance is
-measured structurally). Naming the union on the constructor — `Err<TheUnion>(x)`
-— resolves it.
-
-**`fromPromise` with an inline `.then` chain.** Passing an inline
-`Promise.resolve().then(() => …)` collapses the value type to `unknown`:
-
-```ts
-// ❌ infers AsyncResult<unknown, E>
-// fromPromise(Promise.resolve().then(() => makeThing()), qualify)
-
-const p: Promise<Thing> = Promise.resolve().then(() => makeThing());
-const r = fromPromise(p, qualify); // ✅ AsyncResult<Thing, E>
-```
-
-Binding a typed intermediate (or `fromPromise<Thing, E>(…)`) breaks the
-contextual-typing cycle.
-
 → Continue to [Do Notation](./do-notation).

--- a/packages/core/src/interop.ts
+++ b/packages/core/src/interop.ts
@@ -190,7 +190,18 @@ export function fromSafeThrowable<A extends unknown[], T>(
  */
 export function fromPromise<T, R>(
   promise: Promise<T> | (() => Promise<T>),
-  qualify: (cause: unknown, defect: (cause: unknown) => Defect) => R & NotThenable<R>,
+  qualify: (cause: unknown, defect: (cause: unknown) => Defect) => R,
+  // Phantom rest-tuple guard — the async-qualify ban, encoded OFF the callback's
+  // return type: `R & NotThenable<R>` there made TS defer qualify's inference,
+  // which collapsed `T` to `unknown` for an inline `.then(…)` chain argument.
+  // With the conditional here instead, an async qualify demands an impossible
+  // third argument (compile error carrying the message) while `T`/`R` infer
+  // normally. Nothing is ever passed at runtime.
+  ..._guard: [R] extends [never]
+    ? [] // a qualify that always throws returns `never` — legal (the throw is a Defect)
+    : [R] extends [PromiseLike<unknown>]
+      ? ["unthrown: qualify must be synchronous — its Promise would land in E un-triaged"]
+      : []
 ): AsyncResult<T, Exclude<R, Defect>> {
   type E = Exclude<R, Defect>;
   const triage = qualify as (cause: unknown, defect: (cause: unknown) => Defect) => E | Defect;

--- a/packages/core/src/interop.ts
+++ b/packages/core/src/interop.ts
@@ -172,6 +172,11 @@ export function fromSafeThrowable<A extends unknown[], T>(
  * @param promise - the promise, or a thunk returning one.
  * @param qualify - triages a rejection `cause` into a modeled `E`, or marks it
  * unmodeled by returning `defect(cause)` (the helper passed as its second arg).
+ * @param _guard - compile-time only; never pass it. The phantom rest-tuple that
+ * enforces "qualify is synchronous": an `async` qualify makes this demand an
+ * impossible extra argument (whose type spells out the error), while a
+ * synchronous one leaves it empty. Encoded here — not on `qualify`'s return
+ * type — so `T`'s inference from `promise` is undisturbed.
  *
  * @category Interop
  *

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -126,12 +126,48 @@ type _safeThrowable = Expect<
 fromPromise(Promise.resolve(1));
 
 // qualify is synchronous — an async qualify would put a Promise in E (an
-// un-triaged boundary) and let its own rejection float, so NotThenable bans it
+// un-triaged boundary) and let its own rejection float. On `fromPromise` the
+// ban is a phantom rest-tuple guard (an async qualify demands an impossible
+// extra argument), NOT `NotThenable` on the return — that intersection made TS
+// defer qualify's inference and collapse `T` to `unknown` for an inline
+// `.then(…)` chain argument (see the guard below).
 const asyncQualify = async (c: unknown) => c;
 // @ts-expect-error - an async qualify is banned on fromPromise
 fromPromise(Promise.resolve(1), asyncQualify);
 // @ts-expect-error - an async qualify is banned on fromThrowable
 fromThrowable(() => 1, asyncQualify);
+
+// REGRESSION GUARD: an inline `.then` chain as the promise argument keeps its
+// value type (it collapsed to `unknown` while the ban lived on qualify's
+// return type as `R & NotThenable<R>`).
+const inlineThen = fromPromise(
+  Promise.resolve().then(() => ({ a: 1 })),
+  () => "e" as const,
+);
+type _inlineThen = Expect<Equal<typeof inlineThen, AsyncResult<{ a: number }, "e">>>;
+// an always-throwing qualify returns `never` — legal (the throw is a Defect)
+const throwingQualify = fromPromise(Promise.resolve(1), (): never => {
+  throw new Error("boom");
+});
+type _throwingQualify = Expect<Equal<typeof throwingQualify, AsyncResult<number, never>>>;
+
+// REGRESSION GUARD: a concrete `Err` widens into a GENERIC error union — the
+// variant views and `AsyncResult` are interfaces carrying verified
+// `out T, out E` annotations precisely so this covariance survives an
+// unresolved type parameter (as an intersection, their variance was measured
+// structurally, where the matcher makes `E` invariant, and this failed).
+function _widenErr<G>(): Result<number, G | "boom"> {
+  return Err("boom" as const);
+}
+void _widenErr;
+function _widenErrAsync<G>(): AsyncResult<number, G | "boom"> {
+  return ErrAsync("boom" as const);
+}
+void _widenErrAsync;
+function _widenOk<G>(): Result<number, G | "boom"> {
+  return Ok(1);
+}
+void _widenOk;
 
 // --- combinators -------------------------------------------------------------
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -565,10 +565,11 @@ export type ResultMethods<out T, out E> = {
  *
  * @category Types
  */
-export type OkView<T, E = never> = ResultMethods<T, E> & {
+// oxlint-disable-next-line typescript/consistent-type-definitions -- deliberately an interface, not a `type` intersection: interfaces are the only construct that can carry a VERIFIED `out T, out E` variance annotation, which the intersection form silently loses (TS measures intersection variance structurally, where the matcher makes `E` invariant — a concrete `Err` then fails to widen into a generic error union)
+export interface OkView<out T, out E = never> extends ResultMethods<T, E> {
   readonly tag: "Ok";
   readonly value: T;
-};
+}
 /**
  * The `Err` variant of a {@link Result}: a modeled failure carrying an `error`.
  * This is what a successful `isErr` guard narrows to, exposing `.error`. It also
@@ -589,10 +590,11 @@ export type OkView<T, E = never> = ResultMethods<T, E> & {
  *
  * @category Types
  */
-export type ErrView<E, T = never> = ResultMethods<T, E> & {
+// oxlint-disable-next-line typescript/consistent-type-definitions -- see OkView: the variance annotations require an interface
+export interface ErrView<out E, out T = never> extends ResultMethods<T, E> {
   readonly tag: "Err";
   readonly error: E;
-};
+}
 /**
  * The `Defect` variant of a {@link Result}: an unmodeled failure carrying a
  * `cause`. This is what a successful `isDefect` guard narrows to, exposing
@@ -605,10 +607,11 @@ export type ErrView<E, T = never> = ResultMethods<T, E> & {
  *
  * @category Types
  */
-export type DefectView<T = never, E = never> = ResultMethods<T, E> & {
+// oxlint-disable-next-line typescript/consistent-type-definitions -- see OkView: the variance annotations require an interface
+export interface DefectView<out T = never, out E = never> extends ResultMethods<T, E> {
   readonly tag: "Defect";
   readonly cause: unknown;
-};
+}
 
 /**
  * A failure variant of a {@link Result}: an {@link ErrView} **or** a
@@ -952,7 +955,9 @@ export type AsyncResultMethods<out T, out E> = {
  * @typeParam T - the success value type.
  * @typeParam E - the modeled error type.
  */
-export type AsyncResult<T, E> = Awaitable<Result<T, E>> & AsyncResultMethods<T, E>;
+// oxlint-disable-next-line typescript/consistent-type-definitions -- see OkView: the variance annotations require an interface
+export interface AsyncResult<out T, out E>
+  extends Awaitable<Result<T, E>>, AsyncResultMethods<T, E> {}
 
 /**
  * Extract the success type `T` from a `Result` type — derive one type from


### PR DESCRIPTION
## Summary

Fixes the **two remaining v5 inference regressions** that the `@amqp-contract` / `@temporal-contract` adoptions had to work around. Both are proven regressions (identical repros: clean on `4.1.0`, failing on `5.0.0-beta.2`), and both fixes are type-level only — no runtime change, no inference drift elsewhere (every existing `Expect<Equal<…>>` assertion passes unchanged).

This supersedes the "known limitations" record from #122 — the limitation analysis there was correct about intersections, but missed that **interfaces** accept the variance annotations intersections can't.

### 1. A concrete `Err`/`Ok` widens into a generic error union again

```ts
function step<G>(): Result<number, G | RuntimeError> {
  return Err(new RuntimeError()); // ✅ v4 · ❌ v5-beta.2 · ✅ this PR
}
```

The variant views (`OkView`/`ErrView`/`DefectView`) and `AsyncResult` were intersection aliases. An intersection can't carry a variance annotation (TS2637) and gets its variance **measured structurally** — where the v5 exhaustive matcher (`ErrMatcher<E>`, ts-pattern's invariant `Match`) makes `E` invariant — so the declared `out E` on `ResultMethods` was silently lost at the view layer, and widening to unresolved-generic targets failed. (v4 never needed declared variance: its plain `(e: E) => …` callbacks sat in bivariantly-compared method-param positions — the same reason neverthrow's class surface widens without annotations. The exhaustive matcher is what made declared variance mandatory; this is also the shape Effect uses: `interface Left<out E, out A> extends Pipeable`.)

**Fix:** the four types become `interface … extends` carrying **verified** `out T, out E` annotations — semantically identical, TS-verified (TS2636 if unprovable), no eager expansion (the mapped-type flatten alternative hits TS2589). The one sanctioned use of `interface` in core; each carries a targeted `oxlint-disable` with the reason.

### 2. `fromPromise` with an inline `.then` chain infers `T` again

```ts
fromPromise(Promise.resolve().then(() => makeCtx()), qualify)
// v5-beta.2: AsyncResult<unknown, E> · this PR: AsyncResult<Record<string, unknown>, E>
```

The v5 async-qualify ban placed `R & NotThenable<R>` on qualify's **return type**, which made TS defer qualify's inference and collapse `T`. The ban moves to a **phantom rest-tuple guard**: an async qualify now demands an impossible extra argument (carrying the explanatory message), a `[R] extends [never]` carve-out keeps an always-throwing qualify legal, and `T` infers normally. `fromThrowable` keeps `NotThenable` (its `T` infers directly from `fn`; nothing is disturbed).

## Verification

- [x] New `types.test-d.ts` regression guards: generic-union widening (`Err`/`Ok`, sync + async), inline-`.then` inference, always-throwing qualify, and the async-qualify ban still compile-failing
- [x] Full gate: `format --check` · `lint` · `typecheck` (17 pkgs, incl. all `Expect<Equal<…>>` unchanged) · `knip` · `test` (263, core 100% fn/line) · `build` (18) · TypeDoc warning-free
- [x] CLAUDE.md internal-design rewritten as the architecture rule (declared variance requires interfaces; conditional types stay off inference-bearing parameters), replacing the obsolete known-limitations entry; the guide's workaround section removed

Publishes **`unthrown@5.0.0-beta.3`** on merge. Follow-up after release: drop the now-unneeded `Err<E>(...)` / `fromPromise<T,E>(...)` workarounds in amqp-contract #596 and temporal-contract #337.