### PR TITLE
fix(docs): consistent dropdown position, same-tab and same-page version switch

### DIFF
--- a/.github/scripts/inject-docs-version-nav.ts
+++ b/.github/scripts/inject-docs-version-nav.ts
@@ -1,32 +1,41 @@
-// Inject the docs version dropdown into a LEGACY VitePress config — one from a
-// stable tag that predates the native `DOCS_VERSIONS` support in
+// Inject the docs version dropdown into a LEGACY VitePress site — one built
+// from a stable tag that predates the native `DOCS_VERSIONS` support in
 // docs/.vitepress/config.ts. The deploy workflow builds the stable site from
 // that tag's own tree (so its docs stay faithful to the released version:
-// pages, sidebar, API reference), and this script patches ONLY the nav so the
-// stable site still offers the version picker.
+// pages, sidebar, API reference), and this script patches ONLY the version UI:
 //
-// Usage: pnpm --filter ./docs exec tsx inject-docs-version-nav.ts <config.ts>
+// 1. the nav — the dropdown is inserted right AFTER the `btravstack` hub item,
+//    the same position the native config appends it, so the picker sits in the
+//    same place on every version of the site;
+// 2. the theme — the same-page/same-tab switch enhancement (the runtime click
+//    interceptor `docs/.vitepress/theme/version-switch.ts` ships natively) is
+//    appended to the tag's theme entry, so switching versions from a legacy
+//    site also preserves the visitor's place.
+//
+// Usage: tsx inject-docs-version-nav.ts <path-to-docs/.vitepress>
 //   with DOCS_VERSIONS set to the same JSON the native config consumes:
-//   { "current": "v4.3.0", "items": [{ "text", "link" }, ...] }
+//   { "current": "v4.3.0", "items": [{ "text", "link", "target" }, ...] }
 //
 // No-op (exit 0) when the config already supports DOCS_VERSIONS natively —
 // once the latest stable tag is >= the version that shipped native support,
 // this script stops doing anything and can be deleted.
 
 import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 type VersionMenu = {
   current: string;
-  items: { text: string; link: string }[];
+  items: { text: string; link: string; target?: string }[];
 };
 
-const [, , configPath] = process.argv;
+const [, , vitepressDir] = process.argv;
 const raw = process.env["DOCS_VERSIONS"];
