### PR TITLE
refactor!: rename error-matcher combinators to the *Cases form

### DIFF
--- a/.changeset/exhaustive-error-matcher.md
+++ b/.changeset/exhaustive-error-matcher.md
@@ -13,7 +13,7 @@ calls `.exhaustive()` for you:
 import { P, tag } from "unthrown";
 
 // before
-result.mapErrCases((error) => {
+result.mapErr((error) => {
   if (error._tag === "RecordNotFound") return new NotFoundException(id);
   throw error.cause; // silent fallthrough — a future tag lands here unnoticed
 });

--- a/.changeset/exhaustive-error-matcher.md
+++ b/.changeset/exhaustive-error-matcher.md
@@ -3,8 +3,8 @@
 ---
 
 **The error channel is now matched exhaustively with ts-pattern** (Thesis #5).
-The error combinators — `mapErr`, `flatMapErr`, `recoverErr`, `tapErr`,
-`flatTapErr` — no longer take a plain callback. Their callback receives a
+The error combinators — `mapErrCases`, `flatMapErrCases`, `recoverErrCases`, `tapErrCases`,
+`flatTapErrCases` — no longer take a plain callback. Their callback receives a
 ts-pattern match builder over the error (`match(error)`) plus the injected
 `defect` helper, and **returns the un-terminated builder** — the combinator
 calls `.exhaustive()` for you:
@@ -13,13 +13,13 @@ calls `.exhaustive()` for you:
 import { P, tag } from "unthrown";
 
 // before
-result.mapErr((error) => {
+result.mapErrCases((error) => {
   if (error._tag === "RecordNotFound") return new NotFoundException(id);
   throw error.cause; // silent fallthrough — a future tag lands here unnoticed
 });
 
 // after — exhaustive; the type checker forces every case to be handled
-result.mapErr((matcher, defect) =>
+result.mapErrCases((matcher, defect) =>
   matcher
     .with(tag("RecordNotFound"), () => new NotFoundException(id))
     .with(tag("DriverError"), (e) => defect(e.cause)),
@@ -43,7 +43,7 @@ no `.exhaustive()` to forget and no `.otherwise()` to smuggle in a fallback.
   (`.with(tag("X"), (e) => defect(e.cause))`); its `Defect` arm is subtracted
   from the outgoing `E` (`Exclude<O, Defect>`, the boundary inference). A
   throwing branch also becomes a `Defect` (the safety net).
-- **Observers match exhaustively too** (`tapErr`/`flatTapErr`, use `P._` for a
+- **Observers match exhaustively too** (`tapErrCases`/`flatTapErrCases`, use `P._` for a
   catch-all); the error is observed and flows through unchanged.
 
 **Core now depends on `ts-pattern`** (a small, types-heavy, dual-copy-safe

--- a/.changeset/rename-err-combinators-cases.md
+++ b/.changeset/rename-err-combinators-cases.md
@@ -1,0 +1,23 @@
+---
+"unthrown": major
+---
+
+**The error-matcher combinators are renamed with a `*Cases` suffix.** `mapErr`,
+`flatMapErr`, `recoverErr`, `tapErr`, and `flatTapErr` become `mapErrCases`,
+`flatMapErrCases`, `recoverErrCases`, `tapErrCases`, and `flatTapErrCases`.
+
+Each takes a ts-pattern matcher over the error's _cases_, not the error value —
+so the suffix names that protocol and keeps it distinct from the value-taking
+success surface (`map` / `tap`). A bare `mapErr((e) => …)` would promise a
+functor-style callback the combinators never accept; there is deliberately no
+such variant.
+
+Migration is a rename at every call site:
+
+```diff
+- result.mapErr((m) => m.with(P._, wrap))
++ result.mapErrCases((m) => m.with(P._, wrap))
+```
+
+`match`'s `err` handler and the `getErr` extractor are unchanged — they are not
+matcher combinators.

--- a/.changeset/runtime-hardening.md
+++ b/.changeset/runtime-hardening.md
@@ -5,7 +5,7 @@
 **Runtime hardening** — none of these change well-typed behavior:
 
 - Every combinator whose callback must return a `Result` (`flatMap`,
-  `flatTap`, `bind`, `flatMapErr`, `flatTapErr`, `recoverDefect` — both
+  `flatTap`, `bind`, `flatMapErrCases`, `flatTapErrCases`, `recoverDefect` — both
   surfaces) now turns an out-of-contract non-`Result` return (untyped or cast
   callers) into a `TypeError`-caused `Defect` instead of letting a poison
   value throw a raw `TypeError` further down the pipeline — the same policy

--- a/.changeset/synchronous-qualify-and-taperr.md
+++ b/.changeset/synchronous-qualify-and-taperr.md
@@ -2,7 +2,7 @@
 "unthrown": major
 ---
 
-**`qualify` is now synchronous, and `tapErr` bans async branches** — two
+**`qualify` is now synchronous, and `tapErrCases` bans async branches** — two
 qualification-bypass holes closed at the type level.
 
 - `fromThrowable` / `fromPromise` now intersect `qualify`'s return with
@@ -12,12 +12,12 @@ qualification-bypass holes closed at the type level.
   and a throwing async qualify escaped as an unhandled rejection. At runtime a
   thenable slipped past the types now becomes a `Defect` (never `Err(Promise)`),
   and the orphaned thenable is adopted so its later rejection cannot float.
-- `tapErr`'s matcher-builder output is now `NotThenable`-constrained on both
+- `tapErrCases`'s matcher-builder output is now `NotThenable`-constrained on both
   surfaces. It was the one observer whose branch results are discarded, so an
   `async` branch's rejection floated invisibly — `tap`, `tapDefect`, and
   `tapFailure` already banned thenable callbacks. The non-awaiting
-  transformers `mapErr` / `recoverErr` still accept an async branch (its
+  transformers `mapErrCases` / `recoverErrCases` still accept an async branch (its
   promise is a visible value in the output type, not a rejection bypass).
 
-Migration: make the qualify (or `tapErr` branch) synchronous — do the async
+Migration: make the qualify (or `tapErrCases` branch) synchronous — do the async
 work first, or re-enter through `fromPromise` and compose with `flatMap`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,8 +63,8 @@ was planned).
    lives in typed fields, defined per error type, never baked into a per-call
    string.
 5. **The error channel is matched exhaustively, never blanket-handled.** The
-   error combinators (`mapErr`, `flatMapErr`, `recoverErr`, `tapErr`,
-   `flatTapErr`) do not take a single callback: their callback receives a
+   error combinators (`mapErrCases`, `flatMapErrCases`, `recoverErrCases`, `tapErrCases`,
+   `flatTapErrCases`) do not take a single callback: their callback receives a
    **ts-pattern match builder** over the error (`match(error)`, typed
    `ErrMatcher<E>`) plus the injected `defect` helper, and **returns the
    un-terminated builder** — the combinator calls `.exhaustive()` itself. So a
@@ -82,13 +82,13 @@ was planned).
    the outgoing type is the builder's output **with the `Defect` arm
    subtracted** (`Exclude<O, Defect>`, exactly the boundary inference), so a
    defect branch — or a throwing one, the safety net — contributes nothing.
-   The **observers** (`tapErr`, `flatTapErr`) take the same exhaustive builder
+   The **observers** (`tapErrCases`, `flatTapErrCases`) take the same exhaustive builder
    (the error passes through unchanged); a branch that returns a raw
    `Promise`/`AsyncResult` is rejected where the combinator awaits it
-   (`flatMapErr`/`flatTapErr`, via the builder-output constraint) **and** in
-   `tapErr` (its branch results are discarded, so a rejected `Promise` would
+   (`flatMapErrCases`/`flatTapErrCases`, via the builder-output constraint) **and** in
+   `tapErrCases` (its branch results are discarded, so a rejected `Promise` would
    float unobserved — its builder output is `NotThenable`-constrained) — only
-   the non-awaiting transformers `mapErr`/`recoverErr` run the branch
+   the non-awaiting transformers `mapErrCases`/`recoverErrCases` run the branch
    synchronously with an async branch remaining a visible Promise-valued
    result, not a rejection bypass. `tapDefect` / `tapFailure` keep single callbacks — their payloads
    carry no discriminant to match (a defect's cause is `unknown`; `tapFailure`
@@ -111,9 +111,9 @@ was planned).
 ## Load-bearing runtime invariants (tests must guard these)
 
 - **Throw → defect.** Any value thrown by a callback (or match branch) inside
-  a combinator (`map`, `flatMap`, `flatTap`, `ensure`, `bind`, `let`, `mapErr`,
-  `flatMapErr`,
-  `recoverErr`, `tap*`, `flatTapErr`, `recoverDefect`) is caught and converted to a
+  a combinator (`map`, `flatMap`, `flatTap`, `ensure`, `bind`, `let`, `mapErrCases`,
+  `flatMapErrCases`,
+  `recoverErrCases`, `tap*`, `flatTapErrCases`, `recoverDefect`) is caught and converted to a
   `Defect`. Nothing escapes a pipeline as a raw throw.
   This is what lets an HTTP adapter do a single `match({ ok, err, defect })`
   with **no surrounding `try/catch`**.
@@ -121,8 +121,8 @@ was planned).
   throw/rejection.** Reachable only from untyped/cast callers: the aggregates
   (`all` / `allFromDict` and their async pair) turn a non-`Result` element into
   a `TypeError`-caused `Defect`, and every combinator whose callback is
-  constrained to return a `Result` (`flatMap`, `flatTap`, `bind`, `flatMapErr`,
-  `flatTapErr`, `recoverDefect` — both surfaces; the async ones check the
+  constrained to return a `Result` (`flatMap`, `flatTap`, `bind`, `flatMapErrCases`,
+  `flatTapErrCases`, `recoverDefect` — both surfaces; the async ones check the
   **awaited** value, so a legitimately returned `AsyncResult` still passes)
   does the same with a non-`Result` callback return, instead of letting a
   poison value throw a raw `TypeError` further down the pipeline.
@@ -136,8 +136,8 @@ was planned).
   throw→defect) the same non-exhaustive rogue value instead **throws**
   `NonExhaustiveError` outright — a genuinely unmodeled tag at the edge is a
   bug, not a routed value.
-- **Exhaustiveness is type-enforced, with no forgettable step.** `mapErr` /
-  `flatMapErr` / `recoverErr` / `tapErr` / `flatTapErr` require the callback to
+- **Exhaustiveness is type-enforced, with no forgettable step.** `mapErrCases` /
+  `flatMapErrCases` / `recoverErrCases` / `tapErrCases` / `flatTapErrCases` require the callback to
   return an `ExhaustiveMatch` — `.exhaustive` is typed callable only when
   ts-pattern has narrowed the input to `never` (all cases covered); a
   non-exhaustive builder types `.exhaustive` as `NonExhaustiveError` and fails
@@ -156,7 +156,7 @@ was planned).
   the modeled `Err`, never an unmodeled defect (a defect is a bug, not an
   absent value).
 - **A failure-observer throw preserves the original failure.** A throw inside
-  `tapErr` / `tapDefect` / `tapFailure` / `flatTapErr` produces a `Defect` whose
+  `tapErrCases` / `tapDefect` / `tapFailure` / `flatTapErrCases` produces a `Defect` whose
   cause is an `AggregateError([thrown, original])` — observing a failure never
   destroys it. (A throw in the success-channel `tap`/`map` keeps the plain
   thrown cause.)
@@ -167,12 +167,12 @@ was planned).
   `NotThenable<R>`, so an `async` callback is a compile error (an async
   `ensure` predicate already fails its `boolean` return type — a `Promise`
   would be always-truthy). Among the error-matcher combinators, the
-  **awaiting** ones — `flatMapErr` / `flatTapErr` — reject an async branch via
+  **awaiting** ones — `flatMapErrCases` / `flatTapErrCases` — reject an async branch via
   their builder-output constraint (an awaited rejection would bypass
-  qualification), and so does the observer **`tapErr`** (its branch results are
+  qualification), and so does the observer **`tapErrCases`** (its branch results are
   **discarded**, so a rejected `Promise` would float unobserved; same
   builder-output `NotThenable` constraint). The **non-awaiting** transformers
-  `mapErr` / `recoverErr` run
+  `mapErrCases` / `recoverErrCases` run
   the matched branch **synchronously with no await**, so an async branch is
   merely a visible `Promise`-valued result, not a rejection bypass — they do
   not ban it. The boundary `qualify` is constrained the same way, with a
@@ -198,14 +198,14 @@ was planned).
 - **`get()` / `getErr()` are type-gated.** `get()` compiles only when the
   error channel is empty (`this: Result<T, never>`); `getErr()` only when the
   success channel is empty (`this: Result<never, E>`). Eliminate the opposite
-  channel first (`match` / `recoverErr` / `flatMapErr`), or use the `getOr` /
+  channel first (`match` / `recoverErrCases` / `flatMapErrCases`), or use the `getOr` /
   `getOrElse` / `getOrNull` / `getOrUndefined` family (which recover an `Err`).
   On a `Defect` they still **rethrow the original `cause`** (they _panic_) with its
   original stack — so `Result<T, never>` means the modeled error channel is empty,
   **not** that `get()` cannot throw. The `GetError`-on-wrong-variant branch
   remains at runtime as a defensive guard but is **unreachable through well-typed
   code** (only a cast or a raw-JS caller can reach it).
-- **`recoverErr` returns `Result<T | U, never>`, and `never` means only the _error_
+- **`recoverErrCases` returns `Result<T | U, never>`, and `never` means only the _error_
   channel is empty — a `Defect` can still be present at runtime.** This is the one
   place the type intentionally under-describes the runtime. Do not read `never`
   as "total".
@@ -245,18 +245,18 @@ async work re-enters via `fromPromise` / `fromSafePromise` and composes with
   pure value). On `AsyncResult`, `bind`'s `f` may return a `Result` or an
   `AsyncResult`. A throw in either becomes a `Defect`; `Err`/`Defect`
   short-circuits/passes through. To go async, lift with `toAsync()`.
-- error: `mapErr`, `flatMapErr`, `recoverErr`, `tapErr`, `flatTapErr` all take
+- error: `mapErrCases`, `flatMapErrCases`, `recoverErrCases`, `tapErrCases`, `flatTapErrCases` all take
   the Thesis-#5 **ts-pattern matcher callback** `(m: ErrMatcher<E>, defect) => M`
   where `M extends ExhaustiveMatch<…>` (the callback returns the un-terminated
   builder; the combinator runs `.run()`). Outgoing types are computed from the
-  builder output `MatchOut<M>` — mapErr: `MatchErrOut<M>` (= `Exclude<MatchOut,
-Defect>`); flatMapErr: `OkOf`/`ErrOf` — plus `AsyncOkOf`/`AsyncErrOf` on the
-  async surface — over it; recoverErr: `T | MatchErrOut<M>` with `E = never`.
-  `flatTapErr` is the exception: it infers a plain `E2` from the builder output
+  builder output `MatchOut<M>` — mapErrCases: `MatchErrOut<M>` (= `Exclude<MatchOut,
+Defect>`); flatMapErrCases: `OkOf`/`ErrOf` — plus `AsyncOkOf`/`AsyncErrOf` on the
+  async surface — over it; recoverErrCases: `T | MatchErrOut<M>` with `E = never`.
+  `flatTapErrCases` is the exception: it infers a plain `E2` from the builder output
   and returns `E | E2` (the `MatchOut<M>` shape unioned with the class `E`
   defeats variance measurement of the intersection `AsyncResult` — see internal
   design). The `defect` helper is passed to every branch (the deliberate
-  `Err`→`Defect`); `tapErr`/`flatTapErr` keep the same exhaustive builder (the
+  `Err`→`Defect`); `tapErrCases`/`flatTapErrCases` keep the same exhaustive builder (the
   error passes through), the error-channel mirror of `tap`/`flatTap`
 - defect: `recoverDefect`, `tapDefect`
 - failure (both KO channels): `tapFailure` — the one cross-channel combinator:
@@ -274,7 +274,7 @@ Defect>`); flatMapErr: `OkOf`/`ErrOf` — plus `AsyncOkOf`/`AsyncErrOf` on the
   to a value; the folded type unions all branch returns), `get`/`getErr`
   (type-gated — `get` only compiles on
   `Result<T, never>`, `getErr` only on `Result<never, E>`; use `match` /
-  `recoverErr` / `flatMapErr` to empty the opposite channel first), `getOr` (signature
+  `recoverErrCases` / `flatMapErrCases` to empty the opposite channel first), `getOr` (signature
   `getOr<U>(fallback: U): T | U` — widening, not narrowed to `T`), `getOrElse`
   (same `T | U` widening), `getOrNull`, `getOrUndefined` — the `getOr…`
   family extracts from a still-fallible `Result` with a fallback, since
@@ -283,9 +283,9 @@ Defect>`); flatMapErr: `OkOf`/`ErrOf` — plus `AsyncOkOf`/`AsyncErrOf` on the
   as-is** on `Err` (and panics on a `Defect`, like the rest of the family). It
   exists so a `no-throw` lint rule can ban raw `throw` while this one sanctioned
   extraction remains — the faithful, lint-clean form of
-  `.flatMapErr((matcher) => matcher.with(P._, (e) => { throw e })).get()`; it is
-  **off the errors-as-values thesis** by design, so reach for `match` / `recoverErr`
-  / `flatMapErr` whenever the error can stay a value. It is type-gated as the
+  `.flatMapErrCases((matcher) => matcher.with(P._, (e) => { throw e })).get()`; it is
+  **off the errors-as-values thesis** by design, so reach for `match` / `recoverErrCases`
+  / `flatMapErrCases` whenever the error can stay a value. It is type-gated as the
   **complement of `get`**: it compiles only when the error channel is **non-empty**
   (`E` is not `never`, spelled `this: [E] extends [never] ? never : Result<T,E>`) —
   on a `Result<T, never>` there is nothing to throw, so `getOrThrow` does not
@@ -324,7 +324,7 @@ match<E>>`, so ts-pattern's non-exported `Match` type is never imported).
   `MatchOut`/`MatchErrOut` extract. Note `ErrMatcher<E>` must appear only as a
   callback **parameter** type (contravariant), never combined with the class `E`
   in a covariant return — ts-pattern's `Match` is invariant in its input, which
-  would poison `E` inference (why `flatTapErr` infers a plain `E2` instead).
+  would poison `E` inference (why `flatTapErrCases` infers a plain `E2` instead).
 - constructors: `Ok` (a no-arg overload — `Ok()` — constructs a `void` success,
   `Result<void, never>`, sparing `Ok(undefined)`; `OkAsync()` mirrors it),
   `Err` (there is **no** `Defect` constructor — a defect-state
@@ -457,7 +457,7 @@ library can be "done".
   is contravariant there and harmless, but unioning an `M`-derived output with
   the class `E` in a covariant return re-invaded `E`'s variance and collapsed
   inference (`combine<T,E>(rs: AsyncResult<T,E>[])` inferring `unknown`) — which
-  is exactly why `flatTapErr` infers a plain `E2` from the builder output and
+  is exactly why `flatTapErrCases` infers a plain `E2` from the builder output and
   returns `E | E2` rather than `E | ErrOf<MatchOut<M>>`.
 - **Inference-bearing parameters stay free of conditional types.** The
   async-qualify ban on `fromPromise` is a **phantom rest-tuple guard** (an async
@@ -494,7 +494,7 @@ AsyncResult<infer T, …>` — structural inference over the whole method surfac
   keeps a bare `Promise<Result>` out (a Promise has no `flatMap`, so a raw
   rejection still can't bypass qualification). The error channel stays a **plain**
   `E | E2` — deriving it as `E | ErrOf<R> | AsyncErrOf<R>` re-invaded `E`'s
-  variance (the same `out E` collapse `flatTapErr` avoids), so `flatMap` keeps
+  variance (the same `out E` collapse `flatTapErrCases` avoids), so `flatMap` keeps
   the plain `E2`. Keeping the `<U, E2>` shape (rather than inferring a whole
   `R`) also means the precise `AsyncRes` impl signatures conform to the public
   type unchanged — no loosening needed for these three.
@@ -600,7 +600,7 @@ AsyncResult<infer T, …>` — structural inference over the whole method surfac
   output, `Err` ↔ returned inferable `ORPCError`, `Defect` ↔ the rest. Three
   entry points, **no root export**: `./server` — `handlerResult(fn)` adapts a
   `Result`-returning handler (`Err` is constrained to `ORPCError`, so the
-  `mapErr` into `errors.CODE(...)` at the endpoint is the Thesis-#3 triage
+  `mapErrCases` into `errors.CODE(...)` at the endpoint is the Thesis-#3 triage
   point; a `Defect` rethrows its cause; a non-`ORPCError` `Err` smuggled past
   the types routes to the defect path — it must never be served as a
   successful output; the callback may be async — an elimination edge, exempt
@@ -613,7 +613,7 @@ AsyncResult<infer T, …>` — structural inference over the whole method surfac
   server-side `call(...)`), `createResultClient(client)` recursively wraps a
   router (the `createSafeClient` mirror): `E` is the raw inferable `ORPCError`
   union discriminated by `code` — deliberately NOT re-wrapped into
-  `TaggedError` (match it on `code`, e.g. `.mapErr((matcher) => matcher.with({
+  `TaggedError` (match it on `code`, e.g. `.mapErrCases((matcher) => matcher.with({
 code: "NOT_FOUND" }, …))`); non-inferable →
   `Defect`. Event-iterator (streaming) procedures are deliberately out of
   scope — the raw client is the escape hatch. Tested end-to-end against real
@@ -723,14 +723,14 @@ configured outside the repo).
   enforced by thresholds in its `vitest.config.ts`.
 - **Type-level tests:** `packages/core/src/types.test-d.ts` asserts the
   type-level behaviour the runtime can't (the conditional `all`/`allFromDict`
-  shapes, `Exclude<R, Defect>` boundary inference, `flatTap`/`recoverErr` channel
+  shapes, `Exclude<R, Defect>` boundary inference, `flatTap`/`recoverErrCases` channel
   widening, the `this is …` guard narrowing, `match`'s `err`-matcher
   exhaustiveness (a missing tag does not compile; the folded type unions the
   branch returns), and the
   error-matcher semantics — narrowing, defect/throw-branch subtraction,
   `P._` catch-all, grouped patterns, `code`-discriminated and untagged unions,
   forced exhaustiveness (a missing case does not compile), the `E`-inference
-  regression guard (`combine` still infers), and the `flatMapErr`/`flatTapErr`
+  regression guard (`combine` still infers), and the `flatMapErrCases`/`flatTapErrCases`
   async-branch rejection) with a
   `Expect<Equal<…>>` helper plus `@ts-expect-error` for must-not-compile cases.
   They are checked by `tsc` via `tsconfig.test-d.json` (which relaxes
@@ -740,5 +740,16 @@ configured outside the repo).
 - Public API carries full **TSDoc**; `pnpm --filter <pkg> build:docs` must stay
   typedoc-warning-free.
 - One concept = one name. Resist convenience aliases.
+- **The error-matcher combinators carry a `*Cases` suffix** (`mapErrCases`,
+  `flatMapErrCases`, `recoverErrCases`, `tapErrCases`, `flatTapErrCases`) —
+  **not** the bare `mapErr`/`tapErr`. The callback receives a ts-pattern matcher
+  over the error's _cases_, not the value, so the suffix names the protocol and
+  keeps it distinct from the value-taking success surface (`map`/`tap`). This
+  reverses the earlier plan to keep the bare `map*`/`tap*` names (weighed and
+  changed 2026-07): the functor-style name promised a `(e) => …` callback the
+  combinators never accept. There is **no** plain-callback `mapErr` variant —
+  that would reopen the blanket-handling hole the matcher closes. Do not
+  re-litigate or add bare aliases. Documented user-side in the
+  exhaustive-error-matching guide.
 - The core has **one runtime dependency, `ts-pattern`** (it powers the error
   matchers and is re-exported). Add no others — protect that minimalism.

--- a/docs/explanation/async-model.md
+++ b/docs/explanation/async-model.md
@@ -49,7 +49,7 @@ This is the rule that keeps qualification honest:
 If `.map(async …)` were allowed, a rejection inside that callback would silently
 become a defect — an un-qualified async boundary, exactly what
 [qualification](./qualification) exists to prevent. So combinator callbacks are
-synchronous. The `Result`-returning binds (`flatMap`, `flatMapErr`,
+synchronous. The `Result`-returning binds (`flatMap`, `flatMapErrCases`,
 `recoverDefect`, `bind`, …) accept a `Result` **or** an `AsyncResult`, but never a
 raw promise — a `Promise` has no `flatMap`, so the types keep it out.
 

--- a/docs/explanation/design-decisions.md
+++ b/docs/explanation/design-decisions.md
@@ -99,10 +99,12 @@ the old `unwrap*` aliases were removed. Convenience aliases multiply the surface
 and force every reader to learn that two names mean one thing. Resisting them is
 part of staying "done".
 
-The one place a conventional name is kept _despite_ a protocol change is the
-error combinators (`mapErr`, `tapErr`, …), whose callback receives a matcher
-rather than the value — a settled trade-off explained in
-[Exhaustive error matching](./exhaustive-error-matching#why-keep-the-map-tap-names).
+Naming follows behavior, even when that breaks symmetry with the success surface:
+the error-matcher combinators carry a `*Cases` suffix (`mapErrCases`,
+`flatMapErrCases`, `recoverErrCases`, `tapErrCases`, `flatTapErrCases`) rather than
+the bare `mapErr` / `tapErr`, because their callback receives a matcher over the
+error's _cases_, not the value. The suffix is the honest name — see
+[Exhaustive error matching](./exhaustive-error-matching#why-the-cases-suffix).
 
 ## Where to go next
 

--- a/docs/explanation/exhaustive-error-matching.md
+++ b/docs/explanation/exhaustive-error-matching.md
@@ -1,10 +1,10 @@
 # Exhaustive error matching
 
 > **Explanation.** This page explains _why_ the error combinators take a
-> ts-pattern matcher instead of a plain callback, and why they keep their
-> conventional `map*` / `tap*` names anyway. For the mechanics — the rules, the
-> `P._` catch-all, the per-method signatures — see the
-> [combinator reference](../reference/combinators#the-error-channel).
+> ts-pattern matcher instead of a plain callback, and why they carry a `*Cases`
+> suffix (`mapErrCases`, `tapErrCases`, …) rather than a bare `map`/`tap`-style
+> name. For the mechanics — the rules, the `P._` catch-all, the per-method
+> signatures — see the [combinator reference](../reference/combinators#the-error-channel).
 
 Errors-as-values only pays off if the values **can't be silently dropped**. On
 the success channel that is easy — `T` is one type, so a `(value: T) => …`
@@ -14,13 +14,13 @@ is what shapes the entire error surface.
 ## The problem with a blanket error handler
 
 `E` is a **union of possibilities**: `NotFound | Forbidden | RateLimited`. A
-plain callback over that union —
+combinator that handed your callback the error _value_ directly —
 
 ```ts
-result.mapErr((e) => wrap(e)); // e: NotFound | Forbidden | RateLimited
+(e) => wrap(e); // e: NotFound | Forbidden | RateLimited
 ```
 
-— keeps compiling no matter how the union grows. Add a `PaymentDeclined` tag a
+— would keep compiling no matter how the union grows. Add a `PaymentDeclined` tag a
 year later and this call site does not change, does not warn, does not fail. It
 silently absorbs the new case. That is precisely the blanket handler
 errors-as-values is supposed to eliminate: the whole reason to make failures
@@ -28,14 +28,14 @@ values is so the compiler forces you to _account for each one_.
 
 ## The solution: an exhaustive matcher, terminated for you
 
-So the error combinators — `mapErr`, `flatMapErr`, `recoverErr`, `tapErr`,
-`flatTapErr` — do not take a single callback. Their callback receives a
+So the error combinators — `mapErrCases`, `flatMapErrCases`, `recoverErrCases`, `tapErrCases`,
+`flatTapErrCases` — do not take a single callback. Their callback receives a
 [ts-pattern](https://github.com/gvergnaud/ts-pattern) **match builder** over the
 error, and you **return the un-terminated builder**. The combinator calls
 `.exhaustive()` itself:
 
 ```ts
-db.reading.tryFindUniqueOrThrow({ where: { id } }).mapErr(
+db.reading.tryFindUniqueOrThrow({ where: { id } }).mapErrCases(
   (matcher, defect) =>
     matcher
       .with(tag("RecordNotFound"), () => new ReadingNotFoundException(id))
@@ -60,7 +60,7 @@ subtracted from the outgoing `E` just like at a boundary.
 A natural first instinct is that returning the matcher untouched must be a no-op:
 
 ```ts
-result.mapErr((matcher) => matcher); // ⚠️ not an identity
+result.mapErrCases((matcher) => matcher); // ⚠️ not an identity
 ```
 
 It isn't. The combinator terminates the builder with `.exhaustive()`, and a
@@ -75,33 +75,38 @@ net turns into a `Defect`.
 There is deliberately **no** identity on the error channel. Passing the error
 through unchanged is a real decision with a real spelling:
 
-- to _observe_ and pass through, use `tapErr` (an observer);
+- to _observe_ and pass through, use `tapErrCases` (an observer);
 - to _re-emit_ every case unchanged, write the catch-all: `.with(P._, (e) => e)`.
 
 `P._` is the sanctioned "handle everything else" branch — the explicit,
 greppable replacement for the old blanket callback. It makes the match
 exhaustive and it reads, at the call site, as an on-purpose "everything else".
 
-## Why keep the `map*` / `tap*` names?
+## Why the `*Cases` suffix?
 
-The names nominally promise the functional-programming functor contract (the
-callback receives the value), while the callback actually receives the _matcher_.
-That break is deliberate, and it was a weighed, settled decision:
+A bare `mapErr` / `tapErr` would promise the functional-programming functor
+contract — that the callback receives the error _value_. It doesn't: it receives
+a **matcher over the error's cases**. The `*Cases` suffix names that difference
+honestly, so the signature tells you what the callback gets before you write it:
 
-- **The names state the channel and the pipeline effect.** `mapErr` transforms
-  the error channel; `tapErr` observes it. They preserve the operator × channel
-  symmetry with the success surface (`map`/`mapErr`, `tap`/`tapErr`), and they
-  stay greppable for people arriving from neverthrow or fp-ts.
-- **Each matcher branch still hands you the error**, narrowed to its exact case —
-  so the functor intuition holds _inside_ a branch, where there is a single
-  concrete value.
-- **Alternatives were rejected**: plural names (`mapErrs`), explicit `*ErrCases`
-  suffixes, and collapsing to `catchErrs` + observers each cost more than the
-  convention break they avoided.
+- **The success surface keeps `map` / `tap`.** Those callbacks really do hand you
+  the value, so the functor name is true there.
+- **The error surface says `*ErrCases`** — `mapErrCases`, `flatMapErrCases`,
+  `recoverErrCases`, `tapErrCases`, `flatTapErrCases` — because the callback builds
+  a match over the union's cases. Each matcher _branch_ still hands you the error,
+  narrowed to its exact case, so the functor intuition holds _inside_ a branch,
+  where there is a single concrete value.
 
-Plain-callback variants are deliberately **not** offered alongside — adding
-`mapErr((e) => …)` back would reopen exactly the blanket-handling hole the
-matcher closes.
+Naming both surfaces the same (`map` / `mapErr`) was considered and **reversed**
+(2026-07): the symmetry read nicely but lied about the protocol, and a reader
+reaching for `mapErr((e) => …)` — the shape that name implies — hit a type error
+with no hint why. The suffix trades a little visual symmetry for a name that
+matches the behavior. Other options — plural `mapErrs`, `catchErrs` + observers —
+were rejected for saying even less about what the callback receives.
+
+There is deliberately **no** bare `mapErr((e) => …)` variant alongside
+`mapErrCases` — a plain callback over the union is exactly the blanket handler the
+matcher exists to eliminate.
 
 ## The one eliminator that still folds the error: `match`
 

--- a/docs/explanation/qualification.md
+++ b/docs/explanation/qualification.md
@@ -21,7 +21,7 @@ fromPromise(p): AsyncResult<T, unknown>;
 ```
 
 That single `unknown` is the leak. It flows into your error type, and from there
-into every consumer. You reach for a `match` or a `mapErr`, discover the error is
+into every consumer. You reach for a `match` or a `mapErrCases`, discover the error is
 `unknown`, and now you either cast it (a lie the compiler can't check) or widen
 `E` to `unknown` all the way up. The type that was supposed to be a precise
 contract quietly became "something went wrong."

--- a/docs/explanation/the-defect-channel.md
+++ b/docs/explanation/the-defect-channel.md
@@ -47,8 +47,8 @@ const d: Result<number, "boom"> = Ok(1).map((): number => {
 });
 
 d.map((n) => n + 1); // still a Defect — the success callback is skipped
-d.mapErr((m) => m.with("boom", () => "handled")); // still a Defect — the branch never runs
-d.recoverErr((m) => m.with("boom", () => 0)); // still a Defect — see below
+d.mapErrCases((m) => m.with("boom", () => "handled")); // still a Defect — the branch never runs
+d.recoverErrCases((m) => m.with("boom", () => 0)); // still a Defect — see below
 ```
 
 The matchers above are the real, exhaustive form — one branch per modeled error.
@@ -57,8 +57,8 @@ combinators only touch the `Err` channel, and a defect flows straight past them.
 
 ### No identity on the error channel
 
-::: warning `mapErr((m) => m)` is not an identity
-It can be tempting to write `mapErr((matcher) => matcher)` — returning the
+::: warning `mapErrCases((m) => m)` is not an identity
+It can be tempting to write `mapErrCases((matcher) => matcher)` — returning the
 matcher untouched — as a "do nothing" on the error channel. It is **not**. The
 combinator terminates the builder with `.exhaustive()` for you, and a builder
 with no `.with(…)` branch is only exhaustive when `E` is `never`. On any real
@@ -66,13 +66,13 @@ error channel it fails to compile; if it slips past the types (a cast), it
 throws `NonExhaustiveError` at runtime, which becomes a `Defect`. There is no
 "no-op" on the error channel — every branch of the union must be handled, which
 is the whole point (see [Exhaustive error matching](./exhaustive-error-matching)).
-To genuinely pass the error through unchanged, use an observer (`tapErr`) or a
+To genuinely pass the error through unchanged, use an observer (`tapErrCases`) or a
 `P._` catch-all that re-emits it.
 :::
 
-## `recoverErr` clears the error channel, not the runtime
+## `recoverErrCases` clears the error channel, not the runtime
 
-`recoverErr` turns an `Err` into an `Ok`, so its type is `Result<T | U, never>`. But
+`recoverErrCases` turns an `Err` into an `Ok`, so its type is `Result<T | U, never>`. But
 `never` describes only the **error** channel — a defect can still be present at
 runtime:
 
@@ -80,7 +80,7 @@ runtime:
 import { P } from "unthrown";
 
 // the `P._` branch is what supplies the `U` in `Result<T | U, never>`
-const recovered = d.recoverErr((matcher) => matcher.with(P._, () => 99));
+const recovered = d.recoverErrCases((matcher) => matcher.with(P._, () => 99));
 // type: Result<number, never>
 recovered.isDefect(); // => true — `never` does NOT mean "total"
 ```

--- a/docs/explanation/why-unthrown.md
+++ b/docs/explanation/why-unthrown.md
@@ -57,7 +57,7 @@ the type**. `Result<T, E>` exposes only your anticipated errors in `E`. Anything
 unexpected becomes a defect that short-circuits to the edge, where you log it and
 return a 500. A defect can only be observed by `match`, `recoverDefect`, or the
 `tapDefect` / `tapFailure` observers; it is never silently recovered by `getOr`,
-`getOrNull`, or `recoverErr`.
+`getOrNull`, or `recoverErrCases`.
 
 This is the idea the rest of the library follows from. It has [its own
 page](./the-defect-channel).

--- a/docs/how-to/handle-results-at-the-edge.md
+++ b/docs/how-to/handle-results-at-the-edge.md
@@ -86,7 +86,7 @@ const app = new Hono();
 
 app.get("/users/:id", (c) => {
   const user = parseId(c.req.param("id"))
-    .mapErr((matcher) => matcher.with(P._, () => new InvalidId()))
+    .mapErrCases((matcher) => matcher.with(P._, () => new InvalidId()))
     .toAsync()
     .flatMap((id) => userRepo.findById(id));
   // AsyncResult<User, InvalidId | NotFound>
@@ -121,8 +121,8 @@ result.getOrThrow(); // Err → throws the modeled error as-is; Defect → throw
 ```
 
 Use `getOrThrow` only as a deliberate escape hatch back into throw-land (it exists
-so a `no-throw` lint rule can ban raw `throw`). Prefer `match` / `recoverErr` /
-`flatMapErr` whenever the error can stay a value. Full family in the
+so a `no-throw` lint rule can ban raw `throw`). Prefer `match` / `recoverErrCases` /
+`flatMapErrCases` whenever the error can stay a value. Full family in the
 [combinator reference](../reference/combinators#eliminating-a-result).
 
 ## Where to go next

--- a/docs/how-to/migrate-from-neverthrow.md
+++ b/docs/how-to/migrate-from-neverthrow.md
@@ -12,8 +12,8 @@
 | `ok(v)` / `err(e)`                   | `Ok(v)` / `Err(e)`                           | constructors are capitalized                                                                                   |
 | `result.andThen(f)`                  | `result.flatMap(f)`                          | one name per concept                                                                                           |
 | `result.map(f)`                      | same                                         | callbacks must be synchronous                                                                                  |
-| `result.mapErr(f)`                   | `result.mapErr((matcher) => …)`              | an exhaustive [ts-pattern](https://github.com/gvergnaud/ts-pattern) match; `.with(P._, f)` is the uniform form |
-| `result.orElse(f)`                   | `result.flatMapErr((matcher) => …)`          | `flatMap` on the error channel; same exhaustive matcher                                                        |
+| `result.mapErr(f)`                   | `result.mapErrCases((matcher) => …)`         | an exhaustive [ts-pattern](https://github.com/gvergnaud/ts-pattern) match; `.with(P._, f)` is the uniform form |
+| `result.orElse(f)`                   | `result.flatMapErrCases((matcher) => …)`     | `flatMap` on the error channel; same exhaustive matcher                                                        |
 | `result.match(okFn, errFn)`          | `match({ ok, err: (matcher) => …, defect })` | the third channel is new, and `err` takes the same exhaustive matcher — see below                              |
 | `result.unwrapOr(v)`                 | `result.getOr(v)`                            | still throws on a Defect (a bug is not an absent value)                                                        |
 | `ResultAsync`                        | `AsyncResult`                                | `await` collapses it to a `Result`; it never rejects                                                           |
@@ -26,9 +26,9 @@
 
 Most rows are a rename. `andThen` → `flatMap` is unthrown's
 [one-name-per-concept](../explanation/design-decisions#one-name-per-concept-no-aliases)
-rule. The one behavioral change to know up front: `mapErr` (and the other error
+rule. The one behavioral change to know up front: `mapErrCases` (and the other error
 combinators) take an **exhaustive matcher** rather than a plain callback — the
-uniform port is `.mapErr((matcher) => matcher.with(P._, f))`, and the reasoning is
+uniform port is `.mapErrCases((matcher) => matcher.with(P._, f))`, and the reasoning is
 in [Exhaustive error matching](../explanation/exhaustive-error-matching). The rest
 of the table is where the libraries genuinely differ.
 

--- a/docs/how-to/migrate-from-try-catch.md
+++ b/docs/how-to/migrate-from-try-catch.md
@@ -97,25 +97,25 @@ throwing until it earns the conversion.
 
 ## `try`/`catch` idioms → combinators
 
-| `try`/`catch` idiom       | unthrown combinator                             | Example                                                                               |
-| ------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------- |
-| catch-and-default         | `getOr(fallback)`                               | `parseConfig(text).getOr(DEFAULT_CONFIG)`                                             |
-| catch-and-rethrow-wrapped | `mapErr((matcher) => …)`                        | `parseConfig(text).mapErr((matcher) => matcher.with(P._, (e) => new ConfigError(e)))` |
-| catch-log-rethrow         | `tapErr((matcher) => …)`                        | `parseConfig(text).tapErr((matcher) => matcher.with(P._, (e) => logger.warn(e)))`     |
-| `finally` cleanup         | run before eliminating, or in every `match` arm | see below                                                                             |
+| `try`/`catch` idiom       | unthrown combinator                             | Example                                                                                    |
+| ------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| catch-and-default         | `getOr(fallback)`                               | `parseConfig(text).getOr(DEFAULT_CONFIG)`                                                  |
+| catch-and-rethrow-wrapped | `mapErrCases((matcher) => …)`                   | `parseConfig(text).mapErrCases((matcher) => matcher.with(P._, (e) => new ConfigError(e)))` |
+| catch-log-rethrow         | `tapErrCases((matcher) => …)`                   | `parseConfig(text).tapErrCases((matcher) => matcher.with(P._, (e) => logger.warn(e)))`     |
+| `finally` cleanup         | run before eliminating, or in every `match` arm | see below                                                                                  |
 
 `catch-and-rethrow-wrapped` — turn a caught error into a modeled `Err`:
 
 ```ts
 // before: throw new ConfigError(cause)
 // after:  ConfigError becomes a modeled Err, not a throw
-parseConfig(text).mapErr((matcher) => matcher.with(P._, (e) => new ConfigError(e)));
+parseConfig(text).mapErrCases((matcher) => matcher.with(P._, (e) => new ConfigError(e)));
 ```
 
 `catch-log-rethrow` — log, keep the original error, still propagate as an `Err`:
 
 ```ts
-parseConfig(text).tapErr((matcher) => matcher.with(P._, (e) => logger.warn("bad config", e)));
+parseConfig(text).tapErrCases((matcher) => matcher.with(P._, (e) => logger.warn("bad config", e)));
 ```
 
 `finally` has no combinator counterpart — a `Result` pipeline has no single point

--- a/docs/how-to/model-errors.md
+++ b/docs/how-to/model-errors.md
@@ -124,7 +124,7 @@ const status = authorize(id).match({
 });
 ```
 
-Unlike the error _combinators_ (`mapErr`, `flatMapErr`, …), `match`'s `err`
+Unlike the error _combinators_ (`mapErrCases`, `flatMapErrCases`, …), `match`'s `err`
 handler receives **no `defect` helper** — `match` is total elimination to a value,
 and a `Result` that already carries a defect is handled by the `defect:` case. To
 keep matching _inside_ the pipeline (transforming or recovering the error rather

--- a/docs/how-to/use-with-orpc.md
+++ b/docs/how-to/use-with-orpc.md
@@ -49,14 +49,16 @@ const find = os
   .errors({ NOT_FOUND: {} })
   .handler(
     handlerResult(({ input, errors }) =>
-      repo.findPlanet(input.id).mapErr((matcher) => matcher.with(P._, () => errors.NOT_FOUND())),
+      repo
+        .findPlanet(input.id)
+        .mapErrCases((matcher) => matcher.with(P._, () => errors.NOT_FOUND())),
     ),
   );
 ```
 
 - `Ok` becomes the procedure's output.
 - `Err` is **returned as a value**; oRPC marks it inferable, so the client sees it
-  fully typed. The error channel is constrained to `ORPCError` — the `mapErr` that
+  fully typed. The error channel is constrained to `ORPCError` — the `mapErrCases` that
   turns a domain error into one (here `errors.NOT_FOUND()`) is the explicit triage
   point at the transport boundary.
 - A `Defect` rethrows its original cause, which oRPC collapses to
@@ -93,7 +95,7 @@ const find = os
   .input(z.object({ id: z.string() }))
   .errors({ NOT_FOUND: {} })
   .result(({ input, errors }) =>
-    repo.findPlanet(input.id).mapErr((matcher) => matcher.with(P._, () => errors.NOT_FOUND())),
+    repo.findPlanet(input.id).mapErrCases((matcher) => matcher.with(P._, () => errors.NOT_FOUND())),
   );
 ```
 
@@ -164,7 +166,7 @@ browser consumes it, all in `Result`:
 ```ts
 import { tag } from "unthrown";
 
-// server — the one mapErr is the whole edge, and it is exhaustive: a new P-code
+// server — the one mapErrCases is the whole edge, and it is exhaustive: a new P-code
 // in the union becomes a compile error here, never a silent 500.
 const createUser = os
   .input(z.object({ email: z.string() }))
@@ -173,7 +175,7 @@ const createUser = os
     handlerResult(({ input, errors }) =>
       db.user
         .tryCreate({ data: input })
-        .mapErr((matcher) =>
+        .mapErrCases((matcher) =>
           matcher
             .with(tag("UniqueConstraintViolation"), () => errors.EMAIL_TAKEN())
             .with(

--- a/docs/reference/combinators.md
+++ b/docs/reference/combinators.md
@@ -18,8 +18,8 @@ and its binds also accept an `AsyncResult`). The
 ## By intent
 
 The `→ Result<…>` half of each signature is the tell — it shows how the combinator
-moves the channels: `flatMap` widens `E` to `E | E2`, `recoverErr` empties it to
-`never`, `flatMapErr` widens the value to `T | U`. The error combinators take an
+moves the channels: `flatMap` widens `E` to `E | E2`, `recoverErrCases` empties it to
+`never`, `flatMapErrCases` widens the value to `T | U`. The error combinators take an
 [exhaustive ts-pattern matcher](#the-error-channel) rather than a single callback;
 the signatures below abbreviate its callback as `(matcher) => …`.
 
@@ -33,11 +33,11 @@ the signatures below abbreviate its callback as `(matcher) => …`.
 | sequence steps into a named scope              | `Do`/`bind`/`let` | `bind(k, (scope) => Result<U, E2>)` → `Result<{…}, E \| E2>` | Ok           |
 | replace the value with a constant              | `as`              | `(value: U)` → `Result<U, E>`                                | Ok           |
 | drop the value (success type becomes `void`)   | `discard`         | `()` → `Result<void, E>`                                     | Ok           |
-| transform the error (matched)                  | `mapErr`          | `(matcher) => …` → `Result<T, E2>`                           | Err          |
-| try a fallback that returns a `Result`         | `flatMapErr`      | `(matcher) => …` → `Result<T \| U, E2>`                      | Err          |
-| turn an error into a success value             | `recoverErr`      | `(matcher) => …` → `Result<T \| U, never>`                   | Err          |
-| run a side effect on the error                 | `tapErr`          | `(matcher) => …` → `Result<T, E>`                            | Err          |
-| run a **failable** side effect on the error    | `flatTapErr`      | `(matcher) => …` → `Result<T, E \| E2>`                      | Err          |
+| transform the error (matched)                  | `mapErrCases`     | `(matcher) => …` → `Result<T, E2>`                           | Err          |
+| try a fallback that returns a `Result`         | `flatMapErrCases` | `(matcher) => …` → `Result<T \| U, E2>`                      | Err          |
+| turn an error into a success value             | `recoverErrCases` | `(matcher) => …` → `Result<T \| U, never>`                   | Err          |
+| run a side effect on the error                 | `tapErrCases`     | `(matcher) => …` → `Result<T, E>`                            | Err          |
+| run a **failable** side effect on the error    | `flatTapErrCases` | `(matcher) => …` → `Result<T, E \| E2>`                      | Err          |
 | recover from a defect (rare)                   | `recoverDefect`   | `(cause) => Result<U, E2>` → `Result<T \| U, E \| E2>`       | Defect       |
 | observe a defect, e.g. log it                  | `tapDefect`       | `(cause) => void` → `Result<T, E>`                           | Defect       |
 | observe **any** failure (error _or_ defect)    | `tapFailure`      | `(f: FailureView<E>) => void` → `Result<T, E>`               | Err + Defect |
@@ -52,31 +52,31 @@ untouched (`tapFailure` is the one combinator whose "own channel" spans both
 failures). The `Defect` column is "passes ▸" everywhere except `recoverDefect`,
 the observers (`tapDefect` / `tapFailure`), and `match`:
 
-| method                  | on `Ok`  | on `Err`      | on `Defect` | resulting `E`   |
-| ----------------------- | -------- | ------------- | ----------- | --------------- |
-| `map`                   | runs `f` | passes ▸      | passes ▸    | `E`             |
-| `flatMap`               | runs `f` | passes ▸      | passes ▸    | `E \| E2`       |
-| `tap` / `flatTap`       | runs `f` | passes ▸      | passes ▸    | `E` / `E \| E2` |
-| `ensure`                | runs `f` | passes ▸      | passes ▸    | `E \| E2`       |
-| `mapErr`                | passes ▸ | runs a branch | passes ▸    | `E2`            |
-| `flatMapErr`            | passes ▸ | runs a branch | passes ▸    | `E2`            |
-| `recoverErr`            | passes ▸ | branch → `Ok` | passes ▸    | `never`         |
-| `tapErr` / `flatTapErr` | passes ▸ | runs a branch | passes ▸    | `E` / `E \| E2` |
-| `recoverDefect`         | passes ▸ | passes ▸      | runs `f`    | `E \| E2`       |
-| `tapDefect`             | passes ▸ | passes ▸      | runs `f`    | `E`             |
-| `tapFailure`            | passes ▸ | runs `f`      | runs `f`    | `E`             |
-| `match`                 | `ok()`   | `err()`       | `defect()`  | —               |
+| method                            | on `Ok`  | on `Err`      | on `Defect` | resulting `E`   |
+| --------------------------------- | -------- | ------------- | ----------- | --------------- |
+| `map`                             | runs `f` | passes ▸      | passes ▸    | `E`             |
+| `flatMap`                         | runs `f` | passes ▸      | passes ▸    | `E \| E2`       |
+| `tap` / `flatTap`                 | runs `f` | passes ▸      | passes ▸    | `E` / `E \| E2` |
+| `ensure`                          | runs `f` | passes ▸      | passes ▸    | `E \| E2`       |
+| `mapErrCases`                     | passes ▸ | runs a branch | passes ▸    | `E2`            |
+| `flatMapErrCases`                 | passes ▸ | runs a branch | passes ▸    | `E2`            |
+| `recoverErrCases`                 | passes ▸ | branch → `Ok` | passes ▸    | `never`         |
+| `tapErrCases` / `flatTapErrCases` | passes ▸ | runs a branch | passes ▸    | `E` / `E \| E2` |
+| `recoverDefect`                   | passes ▸ | passes ▸      | runs `f`    | `E \| E2`       |
+| `tapDefect`                       | passes ▸ | passes ▸      | runs `f`    | `E`             |
+| `tapFailure`                      | passes ▸ | runs `f`      | runs `f`    | `E`             |
+| `match`                           | `ok()`   | `err()`       | `defect()`  | —               |
 
-::: tip `recoverErr`'s `never` under-describes the runtime
-`recoverErr` empties only the **error** channel to `never` — a `Defect` can still be
+::: tip `recoverErrCases`'s `never` under-describes the runtime
+`recoverErrCases` empties only the **error** channel to `never` — a `Defect` can still be
 present at runtime and flows past it untouched. See
 [The Defect Channel](../explanation/the-defect-channel#recovererr-clears-the-error-channel-not-the-runtime).
 :::
 
 ## The error channel
 
-The error combinators — `mapErr`, `flatMapErr`, `recoverErr`, `tapErr`,
-`flatTapErr` — do not take a single callback. Their callback receives a
+The error combinators — `mapErrCases`, `flatMapErrCases`, `recoverErrCases`, `tapErrCases`,
+`flatTapErrCases` — do not take a single callback. Their callback receives a
 [ts-pattern](https://github.com/gvergnaud/ts-pattern) match builder over the
 error (`match(error)`; the patterns are re-exported from `unthrown` as `P`), and
 you **return the un-terminated builder** — the combinator calls `.exhaustive()`
@@ -85,7 +85,7 @@ for you:
 ```ts
 import { P, tag } from "unthrown";
 
-db.reading.tryFindUniqueOrThrow({ where: { id } }).mapErr(
+db.reading.tryFindUniqueOrThrow({ where: { id } }).mapErrCases(
   (matcher, defect) =>
     matcher
       .with(tag("RecordNotFound"), () => new ReadingNotFoundException(id))
@@ -116,15 +116,15 @@ forget, and no `.otherwise()` to slip in a fallback. The rationale is in
   call site. There is no partial-with-fallback middle ground: a wide union that
   treats several cases identically writes them as grouped patterns or a `P._`,
   never as a silent default.
-- **There is no error-channel identity.** `mapErr((m) => m)` is not a no-op — it
+- **There is no error-channel identity.** `mapErrCases((m) => m)` is not a no-op — it
   only type-checks when `E` is `never` and otherwise fails to compile (see
   [The Defect Channel](../explanation/the-defect-channel#no-identity-on-the-error-channel)).
-  To pass the error through, observe it with `tapErr`, or re-emit it with
+  To pass the error through, observe it with `tapErrCases`, or re-emit it with
   `.with(P._, (e) => e)`.
-- **Observers match exhaustively too.** `tapErr` and `flatTapErr` take the same
+- **Observers match exhaustively too.** `tapErrCases` and `flatTapErrCases` take the same
   builder (use `P._` for a catch-all); the error is observed and then flows
-  through unchanged. Their branch returns are ignored (`tapErr`) or thread only a
-  _new_ effect failure (`flatTapErr`). `tapDefect` / `tapFailure` keep single
+  through unchanged. Their branch returns are ignored (`tapErrCases`) or thread only a
+  _new_ effect failure (`flatTapErrCases`). `tapDefect` / `tapFailure` keep single
   callbacks — their payloads carry no discriminant to match.
 - **A non-exhaustive match is a `Defect` if it ever slips past the types.** Only
   reachable outside the typed contract (a widened cast, a JS caller): ts-pattern
@@ -141,15 +141,15 @@ itself:
 import { P } from "unthrown";
 
 // log whatever the error is, then let it flow through unchanged
-loadUser(id).tapErr((matcher) => matcher.with(P._, (e) => logger.error(e)));
+loadUser(id).tapErrCases((matcher) => matcher.with(P._, (e) => logger.error(e)));
 ```
 
 The same one-branch shape works for every error combinator — transform, recover,
 or fold at the edge:
 
 ```ts
-result.mapErr((matcher) => matcher.with(P._, (e) => new AppError(e))); // any error → AppError
-result.recoverErr((matcher) => matcher.with(P._, () => fallback)); // any error → fallback value
+result.mapErrCases((matcher) => matcher.with(P._, (e) => new AppError(e))); // any error → AppError
+result.recoverErrCases((matcher) => matcher.with(P._, () => fallback)); // any error → fallback value
 result.match({
   ok: (v) => v,
   err: (matcher) => matcher.with(P._, (e) => `failed: ${e}`),
@@ -163,7 +163,7 @@ When you'd rather be forced to revisit a new case, list the variants and omit
 the rest:
 
 ```ts
-result.tapErr((matcher) =>
+result.tapErrCases((matcher) =>
   matcher
     .with(tag("RateLimited"), (e) => metrics.rateLimit(e.retryAfter))
     .with(P._, (e) => logger.error(e)),
@@ -182,7 +182,7 @@ exactly three ways:
   re-entering a boundary and composing it with `flatMap`. (See
   [The async model](../explanation/async-model).)
 - **The `Result`-returning combinators accept `Result` _or_ `AsyncResult`.**
-  `flatMap`, `flatTap`, `flatMapErr`, `flatTapErr`, `bind`, and `recoverDefect` take
+  `flatMap`, `flatTap`, `flatMapErrCases`, `flatTapErrCases`, `bind`, and `recoverDefect` take
   a callback returning either, so you can mix sync and async steps in one chain.
 - **Eliminators return a `Promise`.** `await result.match({ … })` /
   `await result.get()` — or `await` the `AsyncResult` first to collapse it to a
@@ -217,7 +217,7 @@ you nest a `Result<Result<…>>`).
 **`flatMap` vs `flatTap`** — both take a `Result`-returning callback. `flatMap`
 **replaces** the value with the callback's; `flatTap` **discards** it and keeps
 the original (a validation or write whose _outcome_ matters but whose _value_
-you don't need). `tapErr`/`flatTapErr` are the same pair on the error channel.
+you don't need). `tapErrCases`/`flatTapErrCases` are the same pair on the error channel.
 
 **`tap` vs `flatTap`** — decided by what the _effect_ returns, not by what you do
 with its value (both keep the original). An effect that cannot fail — logging, a
@@ -251,15 +251,15 @@ either surface; an `AsyncResult`-returning one only in the **async** `flatTap`:
 
 :::
 
-**`flatMapErr` vs `recoverErr`** — both run on `Err`. `recoverErr` produces a plain
-success value (emptying the error channel to `never`); `flatMapErr` produces another
+**`flatMapErrCases` vs `recoverErrCases`** — both run on `Err`. `recoverErrCases` produces a plain
+success value (emptying the error channel to `never`); `flatMapErrCases` produces another
 `Result` (which may still be an `Err`).
 
-**`recoverErr` vs `recoverDefect`** — `recoverErr` handles a modeled `Err`;
+**`recoverErrCases` vs `recoverDefect`** — `recoverErrCases` handles a modeled `Err`;
 `recoverDefect` is the only combinator that can **consume** a `Defect`. Neither is
-the other's fallback — a defect flows past `recoverErr` untouched.
+the other's fallback — a defect flows past `recoverErrCases` untouched.
 
-**`tapErr` + `tapDefect` vs `tapFailure`** — when the _same_ effect applies to
+**`tapErrCases` + `tapDefect` vs `tapFailure`** — when the _same_ effect applies to
 both failures (a shared logger, a metric, a rollback trigger), `tapFailure` runs
 it once for either. Its callback receives the discriminated **failure variant**
 (`FailureView<E>`, i.e. `ErrView | DefectView`) rather than a payload — so branch
@@ -279,7 +279,7 @@ Reach for an eliminator once you're done chaining:
 - `getOrThrow` — extract `T`, but **throw the modeled error as-is** on `Err`
   (panicking on a defect). A deliberate escape hatch off errors-as-values: its
   point is to move a literal `throw` behind a method so a `no-throw` lint rule can
-  ban raw throws. Prefer `match` / `recoverErr` / `flatMapErr` when the error can stay a
+  ban raw throws. Prefer `match` / `recoverErrCases` / `flatMapErrCases` when the error can stay a
   value.
 
 On an `AsyncResult` every eliminator returns a `Promise` — `await` it (an `Err` or

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -70,7 +70,7 @@ rejecting promise, a nullable API. Each is crossed with a `from*` constructor
 that forces qualification. See [Qualify a boundary](../how-to/qualify-a-boundary).
 
 **combinator**
-: Any method on the fluent surface (`map`, `flatMap`, `mapErr`, `tap`, …) that
+: Any method on the fluent surface (`map`, `flatMap`, `mapErrCases`, `tap`, …) that
 transforms or observes a channel and returns another `Result` / `AsyncResult`. A
 throw inside a combinator becomes a `Defect`.
 

--- a/docs/reference/result-surface.md
+++ b/docs/reference/result-surface.md
@@ -36,8 +36,8 @@ Every `Result` shares one method surface, grouped by the channel it touches:
   `discard`
 - **do-notation** (runs on `Ok`): `bind`, `let` — accumulate a named scope; see
   [Sequence dependent steps](../how-to/sequence-dependent-steps)
-- **error** (runs on `Err`): `mapErr`, `flatMapErr`, `recoverErr`, `tapErr`,
-  `flatTapErr` — all take an **exhaustive ts-pattern matcher** over the error
+- **error** (runs on `Err`): `mapErrCases`, `flatMapErrCases`, `recoverErrCases`, `tapErrCases`,
+  `flatTapErrCases` — all take an **exhaustive ts-pattern matcher** over the error
 - **defect** (the only door to a `Defect`): `recoverDefect`, `tapDefect`
 - **failure** (runs on `Err` **or** `Defect`): `tapFailure` — observe either
   failing channel without consuming it
@@ -52,11 +52,11 @@ import { P } from "unthrown";
 
 Ok(2).map((n) => n + 1); // => Ok(3)
 Err("boom").map((n) => n + 1); // => Err("boom") — the success callback is skipped
-Ok(2 as number).mapErr((m) => m.with(P._, (e) => `wrapped: ${e}`)); // => Ok(2) — the error branch is skipped
+Ok(2 as number).mapErrCases((m) => m.with(P._, (e) => `wrapped: ${e}`)); // => Ok(2) — the error branch is skipped
 ```
 
-The `mapErr` above carries a real, exhaustive matcher; on an `Ok` it simply never
-runs. (There is no error-channel identity — `mapErr((m) => m)` is not a no-op; see
+The `mapErrCases` above carries a real, exhaustive matcher; on an `Ok` it simply never
+runs. (There is no error-channel identity — `mapErrCases((m) => m)` is not a no-op; see
 [Exhaustive error matching](../explanation/exhaustive-error-matching#no-identity-on-the-error-channel).)
 
 The full behavior grid and per-method signatures are in the

--- a/packages/core/src/async-result.spec.ts
+++ b/packages/core/src/async-result.spec.ts
@@ -76,17 +76,21 @@ describe("AsyncResult: a throw in any combinator becomes a Defect", () => {
     expect((await asyncOk(1).flatMap(t)).isDefect()).toBe(true);
     expect((await asyncOk(1).tap(t)).isDefect()).toBe(true);
     expect((await asyncOk(1).flatTap(t)).isDefect()).toBe(true);
-    expect((await asyncErr("e").mapErr((matcher) => matcher.with(P._, t))).isDefect()).toBe(true);
-    expect((await asyncErr("e").flatMapErr((matcher) => matcher.with(P._, t))).isDefect()).toBe(
+    expect((await asyncErr("e").mapErrCases((matcher) => matcher.with(P._, t))).isDefect()).toBe(
       true,
     );
-    expect((await asyncErr("e").recoverErr((matcher) => matcher.with(P._, t))).isDefect()).toBe(
+    expect(
+      (await asyncErr("e").flatMapErrCases((matcher) => matcher.with(P._, t))).isDefect(),
+    ).toBe(true);
+    expect(
+      (await asyncErr("e").recoverErrCases((matcher) => matcher.with(P._, t))).isDefect(),
+    ).toBe(true);
+    expect((await asyncErr("e").tapErrCases((matcher) => matcher.with(P._, t))).isDefect()).toBe(
       true,
     );
-    expect((await asyncErr("e").tapErr((matcher) => matcher.with(P._, t))).isDefect()).toBe(true);
-    expect((await asyncErr("e").flatTapErr((matcher) => matcher.with(P._, t))).isDefect()).toBe(
-      true,
-    );
+    expect(
+      (await asyncErr("e").flatTapErrCases((matcher) => matcher.with(P._, t))).isDefect(),
+    ).toBe(true);
     expect((await asyncDefect().recoverDefect(t)).isDefect()).toBe(true);
     expect((await asyncDefect().tapDefect(t)).isDefect()).toBe(true);
     expect((await asyncErr("e").tapFailure(t)).isDefect()).toBe(true);
@@ -223,91 +227,97 @@ describe("AsyncResult success channel", () => {
 });
 
 describe("AsyncResult error channel", () => {
-  it("mapErr transforms the Err", async () => {
+  it("mapErrCases transforms the Err", async () => {
     expect(
-      (await asyncErr("e").mapErr((matcher) => matcher.with(P._, (s) => `${s}!`))).getErr(),
+      (await asyncErr("e").mapErrCases((matcher) => matcher.with(P._, (s) => `${s}!`))).getErr(),
     ).toBe("e!");
   });
 
-  it("flatMapErr recovers an Err", async () => {
+  it("flatMapErrCases recovers an Err", async () => {
     expect(
-      (await asyncErr("e").flatMapErr((matcher) => matcher.with(P._, () => Ok(9)))).get(),
+      (await asyncErr("e").flatMapErrCases((matcher) => matcher.with(P._, () => Ok(9)))).get(),
     ).toBe(9);
   });
 
-  it("flatMapErr composes async recovery via a qualified boundary", async () => {
-    const r = await asyncErr<string>("e").flatMapErr((matcher) =>
+  it("flatMapErrCases composes async recovery via a qualified boundary", async () => {
+    const r = await asyncErr<string>("e").flatMapErrCases((matcher) =>
       matcher.with(P._, () => fromSafePromise(Promise.resolve("recovered"))),
     );
     expect(r.get()).toBe("recovered");
   });
 
-  it("recoverErr turns an Err into an Ok", async () => {
-    expect((await asyncErr("e").recoverErr((matcher) => matcher.with(P._, () => 1))).get()).toBe(1);
+  it("recoverErrCases turns an Err into an Ok", async () => {
+    expect(
+      (await asyncErr("e").recoverErrCases((matcher) => matcher.with(P._, () => 1))).get(),
+    ).toBe(1);
   });
 
   it("a triage branch returning the injected defect(cause) becomes a Defect on every transformer", async () => {
     const boom2 = new Error("boom2");
     expect(
       (
-        await asyncErr("e").mapErr((matcher, defect) => matcher.with(P._, (_e) => defect(boom2)))
-      ).isDefect(),
-    ).toBe(true);
-    expect(
-      (
-        await asyncErr("e").flatMapErr((matcher, defect) =>
+        await asyncErr("e").mapErrCases((matcher, defect) =>
           matcher.with(P._, (_e) => defect(boom2)),
         )
       ).isDefect(),
     ).toBe(true);
     expect(
       (
-        await asyncErr("e").recoverErr((matcher, defect) =>
+        await asyncErr("e").flatMapErrCases((matcher, defect) =>
+          matcher.with(P._, (_e) => defect(boom2)),
+        )
+      ).isDefect(),
+    ).toBe(true);
+    expect(
+      (
+        await asyncErr("e").recoverErrCases((matcher, defect) =>
           matcher.with(P._, (_e) => defect(boom2)),
         )
       ).isDefect(),
     ).toBe(true);
   });
 
-  it("tapErr runs the side effect and preserves the error", async () => {
+  it("tapErrCases runs the side effect and preserves the error", async () => {
     const seen: string[] = [];
-    const r = await asyncErr("e").tapErr((matcher) => matcher.with(P._, (s) => seen.push(s)));
+    const r = await asyncErr("e").tapErrCases((matcher) => matcher.with(P._, (s) => seen.push(s)));
     expect(seen).toEqual(["e"]);
     expect(r.getErr()).toBe("e");
   });
 
-  it("flatTapErr keeps the original error when the effect succeeds", async () => {
-    const r = await asyncErr("e").flatTapErr((matcher) => matcher.with(P._, () => Ok("ignored")));
+  it("flatTapErrCases keeps the original error when the effect succeeds", async () => {
+    const r = await asyncErr("e").flatTapErrCases((matcher) =>
+      matcher.with(P._, () => Ok("ignored")),
+    );
     expect(r.getErr()).toBe("e");
   });
 
-  it("flatTapErr threads the effect's Err", async () => {
+  it("flatTapErrCases threads the effect's Err", async () => {
     expect(
       (
-        await asyncErr("e").flatTapErr((matcher) => matcher.with(P._, () => Err("log_failed")))
+        await asyncErr("e").flatTapErrCases((matcher) => matcher.with(P._, () => Err("log_failed")))
       ).getErr(),
     ).toBe("log_failed");
   });
 
-  it("flatTapErr composes an async effect via a qualified boundary, keeping the error", async () => {
-    const r = await asyncErr("e").flatTapErr((matcher) =>
+  it("flatTapErrCases composes an async effect via a qualified boundary, keeping the error", async () => {
+    const r = await asyncErr("e").flatTapErrCases((matcher) =>
       matcher.with(P._, () => fromSafePromise(Promise.resolve("logged"))),
     );
     expect(r.getErr()).toBe("e");
   });
 
-  it("flatTapErr does not run the effect on Ok or Defect", async () => {
+  it("flatTapErrCases does not run the effect on Ok or Defect", async () => {
     const f = vi.fn(() => Ok(1));
-    expect((await asyncOk(1).flatTapErr((matcher) => matcher.with(P._, f))).get()).toBe(1);
-    expect((await asyncDefect().flatTapErr((matcher) => matcher.with(P._, f))).isDefect()).toBe(
-      true,
-    );
+    expect((await asyncOk(1).flatTapErrCases((matcher) => matcher.with(P._, f))).get()).toBe(1);
+    expect(
+      (await asyncDefect().flatTapErrCases((matcher) => matcher.with(P._, f))).isDefect(),
+    ).toBe(true);
     expect(f).not.toHaveBeenCalled();
   });
 
-  it("tapErr: a throwing callback preserves the original error in an AggregateError", async () => {
+  it("tapErrCases: a throwing callback preserves the original error in an AggregateError", async () => {
     const thrown = new Error("boom");
-    const r = await asyncErr("original").tapErr((matcher) =>
+    const r = await asyncErr("original").tapErrCases((matcher) =>
       matcher.with(P._, () => {
         throw thrown;
       }),
@@ -319,9 +329,9 @@ describe("AsyncResult error channel", () => {
     }
   });
 
-  it("flatTapErr: a throwing callback preserves the original error in an AggregateError", async () => {
+  it("flatTapErrCases: a throwing callback preserves the original error in an AggregateError", async () => {
     const thrown = new Error("boom");
-    const r = await asyncErr("original").flatTapErr((matcher) =>
+    const r = await asyncErr("original").flatTapErrCases((matcher) =>
       matcher.with(P._, () => {
         throw thrown;
       }),
@@ -337,10 +347,12 @@ describe("AsyncResult Defect channel", () => {
   it("a Defect flows through the success and error combinators untouched", async () => {
     const f = vi.fn();
     expect((await asyncDefect().map(f)).isDefect()).toBe(true);
-    expect((await asyncDefect().mapErr((matcher) => matcher.with(P._, f))).isDefect()).toBe(true);
-    expect((await asyncDefect().recoverErr((matcher) => matcher.with(P._, f))).isDefect()).toBe(
+    expect((await asyncDefect().mapErrCases((matcher) => matcher.with(P._, f))).isDefect()).toBe(
       true,
     );
+    expect(
+      (await asyncDefect().recoverErrCases((matcher) => matcher.with(P._, f))).isDefect(),
+    ).toBe(true);
     expect(f).not.toHaveBeenCalled();
   });
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -185,7 +185,7 @@ class Res<T, E> {
     }
   }
 
-  mapErr<M extends ExhaustiveMatch<unknown>>(
+  mapErrCases<M extends ExhaustiveMatch<unknown>>(
     this: Result<T, E>,
     f: (matcher: ErrMatcher<E>, defect: (cause: unknown) => Defect) => M,
   ): Result<T, MatchErrOut<M>> {
@@ -199,7 +199,7 @@ class Res<T, E> {
     }
   }
 
-  flatMapErr<M extends ExhaustiveMatch<Result<unknown, unknown> | Defect>>(
+  flatMapErrCases<M extends ExhaustiveMatch<Result<unknown, unknown> | Defect>>(
     this: Result<T, E>,
     f: (matcher: ErrMatcher<E>, defect: (cause: unknown) => Defect) => M,
   ): Result<T | OkOf<MatchOut<M>>, ErrOf<MatchOut<M>>> {
@@ -214,7 +214,7 @@ class Res<T, E> {
     }
   }
 
-  recoverErr<M extends ExhaustiveMatch<unknown>>(
+  recoverErrCases<M extends ExhaustiveMatch<unknown>>(
     this: Result<T, E>,
     f: (matcher: ErrMatcher<E>, defect: (cause: unknown) => Defect) => M,
   ): Result<T | MatchErrOut<M>, never> {
@@ -228,7 +228,7 @@ class Res<T, E> {
     }
   }
 
-  tapErr(
+  tapErrCases(
     this: Result<T, E>,
     f: (matcher: ErrMatcher<E>, defect: (cause: unknown) => Defect) => ExhaustiveMatch<unknown>,
   ): Result<T, E> {
@@ -241,7 +241,7 @@ class Res<T, E> {
     }
   }
 
-  flatTapErr<M extends ExhaustiveMatch<Result<unknown, unknown>>>(
+  flatTapErrCases<M extends ExhaustiveMatch<Result<unknown, unknown>>>(
     this: Result<T, E>,
     f: (matcher: ErrMatcher<E>, defect: (cause: unknown) => Defect) => M,
   ): Result<T, E | ErrOf<MatchOut<M>>> {
@@ -540,7 +540,7 @@ function runMatch<E>(
 }
 
 /**
- * A throw inside a *failure observer* (`tapErr` / `tapDefect` / `flatTapErr`)
+ * A throw inside a *failure observer* (`tapErrCases` / `tapDefect` / `flatTapErrCases`)
  * must not destroy the failure being observed — that is the exact place (e.g. a
  * failing error-logger) where losing the underlying failure hurts most. The
  * resulting Defect aggregates both: `errors[0]` is the observer's throw,
@@ -746,7 +746,7 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
   // loosely — `never` error channels keep the returns bivariantly compatible —
   // and the interface re-imposes the precision, mirroring how `get`'s `this`
   // gate is re-imposed in `types.ts`.
-  mapErr(
+  mapErrCases(
     f: (matcher: ErrMatcher<E>, defect: (cause: unknown) => Defect) => ExhaustiveMatch<unknown>,
   ): AsyncResult<T, never> {
     return new AsyncRes<T, never>(
@@ -763,7 +763,7 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
     );
   }
 
-  flatMapErr(
+  flatMapErrCases(
     f: (
       matcher: ErrMatcher<E>,
       defect: (cause: unknown) => Defect,
@@ -785,7 +785,7 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
     );
   }
 
-  recoverErr(
+  recoverErrCases(
     f: (matcher: ErrMatcher<E>, defect: (cause: unknown) => Defect) => ExhaustiveMatch<unknown>,
   ): AsyncResult<T, never> {
     return new AsyncRes<T, never>(
@@ -802,7 +802,7 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
     );
   }
 
-  tapErr(
+  tapErrCases(
     f: (matcher: ErrMatcher<E>, defect: (cause: unknown) => Defect) => ExhaustiveMatch<unknown>,
   ): AsyncResult<T, E> {
     return new AsyncRes<T, E>(
@@ -818,7 +818,7 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
     );
   }
 
-  flatTapErr(
+  flatTapErrCases(
     f: (
       matcher: ErrMatcher<E>,
       defect: (cause: unknown) => Defect,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-// ts-pattern powers the error-matching combinators (`mapErr`/`flatMapErr`/…),
+// ts-pattern powers the error-matching combinators (`mapErrCases`/`flatMapErrCases`/…),
 // and is re-exported so `P` (wildcards, `P.union`, guards) and `match` (for
 // eliminating a `Result` directly) are available from one import.
 export { match, P } from "ts-pattern";

--- a/packages/core/src/invariants.spec.ts
+++ b/packages/core/src/invariants.spec.ts
@@ -36,27 +36,27 @@ describe("Invariant 1: throw inside any combinator becomes a Defect", () => {
     expect(Do().let("a", t).isDefect()).toBe(true);
     expect(
       Err("e")
-        .mapErr((matcher) => matcher.with(P._, t))
+        .mapErrCases((matcher) => matcher.with(P._, t))
         .isDefect(),
     ).toBe(true);
     expect(
       Err("e")
-        .flatMapErr((matcher) => matcher.with(P._, t))
+        .flatMapErrCases((matcher) => matcher.with(P._, t))
         .isDefect(),
     ).toBe(true);
     expect(
       Err("e")
-        .recoverErr((matcher) => matcher.with(P._, t))
+        .recoverErrCases((matcher) => matcher.with(P._, t))
         .isDefect(),
     ).toBe(true);
     expect(
       Err("e")
-        .tapErr((matcher) => matcher.with(P._, t))
+        .tapErrCases((matcher) => matcher.with(P._, t))
         .isDefect(),
     ).toBe(true);
     expect(
       Err("e")
-        .flatTapErr((matcher) => matcher.with(P._, t))
+        .flatTapErrCases((matcher) => matcher.with(P._, t))
         .isDefect(),
     ).toBe(true);
     expect(defectOf(boom).recoverDefect(t).isDefect()).toBe(true);
@@ -73,13 +73,13 @@ describe("Invariant 1b: a Result-constrained callback returning a non-Result bec
   // that throws a raw TypeError later in the pipeline.
   const rogue = (() => 42) as never;
 
-  it("sync: flatMap / flatTap / bind / flatMapErr / flatTapErr / recoverDefect", () => {
+  it("sync: flatMap / flatTap / bind / flatMapErrCases / flatTapErrCases / recoverDefect", () => {
     const hardened = [
       Ok(1).flatMap(rogue),
       Ok(1).flatTap(rogue),
       Do().bind("a", rogue),
-      Err("e").flatMapErr((matcher) => matcher.with(P._, () => 42 as never)),
-      Err("e").flatTapErr((matcher) => matcher.with(P._, () => 42 as never)),
+      Err("e").flatMapErrCases((matcher) => matcher.with(P._, () => 42 as never)),
+      Err("e").flatTapErrCases((matcher) => matcher.with(P._, () => 42 as never)),
       defectOf(boom).recoverDefect(rogue),
     ];
     for (const r of hardened) {
@@ -98,10 +98,10 @@ describe("Invariant 1b: a Result-constrained callback returning a non-Result bec
       Do().toAsync().bind("a", rogue),
       Err("e")
         .toAsync()
-        .flatMapErr((matcher) => matcher.with(P._, () => 42 as never)),
+        .flatMapErrCases((matcher) => matcher.with(P._, () => 42 as never)),
       Err("e")
         .toAsync()
-        .flatTapErr((matcher) => matcher.with(P._, () => 42 as never)),
+        .flatTapErrCases((matcher) => matcher.with(P._, () => 42 as never)),
       defectOf(boom).toAsync().recoverDefect(rogue),
     ]);
     for (const r of hardened) {
@@ -135,11 +135,11 @@ describe("Invariant 2: a Defect flows through every method except match() and re
         f(v);
         return true;
       }, f),
-      defectOf(boom).mapErr((matcher) => matcher.with(P._, f)),
-      defectOf(boom).flatMapErr((matcher) => matcher.with(P._, f)),
-      defectOf(boom).recoverErr((matcher) => matcher.with(P._, f)),
-      defectOf(boom).tapErr((matcher) => matcher.with(P._, f)),
-      defectOf(boom).flatTapErr((matcher) => matcher.with(P._, f)),
+      defectOf(boom).mapErrCases((matcher) => matcher.with(P._, f)),
+      defectOf(boom).flatMapErrCases((matcher) => matcher.with(P._, f)),
+      defectOf(boom).recoverErrCases((matcher) => matcher.with(P._, f)),
+      defectOf(boom).tapErrCases((matcher) => matcher.with(P._, f)),
+      defectOf(boom).flatTapErrCases((matcher) => matcher.with(P._, f)),
     ];
     for (const r of passesThrough) expect(r.isDefect()).toBe(true);
     expect(f).not.toHaveBeenCalled();
@@ -202,9 +202,9 @@ describe("Invariant 3: get() is asymmetric", () => {
   });
 });
 
-describe("Invariant 4: recoverErr empties the error channel in the type, not the runtime", () => {
-  it("recoverErr() returns a value whose type is Result<_, never> but may still be a Defect", () => {
-    const recovered = defectOf(boom).recoverErr((matcher) => matcher.with(P._, () => 1));
+describe("Invariant 4: recoverErrCases empties the error channel in the type, not the runtime", () => {
+  it("recoverErrCases() returns a value whose type is Result<_, never> but may still be a Defect", () => {
+    const recovered = defectOf(boom).recoverErrCases((matcher) => matcher.with(P._, () => 1));
     // `never` in the type does not mean total — a Defect survives at runtime.
     expect(recovered.isDefect()).toBe(true);
   });

--- a/packages/core/src/result.spec.ts
+++ b/packages/core/src/result.spec.ts
@@ -251,9 +251,9 @@ type TagB = { _tag: "B"; b: string };
 const errA = (a: number): Result<never, TagA | TagB> => Err<TagA | TagB>({ _tag: "A", a });
 const errB = (b: string): Result<never, TagA | TagB> => Err<TagA | TagB>({ _tag: "B", b });
 
-describe("Result.mapErr (ts-pattern matcher)", () => {
+describe("Result.mapErrCases (ts-pattern matcher)", () => {
   it("dispatches a tagged error to its matching branch", () => {
-    const r = errA(7).mapErr((matcher) =>
+    const r = errA(7).mapErrCases((matcher) =>
       matcher.with(tag("A"), (e) => `a:${e.a}`).with(tag("B"), (e) => `b:${e.b}`),
     );
     expect(r.getErr()).toBe("a:7");
@@ -261,7 +261,7 @@ describe("Result.mapErr (ts-pattern matcher)", () => {
 
   it("matches a non-_tag (code-discriminated) union", () => {
     type CodeErr = { code: "NOT_FOUND" } | { code: "FORBIDDEN" };
-    const r = (Err({ code: "FORBIDDEN" }) as Result<never, CodeErr>).mapErr((matcher) =>
+    const r = (Err({ code: "FORBIDDEN" }) as Result<never, CodeErr>).mapErrCases((matcher) =>
       matcher.with({ code: "NOT_FOUND" }, () => 404).with({ code: "FORBIDDEN" }, () => 403),
     );
     expect(r.getErr()).toBe(403);
@@ -269,23 +269,23 @@ describe("Result.mapErr (ts-pattern matcher)", () => {
 
   it("shares one strategy across grouped patterns", () => {
     const build = (r: Result<never, TagA | TagB>) =>
-      r.mapErr((matcher) => matcher.with(tag("A"), tag("B"), () => "grouped" as const));
+      r.mapErrCases((matcher) => matcher.with(tag("A"), tag("B"), () => "grouped" as const));
     expect(build(errA(7)).getErr()).toBe("grouped");
     expect(build(errB("x")).getErr()).toBe("grouped");
   });
 
   it("P._ is the deliberate catch-all", () => {
-    const r = errA(7).mapErr((matcher) => matcher.with(P._, (e) => `all:${e._tag}`));
+    const r = errA(7).mapErrCases((matcher) => matcher.with(P._, (e) => `all:${e._tag}`));
     expect(r.getErr()).toBe("all:A");
   });
 
   it("a branch returning the injected defect(cause) becomes a Defect carrying that cause", () => {
-    const ok = errA(7).mapErr((matcher, defect) =>
+    const ok = errA(7).mapErrCases((matcher, defect) =>
       matcher.with(tag("A"), (e) => e.a).with(tag("B"), (_e) => defect(boom)),
     );
     expect(ok.isDefect()).toBe(false); // an A error takes the mapped branch
 
-    const d = errB("x").mapErr((matcher, defect) =>
+    const d = errB("x").mapErrCases((matcher, defect) =>
       matcher.with(tag("A"), (e) => e.a).with(tag("B"), (_e) => defect(boom)),
     );
     expect(d.isDefect()).toBe(true);
@@ -294,13 +294,13 @@ describe("Result.mapErr (ts-pattern matcher)", () => {
 
   it("throws NonExhaustiveError → Defect when a value slips past the types", () => {
     const smuggled = Err({ _tag: "C" }) as unknown as Result<never, TagA>;
-    const r = smuggled.mapErr((matcher) => matcher.with(tag("A"), (e) => e.a));
+    const r = smuggled.mapErrCases((matcher) => matcher.with(tag("A"), (e) => e.a));
     expect(r.isDefect()).toBe(true);
   });
 
   it("passes Ok through and does not run the matcher", () => {
     const f = vi.fn();
-    const r = Ok(1).mapErr((matcher) => matcher.with(P._, f));
+    const r = Ok(1).mapErrCases((matcher) => matcher.with(P._, f));
     expect(r.isOk()).toBe(true);
     if (r.isOk()) expect(r.value).toBe(1);
     expect(f).not.toHaveBeenCalled();
@@ -310,14 +310,14 @@ describe("Result.mapErr (ts-pattern matcher)", () => {
     const f = vi.fn();
     expect(
       defectOf(boom)
-        .mapErr((matcher) => matcher.with(P._, f))
+        .mapErrCases((matcher) => matcher.with(P._, f))
         .isDefect(),
     ).toBe(true);
     expect(f).not.toHaveBeenCalled();
   });
 
   it("converts a throw inside a branch into a Defect", () => {
-    const r = errA(7).mapErr((matcher) =>
+    const r = errA(7).mapErrCases((matcher) =>
       matcher.with(P._, () => {
         throw boom;
       }),
@@ -326,18 +326,18 @@ describe("Result.mapErr (ts-pattern matcher)", () => {
   });
 });
 
-describe("Result.flatMapErr (ts-pattern matcher)", () => {
+describe("Result.flatMapErrCases (ts-pattern matcher)", () => {
   it("recovers an Err into an Ok", () => {
     expect(
       Err("e")
-        .flatMapErr((matcher) => matcher.with(P._, () => Ok(99)))
+        .flatMapErrCases((matcher) => matcher.with(P._, () => Ok(99)))
         .get(),
     ).toBe(99);
   });
 
   it("dispatches per tag — one branch recovers, another re-emits", () => {
     const build = (r: Result<never, TagA | TagB>) =>
-      r.flatMapErr((matcher) =>
+      r.flatMapErrCases((matcher) =>
         matcher.with(tag("A"), (e) => Ok(e.a)).with(tag("B"), (e) => Err(e)),
       );
     expect(build(errA(7)).getOr(-1)).toBe(7);
@@ -346,7 +346,7 @@ describe("Result.flatMapErr (ts-pattern matcher)", () => {
   });
 
   it("a branch may return defect(cause)", () => {
-    const d = Err("e").flatMapErr((matcher, defect) => matcher.with(P._, (e) => defect(e)));
+    const d = Err("e").flatMapErrCases((matcher, defect) => matcher.with(P._, (e) => defect(e)));
     expect(d.isDefect()).toBe(true);
     if (d.isDefect()) expect(d.cause).toBe("e");
   });
@@ -355,12 +355,12 @@ describe("Result.flatMapErr (ts-pattern matcher)", () => {
     const f = vi.fn();
     expect(
       Ok(1)
-        .flatMapErr((matcher) => matcher.with(P._, f))
+        .flatMapErrCases((matcher) => matcher.with(P._, f))
         .getOr(-1),
     ).toBe(1);
     expect(
       defectOf(boom)
-        .flatMapErr((matcher) => matcher.with(P._, f))
+        .flatMapErrCases((matcher) => matcher.with(P._, f))
         .isDefect(),
     ).toBe(true);
     expect(f).not.toHaveBeenCalled();
@@ -369,7 +369,7 @@ describe("Result.flatMapErr (ts-pattern matcher)", () => {
   it("converts a throw into a Defect", () => {
     expect(
       Err("e")
-        .flatMapErr((matcher) =>
+        .flatMapErrCases((matcher) =>
           matcher.with(P._, () => {
             throw boom;
           }),
@@ -379,11 +379,11 @@ describe("Result.flatMapErr (ts-pattern matcher)", () => {
   });
 });
 
-describe("Result.recoverErr (ts-pattern matcher)", () => {
+describe("Result.recoverErrCases (ts-pattern matcher)", () => {
   it("turns an Err into an Ok", () => {
     expect(
       Err("e")
-        .recoverErr((matcher) => matcher.with(P._, () => 7))
+        .recoverErrCases((matcher) => matcher.with(P._, () => 7))
         .get(),
     ).toBe(7);
   });
@@ -391,7 +391,7 @@ describe("Result.recoverErr (ts-pattern matcher)", () => {
   it("dispatches per tag and unions the recovered values", () => {
     expect(
       errA(7)
-        .recoverErr((matcher) => matcher.with(tag("A"), (e) => e.a).with(tag("B"), (e) => e.b))
+        .recoverErrCases((matcher) => matcher.with(tag("A"), (e) => e.a).with(tag("B"), (e) => e.b))
         .get(),
     ).toBe(7);
   });
@@ -400,7 +400,7 @@ describe("Result.recoverErr (ts-pattern matcher)", () => {
     const f = vi.fn();
     expect(
       Ok(1)
-        .recoverErr((matcher) => matcher.with(P._, f))
+        .recoverErrCases((matcher) => matcher.with(P._, f))
         .get(),
     ).toBe(1);
     expect(f).not.toHaveBeenCalled();
@@ -408,13 +408,13 @@ describe("Result.recoverErr (ts-pattern matcher)", () => {
 
   it("does NOT recover a Defect — `never` empties only the error channel", () => {
     const f = vi.fn();
-    const recovered = defectOf(boom).recoverErr((matcher) => matcher.with(P._, f));
+    const recovered = defectOf(boom).recoverErrCases((matcher) => matcher.with(P._, f));
     expect(f).not.toHaveBeenCalled();
     expect(recovered.isDefect()).toBe(true);
   });
 
   it("a branch returning defect(cause) stays a Defect (not a recovery)", () => {
-    const d = Err("e").recoverErr((matcher, defect) => matcher.with(P._, (e) => defect(e)));
+    const d = Err("e").recoverErrCases((matcher, defect) => matcher.with(P._, (e) => defect(e)));
     expect(d.isDefect()).toBe(true);
     if (d.isDefect()) expect(d.cause).toBe("e");
   });
@@ -422,7 +422,7 @@ describe("Result.recoverErr (ts-pattern matcher)", () => {
   it("converts a throw into a Defect", () => {
     expect(
       Err("e")
-        .recoverErr((matcher) =>
+        .recoverErrCases((matcher) =>
           matcher.with(P._, () => {
             throw boom;
           }),
@@ -432,17 +432,17 @@ describe("Result.recoverErr (ts-pattern matcher)", () => {
   });
 });
 
-describe("Result.tapErr (ts-pattern matcher, exhaustive)", () => {
+describe("Result.tapErrCases (ts-pattern matcher, exhaustive)", () => {
   it("runs the side effect on Err and returns the same error", () => {
     const seen: string[] = [];
-    const r = Err("e").tapErr((matcher) => matcher.with(P._, (s) => seen.push(s)));
+    const r = Err("e").tapErrCases((matcher) => matcher.with(P._, (s) => seen.push(s)));
     expect(seen).toEqual(["e"]);
     expect(r.getErr()).toBe("e");
   });
 
   it("runs only the matching branch; the error still passes through unchanged", () => {
     const seenA: number[] = [];
-    const observed = errA(7).tapErr((matcher) =>
+    const observed = errA(7).tapErrCases((matcher) =>
       matcher.with(tag("A"), (e) => seenA.push(e.a)).with(tag("B"), () => undefined),
     );
     expect(seenA).toEqual([7]);
@@ -453,22 +453,22 @@ describe("Result.tapErr (ts-pattern matcher, exhaustive)", () => {
     const f = vi.fn();
     expect(
       Ok(1)
-        .tapErr((matcher) => matcher.with(P._, f))
+        .tapErrCases((matcher) => matcher.with(P._, f))
         .getOr(-1),
     ).toBe(1);
     expect(
       defectOf(boom)
-        .tapErr((matcher) => matcher.with(P._, f))
+        .tapErrCases((matcher) => matcher.with(P._, f))
         .isDefect(),
     ).toBe(true);
     expect(f).not.toHaveBeenCalled();
   });
 });
 
-describe("Result.flatTapErr (ts-pattern matcher, exhaustive)", () => {
+describe("Result.flatTapErrCases (ts-pattern matcher, exhaustive)", () => {
   it("runs the failable effect on Err and keeps the original error on success", () => {
     const seen: string[] = [];
-    const r = Err("e").flatTapErr((matcher) =>
+    const r = Err("e").flatTapErrCases((matcher) =>
       matcher.with(P._, (s) => {
         seen.push(s);
         return Ok("ignored");
@@ -479,12 +479,12 @@ describe("Result.flatTapErr (ts-pattern matcher, exhaustive)", () => {
   });
 
   it("threads the effect's Err", () => {
-    const r = Err("e").flatTapErr((matcher) => matcher.with(P._, () => Err("log_failed")));
+    const r = Err("e").flatTapErrCases((matcher) => matcher.with(P._, () => Err("log_failed")));
     expect(r.getErr()).toBe("log_failed");
   });
 
   it("propagates a Defect from the effect", () => {
-    const r = Err("e").flatTapErr((matcher) => matcher.with(P._, () => defectOf(boom)));
+    const r = Err("e").flatTapErrCases((matcher) => matcher.with(P._, () => defectOf(boom)));
     expect(r.isDefect()).toBe(true);
   });
 
@@ -492,12 +492,12 @@ describe("Result.flatTapErr (ts-pattern matcher, exhaustive)", () => {
     const f = vi.fn(() => Ok(1));
     expect(
       Ok(1)
-        .flatTapErr((matcher) => matcher.with(P._, f))
+        .flatTapErrCases((matcher) => matcher.with(P._, f))
         .getOr(-1),
     ).toBe(1);
     expect(
       defectOf(boom)
-        .flatTapErr((matcher) => matcher.with(P._, f))
+        .flatTapErrCases((matcher) => matcher.with(P._, f))
         .isDefect(),
     ).toBe(true);
     expect(f).not.toHaveBeenCalled();
@@ -506,7 +506,7 @@ describe("Result.flatTapErr (ts-pattern matcher, exhaustive)", () => {
   it("converts a throw into a Defect", () => {
     expect(
       Err("e")
-        .flatTapErr((matcher) =>
+        .flatTapErrCases((matcher) =>
           matcher.with(P._, () => {
             throw boom;
           }),
@@ -517,38 +517,38 @@ describe("Result.flatTapErr (ts-pattern matcher, exhaustive)", () => {
 });
 
 describe("a rogue value past the types: NonExhaustiveError → Defect in EVERY error combinator", () => {
-  // The mapErr case is guarded above; the other four share runMatch, but the
+  // The mapErrCases case is guarded above; the other four share runMatch, but the
   // invariant claims all five — so each gets its own probe.
   const smuggled = () => Err({ _tag: "C" }) as unknown as Result<never, TagA>;
 
-  it("flatMapErr routes the unmatched rogue value to a Defect", () => {
+  it("flatMapErrCases routes the unmatched rogue value to a Defect", () => {
     expect(
       smuggled()
-        .flatMapErr((matcher) => matcher.with(tag("A"), (e) => Ok(e.a)))
+        .flatMapErrCases((matcher) => matcher.with(tag("A"), (e) => Ok(e.a)))
         .isDefect(),
     ).toBe(true);
   });
 
-  it("recoverErr routes the unmatched rogue value to a Defect", () => {
+  it("recoverErrCases routes the unmatched rogue value to a Defect", () => {
     expect(
       smuggled()
-        .recoverErr((matcher) => matcher.with(tag("A"), (e) => e.a))
+        .recoverErrCases((matcher) => matcher.with(tag("A"), (e) => e.a))
         .isDefect(),
     ).toBe(true);
   });
 
-  it("tapErr routes the unmatched rogue value to a Defect", () => {
+  it("tapErrCases routes the unmatched rogue value to a Defect", () => {
     expect(
       smuggled()
-        .tapErr((matcher) => matcher.with(tag("A"), () => undefined))
+        .tapErrCases((matcher) => matcher.with(tag("A"), () => undefined))
         .isDefect(),
     ).toBe(true);
   });
 
-  it("flatTapErr routes the unmatched rogue value to a Defect", () => {
+  it("flatTapErrCases routes the unmatched rogue value to a Defect", () => {
     expect(
       smuggled()
-        .flatTapErr((matcher) => matcher.with(tag("A"), () => Ok(1)))
+        .flatTapErrCases((matcher) => matcher.with(tag("A"), () => Ok(1)))
         .isDefect(),
     ).toBe(true);
   });
@@ -641,9 +641,9 @@ describe("Result.tapFailure (the cross-channel observer)", () => {
 });
 
 describe("failure-observer throws preserve the original failure", () => {
-  it("tapErr: a throwing callback yields a Defect aggregating [thrown, original]", () => {
+  it("tapErrCases: a throwing callback yields a Defect aggregating [thrown, original]", () => {
     const boom = new Error("boom");
-    const r = Err("original").tapErr((matcher) =>
+    const r = Err("original").tapErrCases((matcher) =>
       matcher.with(P._, () => {
         throw boom;
       }),
@@ -668,9 +668,9 @@ describe("failure-observer throws preserve the original failure", () => {
     }
   });
 
-  it("flatTapErr: a throwing callback yields a Defect aggregating [thrown, original]", () => {
+  it("flatTapErrCases: a throwing callback yields a Defect aggregating [thrown, original]", () => {
     const boom = new Error("boom");
-    const r = Err("original").flatTapErr((matcher) =>
+    const r = Err("original").flatTapErrCases((matcher) =>
       matcher.with(P._, () => {
         throw boom;
       }),
@@ -784,7 +784,7 @@ describe("Result eliminators on Ok / Err", () => {
     expect((Ok(3) as Result<number, "e">).getOrThrow()).toBe(3);
 
     // Err throws the error value itself, BY REFERENCE (faithful to
-    // `.flatMapErr((e) => { throw e })`). `toThrow(err)` only matches the message,
+    // `.flatMapErrCases((e) => { throw e })`). `toThrow(err)` only matches the message,
     // so assert identity via try/catch instead.
     const err = new Error("modeled");
     try {

--- a/packages/core/src/result.spec.ts
+++ b/packages/core/src/result.spec.ts
@@ -784,7 +784,7 @@ describe("Result eliminators on Ok / Err", () => {
     expect((Ok(3) as Result<number, "e">).getOrThrow()).toBe(3);
 
     // Err throws the error value itself, BY REFERENCE (faithful to
-    // `.flatMapErrCases((e) => { throw e })`). `toThrow(err)` only matches the message,
+    // `.flatMapErrCases((m) => m.with(P._, (e) => { throw e }))`). `toThrow(err)` only matches the message,
     // so assert identity via try/catch instead.
     const err = new Error("modeled");
     try {

--- a/packages/core/src/tagged.ts
+++ b/packages/core/src/tagged.ts
@@ -66,7 +66,7 @@ export type TaggedErrorConstructor<Tag extends string> = {
  * *narrowing* structured field.
  *
  * `_tag` is the discriminant matched by {@link tag} in the error combinators
- * (`result.mapErr((matcher) => matcher.with(tag("NotFound"), …))`) and in
+ * (`result.mapErrCases((matcher) => matcher.with(tag("NotFound"), …))`) and in
  * `match`; `Error.name` is the human-facing label in stack traces and logs. By
  * default they coincide, but
  * they can be **decoupled** with `options.name` — so a tag can be namespaced for
@@ -160,7 +160,7 @@ export function TaggedError<Tag extends string>(
  *
  * @example
  * ```ts
- * result.mapErr((matcher) =>
+ * result.mapErrCases((matcher) =>
  *   matcher
  *     .with(tag("NotFound"), () => new NotFoundException())
  *     .with(tag("Conflict"), (e) => new ConflictException(e.key)),

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -224,13 +224,13 @@ type _errViewNarrow = Expect<
 const flatTapped = r1.flatTap(() => Err<"e2">("e2"));
 type _flatTapped = Expect<Equal<typeof flatTapped, Result<number, "e1" | "e2">>>;
 
-// flatTapErr KEEPS the value type and widens the error channel (error-side mirror);
+// flatTapErrCases KEEPS the value type and widens the error channel (error-side mirror);
 // as an observer it takes the *partial* triage object
-const flatTapErred = r1.flatTapErr((matcher) => matcher.with(P._, () => Err<"e2">("e2")));
+const flatTapErred = r1.flatTapErrCases((matcher) => matcher.with(P._, () => Err<"e2">("e2")));
 type _flatTapErred = Expect<Equal<typeof flatTapErred, Result<number, "e1" | "e2">>>;
 
-// recoverErr empties the error channel (to `never`)
-const recovered = r1.recoverErr((matcher) => matcher.with(P._, () => 0));
+// recoverErrCases empties the error channel (to `never`)
+const recovered = r1.recoverErrCases((matcher) => matcher.with(P._, () => 0));
 type _recovered = Expect<Equal<typeof recovered, Result<number, never>>>;
 
 // discard collapses the success type to `void` (not `undefined`) — and the async mirror
@@ -240,10 +240,10 @@ type _discarded = Expect<Equal<typeof discarded, Result<void, "e1">>>;
 const discardedAsync = ar.discard();
 type _discardedAsync = Expect<Equal<typeof discardedAsync, AsyncResult<void, "e">>>;
 
-// map changes the value type; mapErr changes the error type
+// map changes the value type; mapErrCases changes the error type
 const mapped = r1.map((n) => `${n}`);
 type _mapped = Expect<Equal<typeof mapped, Result<string, "e1">>>;
-const errMapped = r1.mapErr((matcher) => matcher.with(P._, () => 0 as const));
+const errMapped = r1.mapErrCases((matcher) => matcher.with(P._, () => 0 as const));
 type _errMapped = Expect<Equal<typeof errMapped, Result<number, 0>>>;
 
 // --- do-notation: bind/let accumulate a named scope, errors union ------------
@@ -444,18 +444,18 @@ new WithMsg({ ticketId: "t1" });
   // @ts-expect-error — async map callback is banned (sync surface)
   r.map(async (n) => n + 1);
   // A raw Promise / async branch would bypass qualification where the
-  // combinator awaits it — flatMapErr / flatTapErr — so those reject it via
-  // their builder-output constraint; tapErr rejects it too, because its branch
+  // combinator awaits it — flatMapErrCases / flatTapErrCases — so those reject it via
+  // their builder-output constraint; tapErrCases rejects it too, because its branch
   // results are DISCARDED (a rejected Promise would float unobserved). Only
-  // the non-awaiting transformers mapErr / recoverErr run the handler
+  // the non-awaiting transformers mapErrCases / recoverErrCases run the handler
   // synchronously with no await, so an async branch there is merely a visible
   // Promise-valued result, not a rejection bypass.
-  // @ts-expect-error — an async flatMapErr branch is banned
-  r.flatMapErr((matcher) => matcher.with(P._, async () => Ok(1)));
-  // @ts-expect-error — an async flatTapErr branch is banned
-  r.flatTapErr((matcher) => matcher.with(P._, async () => Ok(1)));
-  // @ts-expect-error — an async tapErr branch is banned (discarded, would float)
-  r.tapErr((matcher) => matcher.with(P._, async () => {}));
+  // @ts-expect-error — an async flatMapErrCases branch is banned
+  r.flatMapErrCases((matcher) => matcher.with(P._, async () => Ok(1)));
+  // @ts-expect-error — an async flatTapErrCases branch is banned
+  r.flatTapErrCases((matcher) => matcher.with(P._, async () => Ok(1)));
+  // @ts-expect-error — an async tapErrCases branch is banned (discarded, would float)
+  r.tapErrCases((matcher) => matcher.with(P._, async () => {}));
   // @ts-expect-error — async tapDefect callback is banned
   r.tapDefect(async () => {});
   // @ts-expect-error — async tapFailure callback is banned
@@ -467,12 +467,12 @@ new WithMsg({ ticketId: "t1" });
   ar.tap(async () => {});
   // @ts-expect-error — async map callback is banned (async surface)
   ar.map(async (n) => n + 1);
-  // @ts-expect-error — an async flatMapErr branch is banned (async surface)
-  ar.flatMapErr((matcher) => matcher.with(P._, async () => Ok(1)));
-  // @ts-expect-error — an async flatTapErr branch is banned (async surface)
-  ar.flatTapErr((matcher) => matcher.with(P._, async () => Ok(1)));
-  // @ts-expect-error — an async tapErr branch is banned (async surface)
-  ar.tapErr((matcher) => matcher.with(P._, async () => {}));
+  // @ts-expect-error — an async flatMapErrCases branch is banned (async surface)
+  ar.flatMapErrCases((matcher) => matcher.with(P._, async () => Ok(1)));
+  // @ts-expect-error — an async flatTapErrCases branch is banned (async surface)
+  ar.flatTapErrCases((matcher) => matcher.with(P._, async () => Ok(1)));
+  // @ts-expect-error — an async tapErrCases branch is banned (async surface)
+  ar.tapErrCases((matcher) => matcher.with(P._, async () => {}));
   // @ts-expect-error — async tapDefect callback is banned (async surface)
   ar.tapDefect(async () => {});
   // @ts-expect-error — async tapFailure callback is banned (async surface)
@@ -484,7 +484,7 @@ new WithMsg({ ticketId: "t1" });
   // Synchronous callbacks still infer exactly as before.
   const mapped = r.map((n) => n + 1);
   type _MapKeeps = Expect<Equal<typeof mapped, Result<number, "e">>>;
-  const recovered = r.recoverErr((matcher) => matcher.with(P._, (e) => e.length));
+  const recovered = r.recoverErrCases((matcher) => matcher.with(P._, (e) => e.length));
   type _RecoverKeeps = Expect<Equal<typeof recovered, Result<number, never>>>;
 
   // match handlers may still be async (edge elimination is not a combinator):
@@ -583,7 +583,7 @@ new WithMsg({ ticketId: "t1" });
   type _Widens = Expect<Equal<typeof widened, number | null>>;
 }
 
-// --- error triage: mapErr/flatMapErr/recoverErr take a ts-pattern matcher and
+// --- error triage: mapErrCases/flatMapErrCases/recoverErrCases take a ts-pattern matcher and
 // --- call `.exhaustive()` for you; the callback returns the un-terminated builder
 
 {
@@ -593,7 +593,7 @@ new WithMsg({ ticketId: "t1" });
   const r = Ok(1) as Result<number, NotFound | Conflict>;
 
   // exhaustive per-tag; the outgoing E is the union of the branch returns
-  const triaged = r.mapErr((matcher) =>
+  const triaged = r.mapErrCases((matcher) =>
     matcher
       .with(tag("NotFound"), (e) => `nf:${e.id}` as const)
       .with(tag("Conflict"), () => new Mapped()),
@@ -601,7 +601,7 @@ new WithMsg({ ticketId: "t1" });
   type _Triaged = Expect<Equal<ErrOf<typeof triaged>, `nf:${string}` | Mapped>>;
 
   // each branch receives the narrowed variant
-  r.mapErr((matcher) =>
+  r.mapErrCases((matcher) =>
     matcher
       .with(tag("NotFound"), (e) => {
         type _Narrowed = Expect<Equal<typeof e, NotFound>>;
@@ -611,7 +611,7 @@ new WithMsg({ ticketId: "t1" });
   );
 
   // a throwing branch types as `never` and drops out of the outgoing union
-  const thrown = r.mapErr((matcher) =>
+  const thrown = r.mapErrCases((matcher) =>
     matcher
       .with(tag("NotFound"), () => new Mapped())
       .with(tag("Conflict"), (e) => {
@@ -623,17 +623,17 @@ new WithMsg({ ticketId: "t1" });
   // the sanctioned deliberate-defect form: the injected `defect` helper — its
   // Defect arm is subtracted from the outgoing union (Exclude<O, Defect>, the
   // same inference as a qualify boundary)
-  const defected = r.mapErr((matcher, defect) =>
+  const defected = r.mapErrCases((matcher, defect) =>
     matcher.with(tag("NotFound"), () => new Mapped()).with(tag("Conflict"), (e) => defect(e.key)),
   );
   type _DefectDrops = Expect<Equal<ErrOf<typeof defected>, Mapped>>;
 
   // P._ is the uniform catch-all; a defect-only match empties the channel
-  const allDefected = r.mapErr((matcher, defect) => matcher.with(P._, (e) => defect(e)));
+  const allDefected = r.mapErrCases((matcher, defect) => matcher.with(P._, (e) => defect(e)));
   type _AllDefected = Expect<Equal<typeof allDefected, Result<number, never>>>;
 
   // the P._ catch-all receives the full union
-  const merged = r.mapErr((matcher) =>
+  const merged = r.mapErrCases((matcher) =>
     matcher.with(P._, (e) => {
       type _MergedParam = Expect<Equal<typeof e, NotFound | Conflict>>;
       return e;
@@ -644,37 +644,37 @@ new WithMsg({ ticketId: "t1" });
   // NOT exhaustive: a missing case makes `.exhaustive()` uncallable, so the
   // builder is not an ExhaustiveMatch and the call fails at the call site
   // @ts-expect-error — Conflict is unhandled
-  r.mapErr((matcher) => matcher.with(tag("NotFound"), (e) => e));
+  r.mapErrCases((matcher) => matcher.with(tag("NotFound"), (e) => e));
 
-  // flatMapErr: channels are the unions of the branch-returned Results' channels
-  const flat = r.flatMapErr((matcher) =>
+  // flatMapErrCases: channels are the unions of the branch-returned Results' channels
+  const flat = r.flatMapErrCases((matcher) =>
     matcher.with(tag("NotFound"), (e) => Ok(e.id)).with(tag("Conflict"), () => Err(new Mapped())),
   );
   type _FlatT = Expect<Equal<typeof flat, Result<number | string, Mapped>>>;
 
-  // flatMapErr: a defect branch contributes to neither channel
-  const flatDefected = r.flatMapErr((matcher, defect) =>
+  // flatMapErrCases: a defect branch contributes to neither channel
+  const flatDefected = r.flatMapErrCases((matcher, defect) =>
     matcher.with(tag("NotFound"), (e) => Ok(e.id)).with(tag("Conflict"), (e) => defect(e.key)),
   );
   type _FlatDefected = Expect<Equal<typeof flatDefected, Result<number | string, never>>>;
 
-  // recoverErr: recovers per tag, unioning the recovered values; E empties
-  const rec = r.recoverErr((matcher) =>
+  // recoverErrCases: recovers per tag, unioning the recovered values; E empties
+  const rec = r.recoverErrCases((matcher) =>
     matcher.with(tag("NotFound"), (e) => e.id).with(tag("Conflict"), () => 0 as const),
   );
   type _Rec = Expect<Equal<typeof rec, Result<number | string | 0, never>>>;
 
-  // recoverErr: a defect branch does not widen the recovered success type
-  const recDefected = r.recoverErr((matcher, defect) =>
+  // recoverErrCases: a defect branch does not widen the recovered success type
+  const recDefected = r.recoverErrCases((matcher, defect) =>
     matcher.with(tag("NotFound"), (e) => e.id).with(tag("Conflict"), (e) => defect(e.key)),
   );
   type _RecDefected = Expect<Equal<typeof recDefected, Result<number | string, never>>>;
 
   // observers are exhaustive too (use P._ for a catch-all); the error passes
   // through unchanged
-  const observed = r.tapErr((matcher) => matcher.with(P._, (e) => void e));
+  const observed = r.tapErrCases((matcher) => matcher.with(P._, (e) => void e));
   type _Observed = Expect<Equal<typeof observed, Result<number, NotFound | Conflict>>>;
-  const flatObserved = r.flatTapErr((matcher) =>
+  const flatObserved = r.flatTapErrCases((matcher) =>
     matcher.with(P._, () => Err("audit-failed" as const)),
   );
   type _FlatObserved = Expect<
@@ -683,7 +683,7 @@ new WithMsg({ ticketId: "t1" });
 
   // async surface mirrors the matcher; branches may return AsyncResults
   const ar2 = r.toAsync();
-  const aflat = ar2.flatMapErr((matcher) =>
+  const aflat = ar2.flatMapErrCases((matcher) =>
     matcher
       .with(tag("NotFound"), (e) => OkAsync(e.id))
       .with(tag("Conflict"), () => Err(new Mapped())),
@@ -699,13 +699,13 @@ new WithMsg({ ticketId: "t1" });
 {
   // untagged E (a bare string): match by value, P._ is the catch-all
   const untagged = Ok(1) as Result<number, string>;
-  const mapped = untagged.mapErr((matcher) => matcher.with(P._, (e) => e.length));
+  const mapped = untagged.mapErrCases((matcher) => matcher.with(P._, (e) => e.length));
   type _Mapped = Expect<Equal<ErrOf<typeof mapped>, number>>;
 
   // a `code`-discriminated union (the orpc shape) — no `_tag`, matched on `code`
   type CodeErr = { code: "NOT_FOUND"; x: 1 } | { code: "FORBIDDEN"; y: 2 };
   const coded = Ok(1) as Result<number, CodeErr>;
-  const byCode = coded.mapErr((matcher) =>
+  const byCode = coded.mapErrCases((matcher) =>
     matcher
       .with({ code: "NOT_FOUND" }, () => 404 as const)
       .with({ code: "FORBIDDEN" }, () => 403 as const),
@@ -715,15 +715,15 @@ new WithMsg({ ticketId: "t1" });
   // NOT exhaustive → the builder's `.exhaustive` is a NonExhaustiveError, not a
   // function, so it fails the ExhaustiveMatch constraint at the call site
   // @ts-expect-error — FORBIDDEN is unhandled
-  coded.mapErr((matcher) => matcher.with({ code: "NOT_FOUND" }, () => 1));
+  coded.mapErrCases((matcher) => matcher.with({ code: "NOT_FOUND" }, () => 1));
 
   // an empty channel (`E = never`): `match(never)` is vacuously exhaustive, so
   // even a matcher with no branches type-checks
   const empty = Ok(1) as Result<number, never>;
-  const still = empty.mapErr((matcher) => matcher);
+  const still = empty.mapErrCases((matcher) => matcher);
   type _Still = Expect<Equal<typeof still, Result<number, never>>>;
 
   // observers are exhaustive too, but the error passes through unchanged
-  const observed = coded.tapErr((matcher) => matcher.with(P._, () => undefined));
+  const observed = coded.tapErrCases((matcher) => matcher.with(P._, () => undefined));
   type _Observed = Expect<Equal<typeof observed, Result<number, CodeErr>>>;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -91,7 +91,7 @@ export type MatchErrOut<M> = Exclude<MatchOut<M>, Defect>;
 
 /**
  * The fluent method surface every {@link Result} variant carries — the
- * combinators (`map`, `flatMap`, `mapErr`, `match`, `get`, …), documented one
+ * combinators (`map`, `flatMap`, `mapErrCases`, `match`, `get`, …), documented one
  * per entry below. Factored out so the three variants ({@link OkView},
  * {@link ErrView}, {@link DefectView}) can each intersect it; {@link AsyncResult}
  * mirrors this surface with async signatures.
@@ -274,7 +274,7 @@ export type ResultMethods<out T, out E> = {
    * @remarks
    * The callback receives `match(error)` (an {@link ErrMatcher}) and the
    * injected `defect` helper. Chain `.with(pattern, handler)` and **return the
-   * un-terminated builder** — `mapErr` calls `.exhaustive()` itself, so a
+   * un-terminated builder** — `mapErrCases` calls `.exhaustive()` itself, so a
    * missing case is a compile error at the call site (there is no `.exhaustive()`
    * to forget, and no way to slip in `.otherwise()`). The outgoing error type is
    * the union of the branch returns with the `Defect` arm subtracted
@@ -289,7 +289,7 @@ export type ResultMethods<out T, out E> = {
    * @typeParam M - the exhaustive builder the callback returns.
    * @param f - builds the match over the error (returns the un-terminated builder).
    */
-  mapErr<M extends ExhaustiveMatch<unknown>>(
+  mapErrCases<M extends ExhaustiveMatch<unknown>>(
     f: (matcher: ErrMatcher<E>, defect: (cause: unknown) => Defect) => M,
   ): Result<T, MatchErrOut<M>>;
 
@@ -305,7 +305,7 @@ export type ResultMethods<out T, out E> = {
    * @typeParam M - the exhaustive builder the callback returns.
    * @param f - builds the match; each branch produces a fallback `Result`.
    */
-  flatMapErr<M extends ExhaustiveMatch<Result<unknown, unknown> | Defect>>(
+  flatMapErrCases<M extends ExhaustiveMatch<Result<unknown, unknown> | Defect>>(
     f: (matcher: ErrMatcher<E>, defect: (cause: unknown) => Defect) => M,
   ): Result<T | OkOf<MatchOut<M>>, ErrOf<MatchOut<M>>>;
 
@@ -323,7 +323,7 @@ export type ResultMethods<out T, out E> = {
    * @typeParam M - the exhaustive builder the callback returns.
    * @param f - builds the match; each branch produces a success value.
    */
-  recoverErr<M extends ExhaustiveMatch<unknown>>(
+  recoverErrCases<M extends ExhaustiveMatch<unknown>>(
     f: (matcher: ErrMatcher<E>, defect: (cause: unknown) => Defect) => M,
   ): Result<T | MatchErrOut<M>, never>;
 
@@ -341,11 +341,11 @@ export type ResultMethods<out T, out E> = {
    * because the branch results are discarded, a returned `Promise` would float
    * unobserved and its rejection would vanish. A failable
    * `Result`-returning effect belongs in
-   * {@link ResultMethods.flatTapErr | flatTapErr}.
+   * {@link ResultMethods.flatTapErrCases | flatTapErrCases}.
    *
    * @param f - builds the match; branch returns are ignored.
    */
-  tapErr<R>(
+  tapErrCases<R>(
     f: (
       matcher: ErrMatcher<E>,
       defect: (cause: unknown) => Defect,
@@ -370,7 +370,7 @@ export type ResultMethods<out T, out E> = {
    * @typeParam M - the exhaustive builder the callback returns.
    * @param f - builds the match; each branch is a failable effect (its `Ok` is ignored).
    */
-  flatTapErr<E2>(
+  flatTapErrCases<E2>(
     f: (
       matcher: ErrMatcher<E>,
       defect: (cause: unknown) => Defect,
@@ -406,7 +406,7 @@ export type ResultMethods<out T, out E> = {
    * Run a side effect on **any failure** — `Err` or `Defect` — and pass the
    * `Result` through unchanged. The one cross-channel observer, for the shared
    * "it went KO" concern (logging, metrics, rollback) that would otherwise be
-   * duplicated across {@link ResultMethods.tapErr | tapErr} and
+   * duplicated across {@link ResultMethods.tapErrCases | tapErrCases} and
    * {@link ResultMethods.tapDefect | tapDefect}.
    *
    * @remarks
@@ -417,7 +417,7 @@ export type ResultMethods<out T, out E> = {
    * treat it opaquely for a shared logger. Runs on `Err` and `Defect`; `Ok`
    * passes through. It **observes without consuming**: the failure flows on
    * unchanged — to also recover, use
-   * {@link ResultMethods.recoverErr | recoverErr} /
+   * {@link ResultMethods.recoverErrCases | recoverErrCases} /
    * {@link ResultMethods.recoverDefect | recoverDefect} (deliberately separate
    * acts) or {@link ResultMethods.match | match} at the edge. If `f` throws, the
    * result is a `Defect` whose cause is an `AggregateError` of `[thrown,
@@ -462,7 +462,7 @@ export type ResultMethods<out T, out E> = {
    *
    * @remarks
    * Compiles only when the error channel is empty (`E = never`) — eliminate
-   * modeled errors first (`match` / `recoverErr` / `flatMapErr`), or reach for the
+   * modeled errors first (`match` / `recoverErrCases` / `flatMapErrCases`), or reach for the
    * `getOr` / `getOrElse` / `getOrNull` / `getOrUndefined` family (which
    * recover an `Err`). If you get a `'this' context` type error here, that is
    * the gate: the receiver still has a non-`never` error channel.
@@ -526,8 +526,8 @@ export type ResultMethods<out T, out E> = {
    * `throw` behind a method, so a `no-throw` lint rule can ban raw throws while
    * this one sanctioned extraction remains — _not_ to replace principled
    * handling. When you can keep the error a value, prefer
-   * {@link ResultMethods.match | match} / {@link ResultMethods.recoverErr | recoverErr} /
-   * {@link ResultMethods.flatMapErr | flatMapErr}.
+   * {@link ResultMethods.match | match} / {@link ResultMethods.recoverErrCases | recoverErrCases} /
+   * {@link ResultMethods.flatMapErrCases | flatMapErrCases}.
    *
    * Type-gated as the **complement** of {@link ResultMethods.get | get}: it
    * compiles only when the error channel is **non-empty** (`E` is not `never`) —
@@ -701,7 +701,7 @@ export type Awaitable<out T> = {
 
 /**
  * The async method surface every {@link AsyncResult} carries — the combinators
- * (`map`, `flatMap`, `mapErr`, `match`, `get`, …) with their asynchronous
+ * (`map`, `flatMap`, `mapErrCases`, `match`, `get`, …) with their asynchronous
  * signatures, documented one per entry below. The async mirror of
  * {@link ResultMethods}: each entry links its synchronous counterpart and states
  * only the async delta.
@@ -807,19 +807,19 @@ export type AsyncResultMethods<out T, out E> = {
   ): AsyncResult<T, E | E2>;
 
   /**
-   * Asynchronous {@link ResultMethods.mapErr | mapErr} — the same exhaustive
+   * Asynchronous {@link ResultMethods.mapErrCases | mapErrCases} — the same exhaustive
    * {@link ErrMatcher} form; the combinator calls `.exhaustive()`.
    */
-  mapErr<M extends ExhaustiveMatch<unknown>>(
+  mapErrCases<M extends ExhaustiveMatch<unknown>>(
     f: (matcher: ErrMatcher<E>, defect: (cause: unknown) => Defect) => M,
   ): AsyncResult<T, MatchErrOut<M>>;
 
   /**
-   * Asynchronous {@link ResultMethods.flatMapErr | flatMapErr} — the same
+   * Asynchronous {@link ResultMethods.flatMapErrCases | flatMapErrCases} — the same
    * exhaustive {@link ErrMatcher} form. Unlike the sync form, a branch may
    * return a `Result` **or** an `AsyncResult`.
    */
-  flatMapErr<
+  flatMapErrCases<
     M extends ExhaustiveMatch<Result<unknown, unknown> | AsyncResult<unknown, unknown> | Defect>,
   >(
     f: (matcher: ErrMatcher<E>, defect: (cause: unknown) => Defect) => M,
@@ -829,16 +829,16 @@ export type AsyncResultMethods<out T, out E> = {
   >;
 
   /**
-   * Asynchronous {@link ResultMethods.recoverErr | recoverErr} — the same
+   * Asynchronous {@link ResultMethods.recoverErrCases | recoverErrCases} — the same
    * exhaustive {@link ErrMatcher} form. Branches are synchronous; a throw
    * becomes a `Defect`.
    */
-  recoverErr<M extends ExhaustiveMatch<unknown>>(
+  recoverErrCases<M extends ExhaustiveMatch<unknown>>(
     f: (matcher: ErrMatcher<E>, defect: (cause: unknown) => Defect) => M,
   ): AsyncResult<T | MatchErrOut<M>, never>;
 
   /**
-   * Asynchronous {@link ResultMethods.tapErr | tapErr}. `f` is synchronous; if it
+   * Asynchronous {@link ResultMethods.tapErrCases | tapErrCases}. `f` is synchronous; if it
    * throws, the result is a `Defect` whose cause is an `AggregateError` of
    * `[thrown, original failure]` — observing a failure never destroys it. An
    * async branch is rejected at compile time ({@link NotThenable} on the
@@ -846,9 +846,9 @@ export type AsyncResultMethods<out T, out E> = {
    * would float unobserved. The
    * {@link AsyncResultMethods.tap | tap} fire-and-forget caveat applies here
    * too — a failable effect belongs in
-   * {@link AsyncResultMethods.flatTapErr | flatTapErr}.
+   * {@link AsyncResultMethods.flatTapErrCases | flatTapErrCases}.
    */
-  tapErr<R>(
+  tapErrCases<R>(
     f: (
       matcher: ErrMatcher<E>,
       defect: (cause: unknown) => Defect,
@@ -856,14 +856,14 @@ export type AsyncResultMethods<out T, out E> = {
   ): AsyncResult<T, E>;
 
   /**
-   * Asynchronous {@link ResultMethods.flatTapErr | flatTapErr} — the
+   * Asynchronous {@link ResultMethods.flatTapErrCases | flatTapErrCases} — the
    * error-channel mirror of `flatTap`. `f` may return a `Result` **or** an
    * `AsyncResult`; its `Ok` value is discarded, an `Err`/`Defect` from `f`
    * threads through, and if `f` throws, the result is a `Defect` whose cause is
    * an `AggregateError` of `[thrown, original failure]` — observing a failure
    * never destroys it.
    */
-  flatTapErr<E2>(
+  flatTapErrCases<E2>(
     f: (
       matcher: ErrMatcher<E>,
       defect: (cause: unknown) => Defect,
@@ -946,7 +946,7 @@ export type AsyncResultMethods<out T, out E> = {
  * {@link fromPromise} forces. To do further async work, re-enter through a
  * qualified boundary and compose it: `ar.flatMap((v) => fromPromise(work(v),
  * qualify))`. The eliminators (`get`, …) return promises; the binds
- * (`flatMap`, `flatTap`, `flatMapErr`, `recoverDefect`) additionally accept an
+ * (`flatMap`, `flatTap`, `flatMapErrCases`, `recoverDefect`) additionally accept an
  * `AsyncResult`. Its combinators are documented one per entry on
  * {@link AsyncResultMethods}.
  *

--- a/packages/orpc/README.md
+++ b/packages/orpc/README.md
@@ -37,12 +37,14 @@ const find = os
   .errors({ NOT_FOUND: {} })
   .handler(
     handlerResult(({ input, errors }) =>
-      repo.findPlanet(input.id).mapErr((matcher) => matcher.with(P._, () => errors.NOT_FOUND())),
+      repo
+        .findPlanet(input.id)
+        .mapErrCases((matcher) => matcher.with(P._, () => errors.NOT_FOUND())),
     ),
   );
 ```
 
-`Ok` becomes the output; `Err` (constrained to `ORPCError` — the `mapErr` at the
+`Ok` becomes the output; `Err` (constrained to `ORPCError` — the `mapErrCases` at the
 endpoint is the explicit triage point) is returned as a value and oRPC marks it
 inferable; a `Defect` rethrows its cause and stays a defect. A handler may also
 be written as `.result(...)` directly, by opting into the builder extension:
@@ -55,7 +57,7 @@ const find = os
   .input(z.object({ id: z.string() }))
   .errors({ NOT_FOUND: {} })
   .result(({ input, errors }) =>
-    repo.findPlanet(input.id).mapErr((matcher) => matcher.with(P._, () => errors.NOT_FOUND())),
+    repo.findPlanet(input.id).mapErrCases((matcher) => matcher.with(P._, () => errors.NOT_FOUND())),
   );
 ```
 

--- a/packages/orpc/src/extensions/result.ts
+++ b/packages/orpc/src/extensions/result.ts
@@ -11,7 +11,7 @@
 //     .input(z.object({ id: z.string() }))
 //     .errors({ NOT_FOUND: {} })
 //     .result(({ input, errors }) =>
-//       repo.findPlanet(input.id).mapErr((m) => m.with(P._, () => errors.NOT_FOUND())),
+//       repo.findPlanet(input.id).mapErrCases((m) => m.with(P._, () => errors.NOT_FOUND())),
 //     );
 //
 // This registration is a genuine import-time side effect — the one entry

--- a/packages/orpc/src/server.ts
+++ b/packages/orpc/src/server.ts
@@ -10,7 +10,7 @@
 //   Defect     → rethrow the cause     (oRPC collapses it to INTERNAL_SERVER_ERROR)
 //
 // The handler's `Err` channel is constrained to `ORPCError`: mapping a domain
-// error into one (`mapErr((e) => errors.NOT_FOUND({...}))`) is the explicit
+// error into one (`mapErrCases((e) => errors.NOT_FOUND({...}))`) is the explicit
 // triage point at the transport boundary (Thesis #3).
 
 import {
@@ -49,7 +49,7 @@ export type ResultHandler<
  * @remarks
  * The elimination boundary of the server half: `Ok` becomes the procedure's
  * output; `Err` (constrained to `ORPCError` — build one with the injected
- * `errors.CODE(...)` constructors, or map a domain error via `mapErr` first)
+ * `errors.CODE(...)` constructors, or map a domain error via `mapErrCases` first)
  * is returned as a value, which oRPC marks *inferable* so the client sees it
  * fully typed; a `Defect` rethrows its original cause, which oRPC collapses
  * to `INTERNAL_SERVER_ERROR` — a bug stays a defect, never a typed error.
@@ -73,7 +73,7 @@ export type ResultHandler<
  *   .errors({ NOT_FOUND: {} })
  *   .handler(
  *     handlerResult(({ input, errors }) =>
- *       repo.findPlanet(input.id).mapErr((matcher) => matcher.with(P._, () => errors.NOT_FOUND())),
+ *       repo.findPlanet(input.id).mapErrCases((matcher) => matcher.with(P._, () => errors.NOT_FOUND())),
  *     ),
  *   );
  * ```
@@ -92,7 +92,7 @@ export function handlerResult<
     // Branch via the guards rather than `match`: this library code is generic in
     // the error type `TError`, and `match`'s exhaustive `err` matcher cannot be
     // proven exhaustive by ts-pattern over an unresolved type parameter. The
-    // concrete triage (`.mapErr((matcher) => …)`) still happens at the endpoint.
+    // concrete triage (`.mapErrCases((matcher) => …)`) still happens at the endpoint.
     if (result.isOk()) return result.value;
     if (result.isErr()) {
       // Unreachable through well-typed code (`TError extends AnyORPCError`); a

--- a/packages/orpc/src/server.ts
+++ b/packages/orpc/src/server.ts
@@ -10,7 +10,7 @@
 //   Defect     → rethrow the cause     (oRPC collapses it to INTERNAL_SERVER_ERROR)
 //
 // The handler's `Err` channel is constrained to `ORPCError`: mapping a domain
-// error into one (`mapErrCases((e) => errors.NOT_FOUND({...}))`) is the explicit
+// error into one (`mapErrCases((m) => m.with(P._, () => errors.NOT_FOUND({...})))`) is the explicit
 // triage point at the transport boundary (Thesis #3).
 
 import {

--- a/packages/orpc/src/types.test-d.ts
+++ b/packages/orpc/src/types.test-d.ts
@@ -93,7 +93,7 @@ type ImplErrCode = Expect<Equal<AsyncErrOf<typeof implCall>["code"], "GONE">>;
 
 // --- must-NOT-compile ----------------------------------------------------------
 
-// @ts-expect-error — the Err channel must be ORPCError; map a domain error via `mapErr` first.
+// @ts-expect-error — the Err channel must be ORPCError; map a domain error via `mapErrCases` first.
 handlerResult(() => Err("domain-error"));
 
 // @ts-expect-error — same constraint on the extension path.


### PR DESCRIPTION
## What

Renames the five matcher-taking error combinators to a `*Cases` suffix, so the name states the protocol — the callback receives a ts-pattern matcher over the error's **cases**, not the error value:

| before | after |
|---|---|
| `mapErr` | `mapErrCases` |
| `flatMapErr` | `flatMapErrCases` |
| `recoverErr` | `recoverErrCases` |
| `tapErr` | `tapErrCases` |
| `flatTapErr` | `flatTapErrCases` |

`match`'s `err` handler and the `getErr` extractor are **unchanged** — they aren't matcher combinators. No plain-callback variant is added (that would reopen the blanket-handling hole the matcher closes).

This **reverses** the naming decision that #127 recorded ("keep the conventional `map*`/`tap*` names") — please drop #127 in favor of this.

## Why

A bare `mapErr`/`tapErr` promises the functor contract — that the callback gets the error value. It doesn't; it gets a matcher. The suffix makes the signature honest and keeps the error surface visually distinct from the value-taking success surface (`map`/`tap`).

## Scope

- **Core:** impl (`core.ts`), public types (`types.ts`), runtime tests, and `types.test-d.ts`.
- **`@unthrown/orpc`:** internal usage (`server.ts`, `extensions/result.ts`, type-tests, README).
- **Spec (`CLAUDE.md`):** records the `*Cases` naming decision and its rationale (replacing the reversed keep-conventional-names note).
- **Docs:** mechanical rename across the guide, plus a real rewrite of the *"Why the `*Cases` suffix?"* section in `explanation/exhaustive-error-matching` and the `design-decisions` note; **neverthrow's own `mapErr`** references in the migration/comparison docs were left as `mapErr` (only unthrown's methods changed).
- **Changeset:** `unthrown` **major** (fixed group follows); the pending changesets that introduce these combinators were updated to the final names so the eventual stable changelog is coherent.

## Verification

Full gate green locally: `format --check`, `lint`, `typecheck`, `knip`, `test`, `build` (18 tasks). Docs build has zero dead links (the section anchor moved to `#why-the-cases-suffix`, inbound links updated). `dist/*.d.mts` exports exactly the five `*Cases` names and none of the old ones.
