### PR TITLE
docs: record the error-matcher naming decision as settled

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -740,5 +740,19 @@ configured outside the repo).
 - Public API carries full **TSDoc**; `pnpm --filter <pkg> build:docs` must stay
   typedoc-warning-free.
 - One concept = one name. Resist convenience aliases.
+- **The error combinators keep their conventional `map*`/`flatMap*`/`tap*`
+  names despite the matcher protocol — a weighed, settled decision (2026-07,
+  do not re-litigate).** The names nominally promise the FP functor contract
+  (callback receives the value) while the callback actually receives the
+  matcher; that break is deliberate: `E` is a union, and a direct `(e: E) => …`
+  callback over a union is the blanket handler Thesis #5 exists to eliminate.
+  The names were kept because they state the channel and the pipeline effect,
+  preserve the operator × channel symmetry with the success surface, and stay
+  greppable for migrants from neverthrow/fp-ts. Alternatives considered and
+  rejected: plural channel names (`mapErrs` — singular-gives-entity /
+  plural-gives-matcher rule; too subtle), explicit `*ErrCases` (too long), and
+  collapsing to `catchErrs` + observers (loses the verb symmetry). Do NOT add
+  plain-callback variants alongside (reopens blanket handling). The break is
+  documented user-side in the core-concepts guide.
 - The core has **one runtime dependency, `ts-pattern`** (it powers the error
   matchers and is re-exported). Add no others — protect that minimalism.

--- a/docs/guide/core-concepts.md
+++ b/docs/guide/core-concepts.md
@@ -32,12 +32,28 @@ Every `Result` shares one method surface, grouped by the channel it touches:
   every case is handled explicitly and a new error type is a compile error at
   every consuming site (see
   [Choosing a combinator](./choosing-a-combinator#triaging-the-error-channel))
+
 - **defect** (the only door to a `Defect`): `recoverDefect`, `tapDefect`
 - **failure** (runs on `Err` **or** `Defect`): `tapFailure` — observe either
   failing channel without consuming it
 - **eliminate**: `match`, `get`, `getErr`, `getOr`, `getOrElse`,
   `getOrNull`, `getOrUndefined`, `getOrThrow` (gated as `get`'s complement — it
   compiles only while the error channel is non-empty)
+
+::: info A deliberate convention break
+In functional-programming convention, `map`/`tap` names promise a callback that
+receives the contained value directly — and on the success channel they keep
+that promise. The error combinators **break it on purpose**: their callback
+receives the _matcher_, not the error. The reason is the channels' shapes. `T`
+is one type, so there is a single value to hand you; `E` is a **union of
+possibilities**, and a plain `(e: E) => …` callback over a union is precisely
+the blanket handler this library exists to eliminate — it keeps compiling,
+silently incomplete, when `E` grows. Each matcher _branch_ still hands you the
+error directly, narrowed to its exact case. The conventional names are kept
+because they say _which channel and what happens to the pipeline_ (`mapErr`
+transforms the error channel, `tapErr` observes it) — only the callback
+protocol differs, and the signature teaches that on first use.
+:::
 
 A combinator only runs its callback on its own channel — the other states flow
 through untouched:


### PR DESCRIPTION
## Summary

Closes out the design discussion on the v5 error combinators' naming: `mapErr`/`flatMapErr`/`tapErr`/`flatTapErr`/`recoverErr` **keep their conventional names** despite receiving a matcher instead of the error value.

- **CLAUDE.md** — the decision recorded as settled (with the rejected alternatives: plural `*Errs` channel names, explicit `*ErrCases`, collapsing to `catchErrs` + observers), plus the standing rule: no plain-callback variants alongside — that would reopen the blanket handling the matcher exists to eliminate.
- **core-concepts guide** — an honest user-facing aside at the point the matcher is introduced: why the FP `map` contract is deliberately broken on the error channel (a union has no single value to hand you; a direct callback over a union is silently incomplete when `E` grows), and that each matcher *branch* still receives the error directly, narrowed.

Docs-only; site builds clean.