-if (!configPath || !raw) {
-  console.error("usage: DOCS_VERSIONS='{...}' tsx inject-docs-version-nav.ts <config.ts>");
+if (!vitepressDir || !raw) {
+  console.error("usage: DOCS_VERSIONS='{...}' tsx inject-docs-version-nav.ts <docs/.vitepress>");
   process.exit(1);
 }
 
+const configPath = join(vitepressDir, "config.ts");
 const source = readFileSync(configPath, "utf8");
 
 if (source.includes("DOCS_VERSIONS")) {
@@ -34,16 +43,60 @@ if (source.includes("DOCS_VERSIONS")) {
   process.exit(0);
 }
 
+// --- 1. Nav dropdown, positioned as the native config positions it. ---
 const versions = JSON.parse(raw) as VersionMenu;
+const anchor = `      { text: "btravstack", link: "https://btravstack.github.io/" },\n`;
+if (!source.includes(anchor)) {
+  console.error(
+    `no btravstack nav anchor found in ${configPath} — layout changed, refusing to guess`,
+  );
+  process.exit(1);
+}
 const entry = `      // Version dropdown — injected at deploy time (this tag predates native
       // DOCS_VERSIONS support in the config; see inject-docs-version-nav.ts).
       ${JSON.stringify({ text: versions.current, items: versions.items })},\n`;
-
-const anchor = "    nav: [\n";
-if (!source.includes(anchor)) {
-  console.error(`no \`nav: [\` anchor found in ${configPath} — layout changed, refusing to guess`);
-  process.exit(1);
-}
-
 writeFileSync(configPath, source.replace(anchor, anchor + entry));
 console.log(`injected version dropdown into ${configPath}`);
+
+// --- 2. Same-page/same-tab switch enhancement, appended to the theme entry. ---
+// Inlined (not imported from the main tree) so the patched tag tree stays
+// self-contained; keep in sync with docs/.vitepress/theme/version-switch.ts.
+const themePath = join(vitepressDir, "theme", "index.ts");
+const theme = readFileSync(themePath, "utf8");
+const enhancement = `
+// Same-page/same-tab version switching — appended at deploy time (this tag
+// predates the native docs/.vitepress/theme/version-switch.ts).
+if (typeof window !== "undefined") {
+  document.addEventListener(
+    "click",
+    (event) => {
+      const target = event.target instanceof Element ? event.target : null;
+      const anchor = target?.closest("a[href]");
+      const match = anchor
+        ?.getAttribute("href")
+        ?.match(/^https:\\/\\/btravstack\\.github\\.io(\\/unthrown\\/(?:beta\\/)?)$/);
+      if (!anchor || !match?.[1]) {
+        return;
+      }
+      const targetBase = match[1];
+      const ownBase = import.meta.env.BASE_URL;
+      if (targetBase === ownBase) {
+        return;
+      }
+      const path = window.location.pathname.startsWith(ownBase)
+        ? window.location.pathname.slice(ownBase.length)
+        : "";
+      event.preventDefault();
+      window.location.href =
+        "https://btravstack.github.io" +
+        targetBase +
+        path +
+        window.location.search +
+        window.location.hash;
+    },
+    true,
+  );
+}
+`;
+writeFileSync(themePath, theme + enhancement);
+console.log(`appended version-switch enhancement to ${themePath}`);

--- a/.github/scripts/inject-docs-version-nav.ts
+++ b/.github/scripts/inject-docs-version-nav.ts
@@ -70,6 +70,16 @@ if (typeof window !== "undefined") {
   document.addEventListener(
     "click",
     (event) => {
+      if (
+        event.defaultPrevented ||
+        event.button !== 0 ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.altKey
+      ) {
+        return; // modified or non-left click — keep native new-tab/window behavior
+      }
       const target = event.target instanceof Element ? event.target : null;
       const anchor = target?.closest("a[href]");
       const match = anchor

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -60,13 +60,18 @@ jobs:
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
             echo "beta_version=$beta_version" >> "$GITHUB_OUTPUT"
             STABLE_VERSION="$stable_version" BETA_VERSION="$beta_version" node -e "
+              // target: '_self' — cross-version links are same-site; without it
+              // VitePress treats the absolute URLs as external and opens a new tab
+              // (the client-side enhancement also preserves the current page).
               const stable = {
                 text: 'v' + process.env.STABLE_VERSION + ' (stable)',
                 link: 'https://btravstack.github.io/unthrown/',
+                target: '_self',
               };
               const beta = {
                 text: 'v' + process.env.BETA_VERSION + ' (beta)',
                 link: 'https://btravstack.github.io/unthrown/beta/',
+                target: '_self',
               };
               const out = [
                 'versions_stable=' + JSON.stringify({ current: 'v' + process.env.STABLE_VERSION, items: [stable, beta] }),
@@ -105,7 +110,7 @@ jobs:
           # version dropdown injected; a no-op once the stable tag carries it natively.
           # (Runs with the main checkout's docs toolchain — tsx lives there.)
           pnpm --filter ./docs exec tsx "$GITHUB_WORKSPACE/.github/scripts/inject-docs-version-nav.ts" \
-            /tmp/stable-docs/docs/.vitepress/config.ts
+            /tmp/stable-docs/docs/.vitepress
           cd /tmp/stable-docs
           pnpm install --frozen-lockfile
           pnpm --filter ./docs exec turbo build

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,5 +1,10 @@
 import Theme from "@btravstack/theme";
 
 import "./custom.css";
+import { setupVersionSwitch } from "./version-switch.js";
+
+// Same-page, same-tab switching for the docs version dropdown (no-op in SSR
+// and on single-version deploys, where no version links exist to intercept).
+setupVersionSwitch();
 
 export default Theme;

--- a/docs/.vitepress/theme/version-switch.ts
+++ b/docs/.vitepress/theme/version-switch.ts
@@ -1,0 +1,42 @@
+// Same-page version switching. The nav's version dropdown links each deployed
+// version's ROOT (a static site can do no better, and with JS disabled that
+// link still works) — this runtime enhancement intercepts those clicks and
+// preserves the visitor's place: /unthrown/guide/boundaries switches to
+// /unthrown/beta/guide/boundaries, same tab, search + hash included. A page
+// missing from the target version lands on its 404 (which carries the nav to
+// recover) — versions legitimately differ in page sets.
+//
+// The deploy workflow appends this same logic to a legacy stable tag's theme
+// (see .github/scripts/inject-docs-version-nav.ts), so keep it dependency-free
+// and self-contained.
+
+const VERSION_ROOT = /^https:\/\/btravstack\.github\.io(\/unthrown\/(?:beta\/)?)$/;
+
+export function setupVersionSwitch(): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  document.addEventListener(
+    "click",
+    (event) => {
+      const target = event.target instanceof Element ? event.target : null;
+      const anchor = target?.closest("a[href]");
+      const match = anchor?.getAttribute("href")?.match(VERSION_ROOT);
+      if (!anchor || !match?.[1]) {
+        return;
+      }
+      const targetBase = match[1];
+      // Vite injects this build's own base (/unthrown/ or /unthrown/beta/).
+      const ownBase = import.meta.env.BASE_URL;
+      if (targetBase === ownBase) {
+        return; // the current version — let the plain link do its thing
+      }
+      const path = window.location.pathname.startsWith(ownBase)
+        ? window.location.pathname.slice(ownBase.length)
+        : "";
+      event.preventDefault();
+      window.location.href = `https://btravstack.github.io${targetBase}${path}${window.location.search}${window.location.hash}`;
+    },
+    true,
+  );
+}

--- a/docs/.vitepress/theme/version-switch.ts
+++ b/docs/.vitepress/theme/version-switch.ts
@@ -19,6 +19,16 @@ export function setupVersionSwitch(): void {
   document.addEventListener(
     "click",
     (event) => {
+      if (
+        event.defaultPrevented ||
+        event.button !== 0 ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.altKey
+      ) {
+        return; // modified or non-left click — keep native new-tab/window behavior
+      }
       const target = event.target instanceof Element ? event.target : null;
       const anchor = target?.closest("a[href]");
       const match = anchor?.getAttribute("href")?.match(VERSION_ROOT);


### PR DESCRIPTION
## Summary

Follow-up to #125 (merged while these fixes were in flight — they landed on a deleted branch, hence this fresh PR). Three UX fixes for the docs version dropdown, each verified on both the stable-tag and beta builds:

1. **Consistent position** — the legacy inject inserted the dropdown *first* in the 4.3.0 nav while the native config appends it *last*. The inject script now anchors on the `btravstack` hub item and inserts right after it — the same slot the native config uses — so the picker sits in the same place on every version of the site.
2. **Same tab** — VitePress treats the absolute cross-version URLs as external and opened a new tab; the version items now carry `target: "_self"` (composed once in the workflow's `DOCS_VERSIONS`, so native and injected navs both get it).
3. **Same page** — new `docs/.vitepress/theme/version-switch.ts`: a client-side interceptor that preserves the visitor's path, query, and hash across versions (`/guide/boundaries` → `/beta/guide/boundaries`), instead of dropping to the target's home page. Ships natively on main; the inject script appends the same logic (inlined, self-contained) to a legacy tag's theme so switching *from* the stable site preserves the place too. Degrades gracefully: no-JS falls back to the plain root link; a page absent from the target version lands on its 404 (which carries the nav).

## Verification (local rehearsal, both paths)

- [x] Stable (4.3.0 tag + inject): dropdown positioned after `btravstack`, interceptor present in the minified theme chunk, build green
- [x] Beta (main, env-driven): same nav order, `target="_self"` rendered, interceptor in the theme chunk
- [x] Native no-op: running the inject against main's config exits 0 untouched
- [x] `format --check` · `lint` · `knip` clean