### PR TITLE
feat(docs): versioned site — stable at root, in-progress beta under /beta/

### DIFF
--- a/.github/scripts/inject-docs-version-nav.mjs
+++ b/.github/scripts/inject-docs-version-nav.mjs
@@ -1,0 +1,44 @@
+// Inject the docs version dropdown into a LEGACY VitePress config — one from a
+// stable tag that predates the native `DOCS_VERSIONS` support in
+// docs/.vitepress/config.ts. The deploy workflow builds the stable site from
+// that tag's own tree (so its docs stay faithful to the released version:
+// pages, sidebar, API reference), and this script patches ONLY the nav so the
+// stable site still offers the version picker.
+//
+// Usage: node inject-docs-version-nav.mjs <path-to-config.ts>
+//   with DOCS_VERSIONS set to the same JSON the native config consumes:
+//   { "current": "v4.3.0 (stable)", "items": [{ "text", "link" }, ...] }
+//
+// No-op (exit 0) when the config already supports DOCS_VERSIONS natively —
+// once the latest stable tag is >= the version that shipped native support,
+// this script stops doing anything and can be deleted.
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+const [, , configPath] = process.argv;
+const raw = process.env.DOCS_VERSIONS;
+if (!configPath || !raw) {
+  console.error("usage: DOCS_VERSIONS='{...}' node inject-docs-version-nav.mjs <config.ts>");
+  process.exit(1);
+}
+
+const source = readFileSync(configPath, "utf8");
+
+if (source.includes("DOCS_VERSIONS")) {
+  console.log("config supports DOCS_VERSIONS natively — no injection needed");
+  process.exit(0);
+}
+
+const versions = JSON.parse(raw);
+const entry = `      // Version dropdown — injected at deploy time (this tag predates native
+      // DOCS_VERSIONS support in the config; see inject-docs-version-nav.mjs).
+      ${JSON.stringify({ text: versions.current, items: versions.items })},\n`;
+
+const anchor = "    nav: [\n";
+if (!source.includes(anchor)) {
+  console.error(`no \`nav: [\` anchor found in ${configPath} — layout changed, refusing to guess`);
+  process.exit(1);
+}
+
+writeFileSync(configPath, source.replace(anchor, anchor + entry));
+console.log(`injected version dropdown into ${configPath}`);

--- a/.github/scripts/inject-docs-version-nav.ts
+++ b/.github/scripts/inject-docs-version-nav.ts
@@ -5,9 +5,9 @@
 // pages, sidebar, API reference), and this script patches ONLY the nav so the
 // stable site still offers the version picker.
 //
-// Usage: node inject-docs-version-nav.mjs <path-to-config.ts>
+// Usage: pnpm --filter ./docs exec tsx inject-docs-version-nav.ts <config.ts>
 //   with DOCS_VERSIONS set to the same JSON the native config consumes:
-//   { "current": "v4.3.0 (stable)", "items": [{ "text", "link" }, ...] }
+//   { "current": "v4.3.0", "items": [{ "text", "link" }, ...] }
 //
 // No-op (exit 0) when the config already supports DOCS_VERSIONS natively —
 // once the latest stable tag is >= the version that shipped native support,
@@ -15,10 +15,15 @@
 
 import { readFileSync, writeFileSync } from "node:fs";
 
+type VersionMenu = {
+  current: string;
+  items: { text: string; link: string }[];
+};
+
 const [, , configPath] = process.argv;
-const raw = process.env.DOCS_VERSIONS;
+const raw = process.env["DOCS_VERSIONS"];
 if (!configPath || !raw) {
-  console.error("usage: DOCS_VERSIONS='{...}' node inject-docs-version-nav.mjs <config.ts>");
+  console.error("usage: DOCS_VERSIONS='{...}' tsx inject-docs-version-nav.ts <config.ts>");
   process.exit(1);
 }
 
@@ -29,9 +34,9 @@ if (source.includes("DOCS_VERSIONS")) {
   process.exit(0);
 }
 
-const versions = JSON.parse(raw);
+const versions = JSON.parse(raw) as VersionMenu;
 const entry = `      // Version dropdown — injected at deploy time (this tag predates native
-      // DOCS_VERSIONS support in the config; see inject-docs-version-nav.mjs).
+      // DOCS_VERSIONS support in the config; see inject-docs-version-nav.ts).
       ${JSON.stringify({ text: versions.current, items: versions.items })},\n`;
 
 const anchor = "    nav: [\n";

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,6 +3,12 @@ name: Deploy Documentation
 # Publish docs when a version is released (changesets creates a GitHub Release on publish), so the
 # site documents the latest *released* library — and also when the docs themselves change on main
 # (theme bumps, content edits), since those need no library release to be worth shipping.
+#
+# Versioned deploys: while a prerelease is in progress (`.changeset/pre.json` on main), the site is
+# built TWICE — the latest stable tag's docs at the root (the default a visitor lands on) and
+# main's docs under /beta/ — with a version dropdown linking the two. When no prerelease is in
+# progress, main IS the stable line and deploys alone to the root, exactly as before. Pages deploys
+# replace the whole site, so every run assembles all versions into one artifact.
 on:
   release:
     types: [published]
@@ -12,6 +18,7 @@ on:
       - "docs/**"
       - "pnpm-workspace.yaml"
       - ".github/workflows/deploy-docs.yml"
+      - ".github/scripts/inject-docs-version-nav.mjs"
   workflow_dispatch:
 
 permissions:
@@ -34,17 +41,85 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # Full history + tags: the stable site is built from the latest stable tag.
+          fetch-depth: 0
 
       - name: Setup
         uses: ./.github/actions/setup
 
-      - name: Build documentation
+      - name: Determine versions
+        id: meta
+        run: |
+          stable_tag=$(git tag -l 'unthrown@*' | grep -v -- '-' | sort -t@ -k2 -V | tail -1)
+          stable_version="${stable_tag#unthrown@}"
+          echo "stable_tag=$stable_tag" >> "$GITHUB_OUTPUT"
+          echo "stable_version=$stable_version" >> "$GITHUB_OUTPUT"
+          if [ -f .changeset/pre.json ]; then
+            beta_version=$(node -p "require('./packages/core/package.json').version")
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "beta_version=$beta_version" >> "$GITHUB_OUTPUT"
+            STABLE_VERSION="$stable_version" BETA_VERSION="$beta_version" node -e "
+              const stable = {
+                text: 'v' + process.env.STABLE_VERSION + ' (stable)',
+                link: 'https://btravstack.github.io/unthrown/',
+              };
+              const beta = {
+                text: 'v' + process.env.BETA_VERSION + ' (beta)',
+                link: 'https://btravstack.github.io/unthrown/beta/',
+              };
+              const out = [
+                'versions_stable=' + JSON.stringify({ current: 'v' + process.env.STABLE_VERSION, items: [stable, beta] }),
+                'versions_beta=' + JSON.stringify({ current: 'v' + process.env.BETA_VERSION, items: [stable, beta] }),
+                '',
+              ].join('\n');
+              require('fs').appendFileSync(process.env.GITHUB_OUTPUT, out);
+            "
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # --- Single-version path: main is the stable line; deploy it alone to the root. ---
+      - name: Build documentation (stable line)
+        if: steps.meta.outputs.prerelease == 'false'
+        run: |
+          pnpm --filter ./docs exec turbo build
+          mkdir -p site
+          cp -r docs/.vitepress/dist/* site/
+
+      # --- Versioned path: stable tag at the root, main under /beta/. ---
+      - name: Build beta documentation (main)
+        if: steps.meta.outputs.prerelease == 'true'
+        env:
+          DOCS_BASE: /unthrown/beta/
+          DOCS_VERSIONS: ${{ steps.meta.outputs.versions_beta }}
         run: pnpm --filter ./docs exec turbo build
+
+      - name: Build stable documentation (latest stable tag)
+        if: steps.meta.outputs.prerelease == 'true'
+        env:
+          DOCS_VERSIONS: ${{ steps.meta.outputs.versions_stable }}
+        run: |
+          git worktree add /tmp/stable-docs "${{ steps.meta.outputs.stable_tag }}"
+          cd /tmp/stable-docs
+          pnpm install --frozen-lockfile
+          # A tag that predates native DOCS_VERSIONS support in the config gets the
+          # version dropdown injected; a no-op once the stable tag carries it natively.
+          node "$GITHUB_WORKSPACE/.github/scripts/inject-docs-version-nav.mjs" \
+            docs/.vitepress/config.ts
+          pnpm --filter ./docs exec turbo build
+
+      - name: Assemble versioned site
+        if: steps.meta.outputs.prerelease == 'true'
+        run: |
+          mkdir -p site/beta
+          cp -r /tmp/stable-docs/docs/.vitepress/dist/* site/
+          cp -r docs/.vitepress/dist/* site/beta/
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         with:
-          path: docs/.vitepress/dist
+          path: site
 
   deploy:
     environment:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,7 +18,7 @@ on:
       - "docs/**"
       - "pnpm-workspace.yaml"
       - ".github/workflows/deploy-docs.yml"
-      - ".github/scripts/inject-docs-version-nav.mjs"
+      - ".github/scripts/inject-docs-version-nav.ts"
   workflow_dispatch:
 
 permissions:
@@ -101,12 +101,13 @@ jobs:
           DOCS_VERSIONS: ${{ steps.meta.outputs.versions_stable }}
         run: |
           git worktree add /tmp/stable-docs "${{ steps.meta.outputs.stable_tag }}"
-          cd /tmp/stable-docs
-          pnpm install --frozen-lockfile
           # A tag that predates native DOCS_VERSIONS support in the config gets the
           # version dropdown injected; a no-op once the stable tag carries it natively.
-          node "$GITHUB_WORKSPACE/.github/scripts/inject-docs-version-nav.mjs" \
-            docs/.vitepress/config.ts
+          # (Runs with the main checkout's docs toolchain — tsx lives there.)
+          pnpm --filter ./docs exec tsx "$GITHUB_WORKSPACE/.github/scripts/inject-docs-version-nav.ts" \
+            /tmp/stable-docs/docs/.vitepress/config.ts
+          cd /tmp/stable-docs
+          pnpm install --frozen-lockfile
           pnpm --filter ./docs exec turbo build
 
       - name: Assemble versioned site

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -632,7 +632,7 @@ code: "NOT_FOUND" }, …))`); non-inferable →
   under `/beta/`, linked by a nav version dropdown (`DOCS_BASE` /
   `DOCS_VERSIONS` env in the VitePress config; a legacy tag without native
   support gets the dropdown injected by
-  `.github/scripts/inject-docs-version-nav.mjs`). With no prerelease, main
+  `.github/scripts/inject-docs-version-nav.ts`). With no prerelease, main
   deploys alone to the root as before
 
 Core depends on `ts-pattern` (it powers the error matchers). Never pull

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -626,7 +626,14 @@ code: "NOT_FOUND" }, …))`); non-inferable →
 - `tools/tsconfig`, `tools/typedoc` → private shared config (`@unthrown/tsconfig`,
   `@unthrown/typedoc`)
 - `docs` → `@unthrown/docs`, the VitePress site (guide + TypeDoc-generated API
-  reference); deployed to GitHub Pages by `deploy-docs.yml`
+  reference); deployed to GitHub Pages by `deploy-docs.yml` — **versioned**:
+  while a prerelease is in progress (`.changeset/pre.json` on main) the site is
+  built twice, the latest stable tag's docs at the root (the default) and main's
+  under `/beta/`, linked by a nav version dropdown (`DOCS_BASE` /
+  `DOCS_VERSIONS` env in the VitePress config; a legacy tag without native
+  support gets the dropdown injected by
+  `.github/scripts/inject-docs-version-nav.mjs`). With no prerelease, main
+  deploys alone to the root as before
 
 Core depends on `ts-pattern` (it powers the error matchers). Never pull
 `vitest` or any interop peer (`effect`, `neverthrow`, `@bloodyowl/boxed`,

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -8,7 +8,10 @@ const SITE_DESCRIPTION =
 // base to /unthrown/beta/ via DOCS_BASE; the stable site (built from the latest
 // stable tag) stays at the root. Absent env — local dev, plain builds — keeps
 // today's root base.
-const BASE = process.env.DOCS_BASE ?? "/unthrown/";
+// Normalized to a guaranteed leading + trailing slash — a DOCS_BASE typed
+// without one in CI must not corrupt asset routing or canonical URLs.
+const RAW_BASE = process.env.DOCS_BASE ?? "/unthrown/";
+const BASE = `/${RAW_BASE.replace(/^\/+|\/+$/g, "")}/`;
 const SITE_URL = `https://btravstack.github.io${BASE}`;
 
 // DOCS_VERSIONS — the marker the deploy workflow probes for to detect native

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -3,11 +3,35 @@ import { defineConfig } from "vitepress";
 const SITE_DESCRIPTION =
   "Explicit errors as values for TypeScript, with a separate defect channel for the unexpected and qualification enforced at every boundary.";
 
+// Versioned deploys (deploy-docs.yml): while a prerelease is in progress the
+// workflow builds main's docs a second time as the "beta" site, overriding the
+// base to /unthrown/beta/ via DOCS_BASE; the stable site (built from the latest
+// stable tag) stays at the root. Absent env — local dev, plain builds — keeps
+// today's root base.
+const BASE = process.env.DOCS_BASE ?? "/unthrown/";
+const SITE_URL = `https://btravstack.github.io${BASE}`;
+
+// DOCS_VERSIONS — the marker the deploy workflow probes for to detect native
+// version-picker support (legacy tags without it get the dropdown injected at
+// build time instead). JSON: { current: string, items: { text, link }[] } —
+// rendered as a dropdown at the end of the nav, linking every deployed version
+// with absolute URLs (cross-version links must not inherit this build's base).
+// Absent env → no dropdown (single-version site, local dev).
+const DOCS_VERSIONS = process.env.DOCS_VERSIONS
+  ? (JSON.parse(process.env.DOCS_VERSIONS) as {
+      current: string;
+      items: { text: string; link: string }[];
+    })
+  : undefined;
+const VERSION_NAV = DOCS_VERSIONS
+  ? [{ text: DOCS_VERSIONS.current, items: DOCS_VERSIONS.items }]
+  : [];
+
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   title: "unthrown",
   description: SITE_DESCRIPTION,
-  base: "/unthrown/",
+  base: BASE,
   lang: "en-US",
   cleanUrls: true,
 
@@ -16,7 +40,7 @@ export default defineConfig({
   ignoreDeadLinks: [/^\/api\//, /^\.\/index$/, /^\.\/[a-z-]+$/, /^\.\.\//],
 
   sitemap: {
-    hostname: "https://btravstack.github.io/unthrown/",
+    hostname: SITE_URL,
   },
 
   // Per-page canonical URL + Open Graph / Twitter title & description, so every
@@ -29,7 +53,7 @@ export default defineConfig({
     const normalizedPath = pageData.relativePath.replace(/^\/+/, "");
     // cleanUrls is true, so the public URL has no `.html` extension: strip
     // `index.md` to the directory and any other `.md` to the bare route.
-    const canonicalUrl = `https://btravstack.github.io/unthrown/${normalizedPath}`
+    const canonicalUrl = `${SITE_URL}${normalizedPath}`
       .replace(/index\.md$/, "")
       .replace(/\.md$/, "");
 
@@ -70,6 +94,8 @@ export default defineConfig({
       },
       // Back to the btravstack hub (links the docs up to the landing page).
       { text: "btravstack", link: "https://btravstack.github.io/" },
+      // Version dropdown (stable / beta), present only on versioned deploys.
+      ...VERSION_NAV,
     ],
 
     sidebar: {

--- a/knip.json
+++ b/knip.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "ignoreExportsUsedInFile": true,
-  "ignore": ["**/*.test-d.ts"],
+  "ignore": ["**/*.test-d.ts", ".github/scripts/**"],
   "workspaces": {
     "packages/*": {
       "project": ["src/**/*.ts"]

--- a/packages/core/src/interop.ts
+++ b/packages/core/src/interop.ts
@@ -202,11 +202,16 @@ export function fromPromise<T, R>(
   // With the conditional here instead, an async qualify demands an impossible
   // third argument (compile error carrying the message) while `T`/`R` infer
   // normally. Nothing is ever passed at runtime.
-  ..._guard: [R] extends [never]
-    ? [] // a qualify that always throws returns `never` — legal (the throw is a Defect)
-    : [R] extends [PromiseLike<unknown>]
-      ? ["unthrown: qualify must be synchronous — its Promise would land in E un-triaged"]
-      : []
+  //
+  // `Extract` (not `[R] extends [PromiseLike<…>]`) so the ban also fires when
+  // only SOME arms of a union return are thenable (`E | Promise<X>` — a
+  // sometimes-async qualify is still an unqualified rejection path), and it
+  // vacuously admits the always-throwing qualify (`R = never` extracts to
+  // `never`) with no special case. The runtime thenable→Defect net in
+  // `qualifyToResult` stays as the last resort for untyped callers.
+  ..._guard: [Extract<R, PromiseLike<unknown>>] extends [never]
+    ? []
+    : ["unthrown: qualify must be synchronous — its Promise would land in E un-triaged"]
 ): AsyncResult<T, Exclude<R, Defect>> {
   type E = Exclude<R, Defect>;
   const triage = qualify as (cause: unknown, defect: (cause: unknown) => Defect) => E | Defect;

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -136,6 +136,12 @@ const asyncQualify = async (c: unknown) => c;
 fromPromise(Promise.resolve(1), asyncQualify);
 // @ts-expect-error - an async qualify is banned on fromThrowable
 fromThrowable(() => 1, asyncQualify);
+// …and so is a SOMETIMES-thenable one (a union return with a thenable arm) —
+// the guard extracts the thenable arms, so a conditional `Promise` can't slip
+// an unqualified rejection path past the ban either
+const sometimesAsyncQualify = (c: unknown) => (c ? Promise.resolve("late") : ("e" as const));
+// @ts-expect-error - a union return with a thenable arm is banned on fromPromise
+fromPromise(Promise.resolve(1), sometimesAsyncQualify);
 
 // REGRESSION GUARD: an inline `.then` chain as the promise argument keeps its
 // value type (it collapsed to `unknown` while the ban lived on qualify's

--- a/turbo.json
+++ b/turbo.json
@@ -28,7 +28,8 @@
     },
     "@unthrown/docs#build": {
       "dependsOn": ["^build", "^build:docs"],
-      "outputs": [".vitepress/dist/**"]
+      "outputs": [".vitepress/dist/**"],
+      "env": ["DOCS_BASE", "DOCS_VERSIONS"]
     }
   }
 }


### PR DESCRIPTION
## Summary

The docs site always published `main` — so the live site currently documents the **v5 beta** while the stable npm release is **4.3.0**. This makes the site versioned:

- **Default** (`/unthrown/`): the docs of the **latest stable release**, built from its git tag (`unthrown@4.3.0` today) — faithful to that version: its own pages, sidebar, and API reference (e.g. the `pattern-matching` guide that v5 removed is still there).
- **Beta** (`/unthrown/beta/`): `main`'s docs, published **only while a prerelease is in progress** (`.changeset/pre.json` present).
- A **version dropdown** in the nav links the two, both ways.
- With no prerelease in progress, `main` *is* the stable line and deploys alone to the root — exactly today's behavior. When `5.0.0` ships and pre-mode exits, the site automatically collapses back to single-version.

## How

- **`docs/.vitepress/config.ts`** — `DOCS_BASE` (drives `base`, sitemap hostname, canonical URLs) and `DOCS_VERSIONS` (the dropdown, absolute cross-version links) come from env. No env → today's behavior, so local dev is untouched. `turbo.json` declares both env keys so the docs build caches correctly.
- **`deploy-docs.yml`** — computes the latest stable tag + prerelease state; on the versioned path builds main with `DOCS_BASE=/unthrown/beta/`, builds the stable tag in a git worktree (its own lockfile/toolchain), and assembles one Pages artifact (deploys replace the whole site, so every run carries all versions).
- **`.github/scripts/inject-docs-version-nav.mjs`** — a stable tag predating the native `DOCS_VERSIONS` support (4.3.0 does) gets the dropdown injected into its config at build time; automatic no-op once the stable tag carries native support, then deletable.

## Verification (full local rehearsal of both workflow paths)

- [x] Beta path: main built with the env overrides → asset URLs on `/unthrown/beta/`, dropdown rendered with both versions
- [x] Stable path: `unthrown@4.3.0` built from a worktree with injection → root base preserved, dropdown present, 4.3.0-only pages intact
- [x] Assembly: combined artifact serves root + `/beta/`
- [x] `format --check` · `lint` · `knip` clean (CI script added to knip ignore)

On merge, the push (touching `docs/**`) triggers the first versioned deploy: **root flips from the beta docs to stable 4.3.0**, and the beta docs move to `/unthrown/beta/`.