### PR TITLE
refactor!: *Cases error-matcher rename + v5-beta migration fixes (#142–#146)

### DIFF
--- a/.changeset/exhaustive-error-matcher.md
+++ b/.changeset/exhaustive-error-matcher.md
@@ -54,10 +54,12 @@ into core; the `P.Ok`/`P.Err`/`P.Defect` sugar is dropped (match the union
 structurally instead).
 
 **`match` now matches the error channel exhaustively too, and `matchTags` is
-removed.** `match`'s `err` handler no longer takes a blanket `(error) => R`
+removed.** `match`'s error handler no longer takes a blanket `(error) => R`
 callback — it receives the same ts-pattern matcher and returns the un-terminated
 builder (no `defect` helper: `match` folds to a value, with no `Defect` output
-channel). This subsumes the old `matchTags` fold — a per-tag fold over a tagged
+channel). It is also **renamed `err` → `errCases`** to match the combinators and
+to make the change loud (a leftover 4.x `err:` handler is now an
+excess-property compile error). This subsumes the old `matchTags` fold — a per-tag fold over a tagged
 union is now `match` with the matcher and `tag(t)`, and it generalises to any
 discriminant, not only `_tag`:
 
@@ -76,7 +78,7 @@ matchTags(result, {
 result.match({
   ok: (n) => `got ${n}`,
   defect: (cause) => `bug: ${String(cause)}`,
-  err: (matcher) =>
+  errCases: (matcher) =>
     matcher.with(tag("NotFound"), () => "404").with(tag("Forbidden"), (e) => `403 for ${e.user}`),
 });
 ```

--- a/.changeset/getorthrow-never-gate-message.md
+++ b/.changeset/getorthrow-never-gate-message.md
@@ -1,0 +1,15 @@
+---
+"unthrown": patch
+---
+
+**`getOrThrow()`'s never-channel gate now explains itself.** When the error
+channel is already empty (`E = never`) `getOrThrow()` is unnecessary — there is
+nothing to throw, so `get()` is the tool. The gate previously surfaced as an
+opaque `The 'this' context of type '…' is not assignable to method's 'this' of
+type 'never'`. The `never` receiver now carries a message, so the diagnostic
+reads:
+
+> unthrown: getOrThrow is unnecessary here — the Err channel is empty (E =
+> never), so there is nothing to throw. Use get() instead.
+
+Behaviour is unchanged; only the compile-time message improves.

--- a/.changeset/rename-err-combinators-cases.md
+++ b/.changeset/rename-err-combinators-cases.md
@@ -19,5 +19,21 @@ Migration is a rename at every call site:
 + result.mapErrCases((m) => m.with(P._, wrap))
 ```
 
-`match`'s `err` handler and the `getErr` extractor are unchanged — they are not
-matcher combinators.
+**`match`'s error handler is renamed the same way — `err` → `errCases`** — for
+the same reason: it takes the exhaustive ts-pattern matcher, not a plain
+`(error) => …` callback. This also makes the change **loud** where it would
+otherwise be silent: a leftover 4.x `err: (error) => …` handler still compiled
+under the matcher constraint (a throwing handler returns `never`, which
+vacuously satisfies it) and then threw the _matcher object_ at runtime. Renaming
+the key turns that into an excess-property compile error.
+
+```diff
+  result.match({
+    ok: (value) => value,
+-   err: (matcher) => matcher.with(P._, wrap),
++   errCases: (matcher) => matcher.with(P._, wrap),
+    defect: (cause) => report(cause),
+  })
+```
+
+The `getErr` extractor is unchanged — it is not a matcher combinator.

--- a/.changeset/ts-pattern-peer-dependency.md
+++ b/.changeset/ts-pattern-peer-dependency.md
@@ -1,0 +1,17 @@
+---
+"unthrown": major
+---
+
+**`ts-pattern` is now a `peerDependency` (`^5`), not a plain dependency.** Core
+re-exports `match` / `P` / `tag` and its error matchers speak ts-pattern's
+builder type. When ts-pattern was a nested, exact-pinned dependency, a consumer
+who already used ts-pattern at another version ended up with two copies whose
+declarations don't unify — feeding a `P.union(...)` built by one copy into an
+unthrown matcher failed five layers deep in a conditional type.
+
+Declaring it as a peer guarantees a single copy the consumer owns, so
+`import { P } from "ts-pattern"` composes with unthrown's matchers as expected.
+
+**Action required:** add `ts-pattern` (`^5`) to your own dependencies if you
+don't already depend on it. Most package managers surface this as a missing-peer
+warning on install.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -536,8 +536,12 @@ AsyncResult<infer T, …>` — structural inference over the whole method surfac
 
 ## Monorepo layout
 
-- `packages/core` → `unthrown` (one runtime dependency: `ts-pattern`, which
-  powers the exhaustive error matchers and is re-exported as `match`/`P`)
+- `packages/core` → `unthrown` (one runtime peer dependency: `ts-pattern`
+  `^5`, which powers the exhaustive error matchers and is re-exported as
+  `match`/`P`. A **peer**, not a plain dependency, so a consumer that already
+  uses ts-pattern shares one copy — two copies' declarations don't unify, and
+  mixing them is a type error. Kept as a `devDependency` (catalog) for the
+  workspace's own build/test.)
 - `packages/vitest` → `@unthrown/vitest` (peerDep `vitest`)
 - `packages/effect` → `@unthrown/effect` (peerDep `effect`)
 - `packages/neverthrow` → `@unthrown/neverthrow` (peerDep `neverthrow`)
@@ -635,9 +639,9 @@ code: "NOT_FOUND" }, …))`); non-inferable →
   `.github/scripts/inject-docs-version-nav.ts`). With no prerelease, main
   deploys alone to the root as before
 
-Core depends on `ts-pattern` (it powers the error matchers). Never pull
-`vitest` or any interop peer (`effect`, `neverthrow`, `@bloodyowl/boxed`,
-`@orpc/*`) into core.
+Core takes `ts-pattern` as a **peer** dependency (it powers the error matchers).
+Never pull `vitest` or any interop peer (`effect`, `neverthrow`,
+`@bloodyowl/boxed`, `@orpc/*`) into core.
 
 Every satellite package depends on core via `workspace:^` (an exact pin would
 create a dual-copy hazard with the `instanceof`-based `isResult`); for the same
@@ -751,5 +755,9 @@ configured outside the repo).
   that would reopen the blanket-handling hole the matcher closes. Do not
   re-litigate or add bare aliases. Documented user-side in the
   exhaustive-error-matching guide.
-- The core has **one runtime dependency, `ts-pattern`** (it powers the error
-  matchers and is re-exported). Add no others — protect that minimalism.
+- The core has **one runtime dependency, `ts-pattern`**, declared as a
+  **peerDependency** (`^5`) so a consumer already using ts-pattern shares a
+  single copy (two copies' declarations don't unify — a type error five layers
+  deep in a conditional type; the same dual-copy hazard `isResult` guards
+  against at runtime). It powers the error matchers and is re-exported. Add no
+  others — protect that minimalism.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,11 +93,14 @@ was planned).
    result, not a rejection bypass. `tapDefect` / `tapFailure` keep single callbacks — their payloads
    carry no discriminant to match (a defect's cause is `unknown`; `tapFailure`
    splits on channel, not tag). The one eliminator that still handles the error
-   channel, **`match`**, applies the **same exhaustive matcher** to its `err`
-   handler (`(matcher) => matcher.with(…)`, returning the un-terminated builder;
-   `match` runs `.exhaustive()`) — so folding at the edge is exhaustive too, and
-   there is no blanket `err` callback left to silently drop a value. Its `err`
-   handler receives the matcher but **no `defect` helper** — `match` folds to a
+   channel, **`match`**, applies the **same exhaustive matcher** to its
+   `errCases` handler (`(matcher) => matcher.with(…)`, returning the
+   un-terminated builder; `match` runs `.exhaustive()`) — so folding at the edge
+   is exhaustive too, and there is no blanket `err` callback left to silently
+   drop a value. The handler key carries the same `…Cases` suffix as the
+   combinators (and a leftover 4.x `err:` handler is now an excess-property
+   compile error, not a silent runtime break). Its `errCases` handler receives
+   the matcher but **no `defect` helper** — `match` folds to a
    plain value, with no `Defect` output channel; the separate `defect` case
    handles a `Result` that already carries one. (This subsumes the former
    `matchTags` fold — per-tag folding at the edge is now `match` with the
@@ -115,7 +118,7 @@ was planned).
   `flatMapErrCases`,
   `recoverErrCases`, `tap*`, `flatTapErrCases`, `recoverDefect`) is caught and converted to a
   `Defect`. Nothing escapes a pipeline as a raw throw.
-  This is what lets an HTTP adapter do a single `match({ ok, err, defect })`
+  This is what lets an HTTP adapter do a single `match({ ok, errCases, defect })`
   with **no surrounding `try/catch`**.
 - **An out-of-contract non-`Result` surfaces as a `Defect`, never a raw
   throw/rejection.** Reachable only from untyped/cast callers: the aggregates
@@ -186,7 +189,7 @@ was planned).
   combinators can't be swapped out from under every instance), `AsyncRes`'s
   wrapped promise is a native `#private` field, and the qualify-time `defect`
   marker is frozen.
-- **`match`'s `err` matcher is type-forced exhaustive, and library code generic
+- **`match`'s `errCases` matcher is type-forced exhaustive, and library code generic
   in `E` uses the guards instead.** For well-typed concrete callers a missing
   branch does not compile; a rogue value slipping past the types throws
   `NonExhaustiveError` (see above). Because ts-pattern cannot prove `.with(P._,
@@ -268,7 +271,7 @@ Defect>`); flatMapErrCases: `OkOf`/`ErrOf` — plus `AsyncOkOf`/`AsyncErrOf` on 
   meaning — recovering stays the separate `recoverDefect`; handling both for
   good is `match`), and no channel-moving operators (`Err`→`Defect` erases the
   modeled type; `Defect`→`Err` would put `unknown` in `E`, violating Thesis #1)
-- eliminate: `match` (the `{ ok, defect }` handlers plus an `err` handler that
+- eliminate: `match` (the `{ ok, defect }` handlers plus an `errCases` handler that
   takes the **exhaustive ts-pattern matcher** `(matcher) => matcher.with(…)` —
   same as the error combinators, but with no `defect` helper since `match` folds
   to a value; the folded type unions all branch returns), `get`/`getErr`
@@ -401,9 +404,9 @@ match<E>>`, so ts-pattern's non-exported `Match` type is never imported).
   (`cause` stays allowed — see Thesis #4), so the
   message is set per subclass with `override message = "…"`, never as a payload
   field) and `tag(t)` (the `{ _tag: t }` ts-pattern pattern, for use in the
-  error matchers, in `match`'s `err` handler, and in `match(result)`); see the
+  error matchers, in `match`'s `errCases` handler, and in `match(result)`); see the
   `TaggedError` convention in Thesis #4. **There is no `matchTags`** — a per-tag
-  exhaustive fold over a tagged error union is `result.match({ ok, defect, err:
+  exhaustive fold over a tagged error union is `result.match({ ok, defect, errCases:
 (matcher) => matcher.with(tag("…"), …) })`, which generalises beyond `_tag` to
   any discriminant.
 
@@ -680,7 +683,7 @@ channel?**
 2. ✅ **`packages/core/src/tagged.ts`** — Done. `TaggedError(tag)` factory
    (extends `Error`, `_tag`, no-arg constructor when payload is empty via the
    `keyof A extends never ? void : A` trick) and `tag(t)` (the `{ _tag: t }`
-   ts-pattern pattern). A per-tag exhaustive fold is `match`'s `err` handler
+   ts-pattern pattern). A per-tag exhaustive fold is `match`'s `errCases` handler
    with the ts-pattern matcher (`matcher.with(tag("…"), …)`), not a dedicated
    `matchTags` — that former helper was folded into `match` when the matcher
    became the error-channel convention.
@@ -728,7 +731,7 @@ configured outside the repo).
 - **Type-level tests:** `packages/core/src/types.test-d.ts` asserts the
   type-level behaviour the runtime can't (the conditional `all`/`allFromDict`
   shapes, `Exclude<R, Defect>` boundary inference, `flatTap`/`recoverErrCases` channel
-  widening, the `this is …` guard narrowing, `match`'s `err`-matcher
+  widening, the `this is …` guard narrowing, `match`'s `errCases`-matcher
   exhaustiveness (a missing tag does not compile; the folded type unions the
   branch returns), and the
   error-matcher semantics — narrowing, defect/throw-branch subtraction,

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,28 @@
+# Migration
+
+## `unthrown@4.x` → `5.0`
+
+The full, worked guide lives in the docs:
+**[Upgrade from 4.x to 5.0](https://btravstack.github.io/unthrown/how-to/upgrade-to-v5)**.
+The headline breaking surface, so you have it up front:
+
+- **Error combinators renamed** with a `…Cases` suffix (each takes an exhaustive
+  ts-pattern matcher): `mapErr` → `mapErrCases`, `flatMapErr` → `flatMapErrCases`,
+  `recoverErr` → `recoverErrCases`, `tapErr` → `tapErrCases`,
+  `flatTapErr` → `flatTapErrCases`.
+- **`match`'s error handler renamed** `err` → `errCases` (it takes the matcher,
+  not the error value). This one was a _silent_ runtime break in the first betas —
+  a leftover `err:` handler that threw compiled and then threw the matcher object;
+  the renamed key makes it an excess-property compile error.
+- **Removed 4.x aliases:** `unwrap` / `unwrapErr` / `unwrapOr` / `unwrapOrElse`
+  (use `get` / `getErr` / `getOr` / `getOrElse`), `orElse` / `recover` (use
+  `flatMapErrCases` / `recoverErrCases`), and `matchTags` / the `TagHandlers` type
+  (use `match({ …, errCases: (m) => m.with(tag("…"), …) })`).
+- **Renamed export:** `UnwrapError` → `GetError`.
+- **`getOrThrow()`** is now gated to a non-empty error channel; on a
+  `Result<T, never>` use `get()`.
+- **`ts-pattern` is a peer dependency** (`^5`) — install it yourself so you own
+  the single copy.
+- **`@unthrown/pattern` was absorbed into core** — import `match` / `P` / `tag`
+  from `unthrown`.
+- **New:** `ensure`, `DoAsync`, and the `match` / `P` / `tag` re-exports.

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ const user = fromPromise(fetchUser(id), (cause, defect) =>
 // Handle every channel once, at the edge — no surrounding try/catch.
 const status = await user.match({
   ok: () => 200,
-  // `err` receives the exhaustive ts-pattern matcher; `.with(P._, …)` handles every error:
-  err: (matcher) => matcher.with(P._, () => 404), // your modeled NotFound
+  // `errCases` receives the exhaustive ts-pattern matcher; `.with(P._, …)` handles every error:
+  errCases: (matcher) => matcher.with(P._, () => 404), // your modeled NotFound
   defect: (cause) => {
     logger.error(cause); // everything unexpected
     return 500;

--- a/README.md
+++ b/README.md
@@ -46,8 +46,13 @@ the comparison with `neverthrow`, `boxed`, and `effect`.
 ## Install
 
 ```sh
-pnpm add unthrown
+pnpm add unthrown ts-pattern
 ```
+
+`ts-pattern` (`^5`) is a peer dependency — it powers the exhaustive error
+matchers and is re-exported by `unthrown` as `match` / `P`. Owning the single
+copy yourself means `import { P } from "ts-pattern"` composes with unthrown's
+matchers instead of colliding with a second, nested copy.
 
 ## Quick Example
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -46,6 +46,7 @@ const GUIDE_SIDEBAR = [
   {
     text: "How-to guides",
     items: [
+      { text: "Upgrade from 4.x to 5.0", link: "/how-to/upgrade-to-v5" },
       { text: "Migrate from try/catch", link: "/how-to/migrate-from-try-catch" },
       { text: "Migrate from neverthrow", link: "/how-to/migrate-from-neverthrow" },
       { text: "Qualify a boundary", link: "/how-to/qualify-a-boundary" },

--- a/docs/explanation/exhaustive-error-matching.md
+++ b/docs/explanation/exhaustive-error-matching.md
@@ -110,18 +110,18 @@ matcher exists to eliminate.
 
 ## The one eliminator that still folds the error: `match`
 
-`match` applies the same exhaustive matcher to its `err` handler:
+`match` applies the same exhaustive matcher to its `errCases` handler:
 
 ```ts
 result.match({
   ok: (v) => v,
-  err: (matcher) => matcher.with(tag("NotFound"), () => 404).with(tag("Forbidden"), () => 403),
+  errCases: (matcher) => matcher.with(tag("NotFound"), () => 404).with(tag("Forbidden"), () => 403),
   defect: (cause) => 500,
 });
 ```
 
-so folding at the edge is exhaustive too — there is no blanket `err` callback
-left to silently drop a case. Its `err` handler receives the matcher but **no
+so folding at the edge is exhaustive too — there is no blanket error callback
+left to silently drop a case. Its `errCases` handler receives the matcher but **no
 `defect` helper**: `match` folds to a plain value, with no `Defect` output
 channel, and a `Result` that already carries a defect is handled by the separate
 `defect:` case.

--- a/docs/explanation/exhaustive-error-matching.md
+++ b/docs/explanation/exhaustive-error-matching.md
@@ -126,6 +126,53 @@ left to silently drop a case. Its `errCases` handler receives the matcher but **
 channel, and a `Result` that already carries a defect is handled by the separate
 `defect:` case.
 
+## Generic boundary helpers: use the guards, not the matcher
+
+The exhaustiveness that makes the matcher safe is proven by ts-pattern _at the
+call site_, from the concrete error union. Inside a **generic** helper — one
+whose error type is still a type parameter `E` — ts-pattern cannot prove any
+builder exhaustive, **not even `.with(P._, …)`**, because `E` is unresolved. So
+this does not compile:
+
+```ts
+// ❌ Won't compile: E is a type parameter, so no builder is provably exhaustive.
+function toPromise<T, E>(result: Result<T, E>): T {
+  return result.match({
+    ok: (value) => value,
+    errCases: (matcher) =>
+      matcher.with(P._, (error) => {
+        throw error;
+      }),
+    defect: (cause) => {
+      throw cause;
+    },
+  });
+}
+```
+
+This is a real limitation, not a bug you can pattern your way around: the same
+body compiles the moment `E` is a concrete union. It means the `…Cases` / `match`
+API is effectively unavailable to code that is generic in the error — a library
+boundary helper, a generic HTTP responder, a test utility.
+
+At such a boundary you are usually **leaving** the `Result` world anyway, so
+reach for the narrowing guards instead — they narrow to `OkView` / `ErrView` /
+`DefectView` with no exhaustiveness obligation, and read clearly:
+
+```ts
+// ✅ Guards carry no exhaustiveness obligation, so they work for any E.
+function toPromise<T, E>(result: Result<T, E>): T {
+  if (result.isErr()) throw result.error;
+  if (result.isDefect()) throw result.cause;
+  return result.value;
+}
+```
+
+This is exactly what unthrown's own generic code does — the interop `to*`
+bridges and `@unthrown/orpc`'s `handlerResult` all branch on the guards, not
+`match`, for the same reason. Concrete application code, where `E` is a known
+union, uses `match` and the `…Cases` combinators normally.
+
 ## Where to go next
 
 - The mechanics and every rule: [Combinator reference](../reference/combinators#the-error-channel).

--- a/docs/explanation/why-unthrown.md
+++ b/docs/explanation/why-unthrown.md
@@ -32,7 +32,7 @@ function getUser(id: string): Result<User, NotFound | Timeout>;
 
 getUser(id)
   .map((u) => u.emial.trim()) // typo — TypeError → Defect, NOT an Err
-  .match({ ok: render, err: (matcher) => matcher.with(P._, showMessage), defect: report500 });
+  .match({ ok: render, errCases: (matcher) => matcher.with(P._, showMessage), defect: report500 });
 ```
 
 ## The gap: unexpected failures

--- a/docs/how-to/handle-results-at-the-edge.md
+++ b/docs/how-to/handle-results-at-the-edge.md
@@ -39,7 +39,7 @@ const loadProfile = (id: string) =>
 async function handler(id: string): Promise<HttpResponse> {
   return (await loadProfile(id)).match({
     ok: (profile) => ({ status: 200, body: profile }),
-    err: (matcher) =>
+    errCases: (matcher) =>
       matcher
         .with(tag("NotFound"), (e) => ({ status: 404, body: e }))
         .with(tag("Forbidden"), (e) => ({ status: 403, body: e })),
@@ -93,7 +93,7 @@ app.get("/users/:id", (c) => {
 
   return user.match({
     ok: (u) => c.json(u, 200),
-    err: (matcher) =>
+    errCases: (matcher) =>
       matcher
         .with(tag("InvalidId"), () => c.json({ error: "invalid id" }, 400))
         .with(tag("NotFound"), (e) => c.json({ error: `no user ${e.id}` }, 404)),

--- a/docs/how-to/interoperate-with-libraries.md
+++ b/docs/how-to/interoperate-with-libraries.md
@@ -50,7 +50,7 @@ toExit(Err("e")); // Exit.fail("e")  — a modeled Cause.fail
 // Run an Effect and collect its outcome; a die/interrupt becomes a Defect:
 await fromEffect(Effect.succeed(1)).match({
   ok: (value) => value,
-  err: (matcher) => matcher.with(P._, (error) => error),
+  errCases: (matcher) => matcher.with(P._, (error) => error),
   defect: String,
 });
 ```

--- a/docs/how-to/migrate-from-neverthrow.md
+++ b/docs/how-to/migrate-from-neverthrow.md
@@ -7,22 +7,22 @@
 
 ## API mapping
 
-| neverthrow                           | unthrown                                     | Notes                                                                                                          |
-| ------------------------------------ | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `ok(v)` / `err(e)`                   | `Ok(v)` / `Err(e)`                           | constructors are capitalized                                                                                   |
-| `result.andThen(f)`                  | `result.flatMap(f)`                          | one name per concept                                                                                           |
-| `result.map(f)`                      | same                                         | callbacks must be synchronous                                                                                  |
-| `result.mapErr(f)`                   | `result.mapErrCases((matcher) => …)`         | an exhaustive [ts-pattern](https://github.com/gvergnaud/ts-pattern) match; `.with(P._, f)` is the uniform form |
-| `result.orElse(f)`                   | `result.flatMapErrCases((matcher) => …)`     | `flatMap` on the error channel; same exhaustive matcher                                                        |
-| `result.match(okFn, errFn)`          | `match({ ok, err: (matcher) => …, defect })` | the third channel is new, and `err` takes the same exhaustive matcher — see below                              |
-| `result.unwrapOr(v)`                 | `result.getOr(v)`                            | still throws on a Defect (a bug is not an absent value)                                                        |
-| `ResultAsync`                        | `AsyncResult`                                | `await` collapses it to a `Result`; it never rejects                                                           |
-| `ResultAsync.fromPromise(p, mapErr)` | `fromPromise(p, qualify)`                    | `qualify` must return `E` **or** `defect(cause)` — triage is forced                                            |
-| `ResultAsync.fromSafePromise(p)`     | `fromSafePromise(p)`                         | a rejection becomes a `Defect`, not an `Err`                                                                   |
-| `Result.combine([...])`              | `all([...])`                                 | any `Defect` dominates                                                                                         |
-| `Result.combineWithAllErrors`        | —                                            | error accumulation is deliberately excluded                                                                    |
-| `safeTry(function* …)`               | `Do().bind(…).let(…)`                        | see [do-notation](./sequence-dependent-steps)                                                                  |
-| `fromThrowable(fn, mapErr)`          | `fromThrowable(fn, qualify)`                 | same idea, plus the defect arm                                                                                 |
+| neverthrow                           | unthrown                                          | Notes                                                                                                          |
+| ------------------------------------ | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `ok(v)` / `err(e)`                   | `Ok(v)` / `Err(e)`                                | constructors are capitalized                                                                                   |
+| `result.andThen(f)`                  | `result.flatMap(f)`                               | one name per concept                                                                                           |
+| `result.map(f)`                      | same                                              | callbacks must be synchronous                                                                                  |
+| `result.mapErr(f)`                   | `result.mapErrCases((matcher) => …)`              | an exhaustive [ts-pattern](https://github.com/gvergnaud/ts-pattern) match; `.with(P._, f)` is the uniform form |
+| `result.orElse(f)`                   | `result.flatMapErrCases((matcher) => …)`          | `flatMap` on the error channel; same exhaustive matcher                                                        |
+| `result.match(okFn, errFn)`          | `match({ ok, errCases: (matcher) => …, defect })` | the third channel is new, and `errCases` takes the same exhaustive matcher — see below                         |
+| `result.unwrapOr(v)`                 | `result.getOr(v)`                                 | still throws on a Defect (a bug is not an absent value)                                                        |
+| `ResultAsync`                        | `AsyncResult`                                     | `await` collapses it to a `Result`; it never rejects                                                           |
+| `ResultAsync.fromPromise(p, mapErr)` | `fromPromise(p, qualify)`                         | `qualify` must return `E` **or** `defect(cause)` — triage is forced                                            |
+| `ResultAsync.fromSafePromise(p)`     | `fromSafePromise(p)`                              | a rejection becomes a `Defect`, not an `Err`                                                                   |
+| `Result.combine([...])`              | `all([...])`                                      | any `Defect` dominates                                                                                         |
+| `Result.combineWithAllErrors`        | —                                                 | error accumulation is deliberately excluded                                                                    |
+| `safeTry(function* …)`               | `Do().bind(…).let(…)`                             | see [do-notation](./sequence-dependent-steps)                                                                  |
+| `fromThrowable(fn, mapErr)`          | `fromThrowable(fn, qualify)`                      | same idea, plus the defect arm                                                                                 |
 
 Most rows are a rename. `andThen` → `flatMap` is unthrown's
 [one-name-per-concept](../explanation/design-decisions#one-name-per-concept-no-aliases)
@@ -66,7 +66,7 @@ app.get("/users/:id", async (req, res) => {
   const result = await getUser(req.params.id).map((user) => formatUser(user)); // a bug in formatUser → Defect
   result.match({
     ok: (view) => res.status(200).json(view),
-    err: (matcher) => matcher.with(P._, () => res.status(404).json({ error: "not found" })),
+    errCases: (matcher) => matcher.with(P._, () => res.status(404).json({ error: "not found" })),
     defect: (cause) => {
       console.error(cause); // everything the pipeline caught lands here
       res.status(500).json({ error: "internal error" });

--- a/docs/how-to/migrate-from-try-catch.md
+++ b/docs/how-to/migrate-from-try-catch.md
@@ -67,7 +67,7 @@ The call site becomes an ordinary `Result`, `await`ed once:
 const user = await getUser(id); // Result<User, "not_found">
 user.match({
   ok: (u) => render(u),
-  err: (matcher) => matcher.with("not_found", () => render404()), // the one modeled error
+  errCases: (matcher) => matcher.with("not_found", () => render404()), // the one modeled error
   defect: (cause) => render500(cause),
 });
 ```
@@ -130,7 +130,7 @@ result.match({
     connection.close();
     return v;
   },
-  err: (matcher) =>
+  errCases: (matcher) =>
     matcher.with(P._, (e) => {
       connection.close();
       return handleErr(e);

--- a/docs/how-to/model-errors.md
+++ b/docs/how-to/model-errors.md
@@ -81,7 +81,7 @@ e.name; // "RetryableError"          — clean stack-trace label
 ## Fold a tagged union with `match`
 
 To fold a `Result` whose error is a tagged union straight to a value, use
-`match`. Its `ok` and `defect` handlers are plain callbacks; its **`err` handler
+`match`. Its `ok` and `defect` handlers are plain callbacks; its **`errCases` handler
 receives the ts-pattern matcher** — add one branch per tag with `tag(t)` and
 **return the un-terminated builder** (`match` calls `.exhaustive()` for you):
 
@@ -94,7 +94,7 @@ const status = authorize(id).match({
     logger.error(cause);
     return 500;
   },
-  err: (matcher) =>
+  errCases: (matcher) =>
     matcher
       .with(tag("NotFound"), () => 404)
       .with(tag("Forbidden"), (e) => {
@@ -120,7 +120,7 @@ import { P } from "unthrown";
 const status = authorize(id).match({
   ok: () => 200,
   defect: () => 500,
-  err: (matcher) => matcher.with(P._, () => 403), // every error → 403
+  errCases: (matcher) => matcher.with(P._, () => 403), // every error → 403
 });
 ```
 

--- a/docs/how-to/qualify-a-boundary.md
+++ b/docs/how-to/qualify-a-boundary.md
@@ -136,7 +136,7 @@ the edge of your program needs no `try`/`catch` — just one exhaustive `match`:
 ```ts
 const status = await user.match({
   ok: () => 200,
-  err: (matcher) => matcher.with({ _tag: "NotFound" }, () => 404), // your modeled NotFound
+  errCases: (matcher) => matcher.with({ _tag: "NotFound" }, () => 404), // your modeled NotFound
   defect: (cause) => {
     logger.error(cause);
     return 500; // everything unexpected

--- a/docs/how-to/sequence-dependent-steps.md
+++ b/docs/how-to/sequence-dependent-steps.md
@@ -44,7 +44,7 @@ Do()
   .let("doubled", ({ n }) => n * 2)
   .match({
     ok: ({ n, doubled }) => `${n} → ${doubled}`,
-    err: (matcher) => matcher.with(P._, (e) => `failed: ${e}`),
+    errCases: (matcher) => matcher.with(P._, (e) => `failed: ${e}`),
     defect: (cause) => `bug: ${String(cause)}`,
   });
 ```
@@ -63,7 +63,11 @@ const profile = await Do()
   .bind("user", () => fromPromise(fetchUser(id), (c, defect) => defect(c)))
   .bind("posts", ({ user }) => fromPromise(fetchPosts(user.id), (c, defect) => defect(c)))
   .let("count", ({ posts }) => posts.length)
-  .match({ ok: (s) => s, err: (matcher) => matcher.with(P._, () => null), defect: () => null });
+  .match({
+    ok: (s) => s,
+    errCases: (matcher) => matcher.with(P._, () => null),
+    defect: () => null,
+  });
 ```
 
 ## When to reach for named functions instead

--- a/docs/how-to/upgrade-to-v5.md
+++ b/docs/how-to/upgrade-to-v5.md
@@ -1,0 +1,120 @@
+# Upgrade from 4.x to 5.0
+
+> **How-to.** A checklist for moving an existing codebase from `unthrown@4.x` to
+> `5.0`. Most of it is mechanical renames the compiler will point at; two changes
+> are worth doing deliberately. Work top to bottom.
+
+## At a glance
+
+| Kind                   | 4.x                                                              | 5.0                                                                                       |
+| ---------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| **Renamed** (loud)     | `mapErr` / `flatMapErr` / `recoverErr` / `tapErr` / `flatTapErr` | `mapErrCases` / `flatMapErrCases` / `recoverErrCases` / `tapErrCases` / `flatTapErrCases` |
+| **Renamed** (loud)     | `match({ ok, err, defect })`                                     | `match({ ok, errCases, defect })`                                                         |
+| **Renamed export**     | `UnwrapError`                                                    | `GetError`                                                                                |
+| **Removed** (aliases)  | `unwrap` / `unwrapErr` / `unwrapOr` / `unwrapOrElse`             | `get` / `getErr` / `getOr` / `getOrElse`                                                  |
+| **Removed** (aliases)  | `orElse` / `recover`                                             | `flatMapErrCases` / `recoverErrCases`                                                     |
+| **Removed**            | `matchTags` / the `TagHandlers` type                             | `match({ …, errCases: (m) => m.with(tag("…"), …) })`                                      |
+| **Changed, same name** | `getOrThrow()` on any `Result`                                   | gated to a **non-empty** error channel (use `get()` otherwise)                            |
+| **Packaging**          | `ts-pattern` bundled as a dependency                             | `ts-pattern` is now a **peer** — install it yourself                                      |
+| **Packaging**          | `@unthrown/pattern` (`match` / `P` / `tag`)                      | absorbed into core — import them from `unthrown`                                          |
+| **New**                | —                                                                | `ensure`, `DoAsync`, and `match` / `P` / `tag` re-exports                                 |
+
+Everything except the two rows below is a compile error at the old call site, so
+`pnpm typecheck` is your migration to-do list.
+
+## 1. Install `ts-pattern`
+
+`ts-pattern` (`^5`) moved from a bundled dependency to a **peer** so a codebase
+that already uses ts-pattern shares one copy — two copies' declarations don't
+unify, and feeding a `P.union(...)` built by one into an unthrown matcher fails
+deep in a conditional type.
+
+```sh
+pnpm add ts-pattern   # if you don't already depend on it
+```
+
+Your package manager will otherwise warn about a missing peer. If you already use
+ts-pattern, keep your own version — unthrown works with any `^5`.
+
+## 2. Rename the error-channel combinators
+
+Every Err-channel combinator gained a `…Cases` suffix, because each takes a
+ts-pattern matcher over the error's _cases_, not a plain `(error) => …` callback.
+The old names no longer exist, so the compiler flags each site:
+
+```diff
+- result.mapErr((m) => m.with(P._, wrap))
++ result.mapErrCases((m) => m.with(P._, wrap))
+```
+
+Same for `flatMapErr` → `flatMapErrCases`, `recoverErr` → `recoverErrCases`,
+`tapErr` → `tapErrCases`, `flatTapErr` → `flatTapErrCases`. See
+[Exhaustive error matching](../explanation/exhaustive-error-matching) for why.
+
+## 3. Rename `match`'s error handler — `err` → `errCases`
+
+::: warning The one break the compiler almost missed
+In 5.0 the `match` error handler receives the **matcher**, not the error value,
+and its key is renamed `err` → `errCases` to match the combinators. That rename
+is what makes the change **loud**: a leftover 4.x `err: (error) => …` handler
+still satisfied the new matcher constraint whenever it threw (a throwing handler
+returns `never`, which vacuously satisfies it), so it compiled and then threw the
+_matcher object_ at runtime. The renamed key turns that into an
+excess-property compile error instead.
+:::
+
+```diff
+  result.match({
+    ok: (value) => value,
+-   err: (error) => handleError(error),
++   errCases: (matcher) => matcher.with(P._, (error) => handleError(error)),
+    defect: (cause) => report(cause),
+  })
+```
+
+If your old `err` handler was `(error) => { throw error }`, prefer
+[`getOrThrow()`](../reference/combinators) — the sanctioned single-throw
+extractor — over re-throwing inside a match arm.
+
+## 4. Replace the removed aliases
+
+The `@deprecated` aliases from the 4.x line are gone (one concept, one name):
+
+| Removed        | Use                                                  |
+| -------------- | ---------------------------------------------------- |
+| `unwrap`       | `get`                                                |
+| `unwrapErr`    | `getErr`                                             |
+| `unwrapOr`     | `getOr`                                              |
+| `unwrapOrElse` | `getOrElse`                                          |
+| `orElse`       | `flatMapErrCases`                                    |
+| `recover`      | `recoverErrCases`                                    |
+| `matchTags`    | `match({ …, errCases: (m) => m.with(tag("…"), …) })` |
+
+`UnwrapError` (the throw type of `get`/`getErr`) is renamed **`GetError`**.
+
+## 5. Check the two behavioural gates
+
+- **`getOrThrow()`** now compiles only when the error channel is **non-empty**.
+  On a `Result<T, never>` there is nothing to throw, so the compiler steers you to
+  `get()`. The diagnostic names the reason.
+- **`get()` / `getErr()`** are unchanged, but if you were relying on `getOrThrow`
+  as a universal extractor, split by channel state: `get()` when `E = never`,
+  `getOrThrow()` when it isn't.
+
+## 6. `@unthrown/pattern` is gone
+
+`match`, `P`, and `tag` are now exported by `unthrown` itself. Drop the
+`@unthrown/pattern` dependency and re-point the imports:
+
+```diff
+- import { match, P, tag } from "@unthrown/pattern";
++ import { match, P, tag } from "unthrown";
+```
+
+## What you gained
+
+- **`ensure`** — validate or refine a success in place (`Result<T, E | E2>`, or a
+  type-guard narrowing `T`).
+- **`DoAsync()`** — the pre-lifted async twin of `Do()`.
+- **`match` / `P` / `tag`** as first-class re-exports, so the error matcher is one
+  import.

--- a/docs/how-to/use-with-orpc.md
+++ b/docs/how-to/use-with-orpc.md
@@ -121,7 +121,7 @@ const greeting = await rc.planet
   .match({
     ok: (msg) => msg,
     // the matcher branches on the ORPCError `code`, not a `_tag`
-    err: (matcher) =>
+    errCases: (matcher) =>
       matcher.with({ code: "NOT_FOUND" }, () => "Hello, void!").with(P._, () => "Hello, trouble!"),
     defect: () => "Hello, bug tracker!",
   });
@@ -130,7 +130,7 @@ const greeting = await rc.planet
 The error channel is the raw inferable `ORPCError` union, discriminated by `code`
 — deliberately **not** re-wrapped into [tagged errors](./model-errors): oRPC
 already ships a discriminated error type, and one concept should have one name.
-Branch on `code` — in `match`'s `err` matcher (as above), a `switch`, or a
+Branch on `code` — in `match`'s `errCases` matcher (as above), a `switch`, or a
 standalone ts-pattern `match`. Because these are plain `ORPCError`s rather than
 `TaggedError`s, `tag(...)` doesn't apply — match on the `code` field instead.
 

--- a/docs/how-to/use-with-prisma.md
+++ b/docs/how-to/use-with-prisma.md
@@ -63,7 +63,7 @@ error you want to model (`RecordNotFound`).
 
 ## Handle the errors
 
-Because the errors are [tagged](./model-errors), driving `match`'s `err` handler
+Because the errors are [tagged](./model-errors), driving `match`'s `errCases` handler
 with the ts-pattern matcher gives you an exhaustive fold — the compiler lists
 exactly the cases the operation can hit:
 
@@ -74,7 +74,7 @@ const created = await db.user.tryCreate({ data: { email, name } });
 
 return created.match({
   ok: (user) => resp.created(user),
-  err: (matcher) =>
+  errCases: (matcher) =>
     matcher
       .with(tag("UniqueConstraintViolation"), (e) => resp.conflict(`taken: ${e.fields.join(", ")}`))
       .with(tag("ForeignKeyViolation"), () => resp.badRequest("unknown reference"))
@@ -84,7 +84,7 @@ return created.match({
 // No RecordNotFound arm — a create can't raise it, and the type knows.
 ```
 
-When you don't need per-tag branches, collapse the `err` matcher to a single
+When you don't need per-tag branches, collapse the `errCases` matcher to a single
 `.with(P._, …)` catch-all.
 
 ## Transactions
@@ -130,7 +130,7 @@ const page = await db.user
 
 page.match({
   ok: ([users, meta]) => json({ users, nextCursor: meta.endCursor, hasMore: meta.hasNextPage }),
-  err: (matcher) => matcher.with(P._, (e) => serverError(e)),
+  errCases: (matcher) => matcher.with(P._, (e) => serverError(e)),
   defect: serverError,
 });
 ```

--- a/docs/how-to/validate-with-standard-schema.md
+++ b/docs/how-to/validate-with-standard-schema.md
@@ -35,7 +35,7 @@ if (bad.isErr()) bad.error; // readonly StandardSchemaV1.Issue[]
 
 ## Reduce issues to per-field messages
 
-The error channel is the issues array — map it in the `err` arm. Here a `P._`
+The error channel is the issues array — map it in the `errCases` arm. Here a `P._`
 catch-all hands the whole array to one branch that reduces it to per-field
 messages:
 
@@ -64,7 +64,7 @@ type ValidationResult =
 function validateSignup(input: unknown): ValidationResult {
   return parseSignup(input).match({
     ok: (data) => ({ ok: true, data }),
-    err: (matcher) =>
+    errCases: (matcher) =>
       matcher.with(P._, (issues) => ({
         ok: false as const,
         fieldErrors: issues.reduce<Record<string, string[]>>((byField, issue) => {

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ const profile = fromPromise(db.loadProfile(id), (cause, defect) =>
 // Handle every channel once, at the edge — no surrounding try/catch.
 const status = await profile.match({
   ok: () => 200,
-  err: (matcher) => matcher.with(P._, () => 404), // `err` takes the exhaustive matcher
+  errCases: (matcher) => matcher.with(P._, () => 404), // `errCases` takes the exhaustive matcher
   defect: () => 500,
 });
 ```

--- a/docs/reference/combinators.md
+++ b/docs/reference/combinators.md
@@ -152,7 +152,7 @@ result.mapErrCases((matcher) => matcher.with(P._, (e) => new AppError(e))); // a
 result.recoverErrCases((matcher) => matcher.with(P._, () => fallback)); // any error → fallback value
 result.match({
   ok: (v) => v,
-  err: (matcher) => matcher.with(P._, (e) => `failed: ${e}`),
+  errCases: (matcher) => matcher.with(P._, (e) => `failed: ${e}`),
   defect: (c) => `bug: ${c}`,
 });
 ```
@@ -205,7 +205,7 @@ const status = await findUser(id) // Result<User, NotFound>  (sync)
   .toAsync() // AsyncResult<User, NotFound>
   .flatMap((user) => fromPromise(loadOrders(user.id), qualify)) // async step
   .map((orders) => orders.length) // sync callback, still AsyncResult
-  .match({ ok: (n) => n, err: (matcher) => matcher.with(P._, () => 0), defect: () => -1 }); // await collapses it
+  .match({ ok: (n) => n, errCases: (matcher) => matcher.with(P._, () => 0), defect: () => -1 }); // await collapses it
 ```
 
 ## The pairs that are easy to confuse

--- a/docs/reference/combinators.md
+++ b/docs/reference/combinators.md
@@ -65,12 +65,12 @@ the observers (`tapDefect` / `tapFailure`), and `match`:
 | `recoverDefect`                   | passes ▸ | passes ▸      | runs `f`    | `E \| E2`       |
 | `tapDefect`                       | passes ▸ | passes ▸      | runs `f`    | `E`             |
 | `tapFailure`                      | passes ▸ | runs `f`      | runs `f`    | `E`             |
-| `match`                           | `ok()`   | `err()`       | `defect()`  | —               |
+| `match`                           | `ok()`   | `errCases()`  | `defect()`  | —               |
 
 ::: tip `recoverErrCases`'s `never` under-describes the runtime
 `recoverErrCases` empties only the **error** channel to `never` — a `Defect` can still be
 present at runtime and flows past it untouched. See
-[The Defect Channel](../explanation/the-defect-channel#recovererr-clears-the-error-channel-not-the-runtime).
+[The Defect Channel](../explanation/the-defect-channel#recovererrcases-clears-the-error-channel-not-the-runtime).
 :::
 
 ## The error channel

--- a/docs/tutorial/crossing-an-async-boundary.md
+++ b/docs/tutorial/crossing-an-async-boundary.md
@@ -74,7 +74,7 @@ bug in a `.map` — lands in `defect`:
 ```ts
 const status = await user.match({
   ok: () => 200,
-  err: (matcher) => matcher.with({ _tag: "NotFound" }, () => 404),
+  errCases: (matcher) => matcher.with({ _tag: "NotFound" }, () => 404),
   defect: (cause) => {
     logger.error(cause);
     return 500; // everything unexpected

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -96,9 +96,9 @@ _unexpected_ (you'll meet it in the next step):
 ```ts
 const message = parseAge("-3").match({
   ok: (age) => `age is ${age}`,
-  // `err` receives an exhaustive matcher — one branch per error. ts-pattern
+  // `errCases` receives an exhaustive matcher — one branch per error. ts-pattern
   // matches plain strings too (no tag required), and a missing case won't compile.
-  err: (matcher) =>
+  errCases: (matcher) =>
     matcher.with("negative", () => "must be positive").with("not_a_number", () => "not a number"),
   defect: (cause) => {
     console.error(cause); // a bug slipped through — log it, don't leak it

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -12,21 +12,24 @@ outcome as a value — with no `try`/`catch` to write. It takes about ten minute
 ::: code-group
 
 ```sh [pnpm]
-pnpm add unthrown
+pnpm add unthrown ts-pattern
 ```
 
 ```sh [npm]
-npm install unthrown
+npm install unthrown ts-pattern
 ```
 
 ```sh [yarn]
-yarn add unthrown
+yarn add unthrown ts-pattern
 ```
 
 :::
 
 `unthrown` is ESM-first, ships dual CJS/ESM builds with full types, and has one
-tiny runtime dependency (`ts-pattern`). Use it with TypeScript in `strict` mode.
+tiny runtime dependency, `ts-pattern` (`^5`) — a **peer** you install alongside
+it, so you own the single copy that powers the error matchers (and that
+`unthrown` re-exports as `match` / `P`). Use it with TypeScript in `strict`
+mode.
 
 ## Step 2 — Return a failure instead of throwing
 

--- a/packages/boxed/src/index.ts
+++ b/packages/boxed/src/index.ts
@@ -48,7 +48,7 @@ export function toBoxed<T, E>(
   onDefect: (cause: unknown) => E,
 ): BoxedResult<T, E> {
   // Guard-based (not `match`): this bridge is generic in `E`, and `match`'s
-  // exhaustive `err` matcher cannot be proven exhaustive over an unresolved
+  // exhaustive `errCases` matcher cannot be proven exhaustive over an unresolved
   // type parameter.
   if (result.isOk()) return BoxedResult.Ok(result.value);
   if (result.isErr()) return BoxedResult.Error(result.error);

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -7,8 +7,13 @@
 [API Reference](https://btravstack.github.io/unthrown/api/core/)
 
 ```sh
-pnpm add unthrown
+pnpm add unthrown ts-pattern
 ```
+
+`ts-pattern` (`^5`) is a peer dependency — it powers the exhaustive error
+matchers and is re-exported as `match` / `P`. Declaring it a peer means you own
+the single copy, so `import { P } from "ts-pattern"` composes with unthrown's
+matchers.
 
 ```ts
 import { fromPromise, P, TaggedError } from "unthrown";
@@ -34,7 +39,8 @@ const status = await user.match({
   to triage each failure into a modeled error or a defect.
 - **Tagged errors** — `TaggedError(tag)` + `tag(t)`, folded exhaustively through
   `match`'s ts-pattern error matcher.
-- One tiny runtime dependency (`ts-pattern`), ESM-first, dual CJS/ESM.
+- One tiny runtime dependency (`ts-pattern`, a peer you share), ESM-first, dual
+  CJS/ESM.
 
 See the [full documentation](https://btravstack.github.io/unthrown/) for the guide
 and complete API.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -45,6 +45,9 @@ const status = await user.match({
 See the [full documentation](https://btravstack.github.io/unthrown/) for the guide
 and complete API.
 
+**Upgrading from 4.x?** See
+[Upgrade from 4.x to 5.0](https://btravstack.github.io/unthrown/how-to/upgrade-to-v5).
+
 ## License
 
 [MIT](https://github.com/btravstack/unthrown/blob/main/LICENSE) © Benoit TRAVERS

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -27,7 +27,7 @@ const user = fromPromise(fetchUser(id), (cause, defect) =>
 
 const status = await user.match({
   ok: () => 200,
-  err: (matcher) => matcher.with(P._, () => 404), // `err` takes the exhaustive matcher
+  errCases: (matcher) => matcher.with(P._, () => 404), // `errCases` takes the exhaustive matcher
   defect: () => 500,
 });
 ```

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,19 +53,20 @@
     "test:types": "tsc --noEmit -p tsconfig.test-d.json",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test-d.json"
   },
-  "dependencies": {
-    "ts-pattern": "catalog:"
-  },
   "devDependencies": {
     "@btravstack/tsconfig": "catalog:",
     "@btravstack/typedoc": "catalog:",
     "@types/node": "catalog:",
     "@vitest/coverage-v8": "catalog:",
+    "ts-pattern": "catalog:",
     "tsdown": "catalog:",
     "typedoc": "catalog:",
     "typedoc-plugin-markdown": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "ts-pattern": "^5"
   },
   "engines": {
     "node": ">=20"

--- a/packages/core/src/async-result.spec.ts
+++ b/packages/core/src/async-result.spec.ts
@@ -425,7 +425,7 @@ describe("AsyncResult eliminators", () => {
     const fold = (r: AsyncResult<number, string>) =>
       r.match({
         ok: (v) => `ok:${v}`,
-        err: (matcher) => matcher.with(P._, (e) => `err:${e}`),
+        errCases: (matcher) => matcher.with(P._, (e) => `err:${e}`),
         defect: () => "defect",
       });
     expect(await fold(asyncOk(1))).toBe("ok:1");

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -296,7 +296,7 @@ class Res<T, E> {
     this: Result<T, E>,
     cases: {
       ok: (value: T) => ROk;
-      err: (matcher: ErrMatcher<E>) => M;
+      errCases: (matcher: ErrMatcher<E>) => M;
       defect: (cause: unknown) => RDefect;
     },
   ): ROk | RDefect | MatchOut<M> {
@@ -304,12 +304,12 @@ class Res<T, E> {
       case "Ok":
         return cases.ok(this.value);
       case "Err":
-        // The `err` handler returns the un-terminated builder; `.run()` executes
-        // `.exhaustive()`. Type-forced exhaustive for well-typed callers; a value
-        // slipping past the types (widened cast, JS caller) with no matching case
-        // throws ts-pattern's `NonExhaustiveError` — `match` is an edge eliminator,
-        // so it surfaces rather than being caught into a Defect.
-        return cases.err(match(this.error) as ErrMatcher<E>).run() as MatchOut<M>;
+        // The `errCases` handler returns the un-terminated builder; `.run()`
+        // executes `.exhaustive()`. Type-forced exhaustive for well-typed
+        // callers; a value slipping past the types (widened cast, JS caller) with
+        // no matching case throws ts-pattern's `NonExhaustiveError` — `match` is
+        // an edge eliminator, so it surfaces rather than being caught into a Defect.
+        return cases.errCases(match(this.error) as ErrMatcher<E>).run() as MatchOut<M>;
       case "Defect":
         return cases.defect(this.cause);
     }
@@ -469,7 +469,8 @@ export function defectRes<T, E>(cause: unknown): Result<T, E> {
  * isResult(Ok(1).toAsync()); // => false (an AsyncResult is not a Result)
  *
  * const x: unknown = Ok(1);
- * if (isResult(x)) x.match({ ok: () => 1, err: () => 0, defect: () => -1 });
+ * if (isResult(x))
+ *   x.match({ ok: () => 1, errCases: (m) => m.with(P._, () => 0), defect: () => -1 });
  * ```
  *
  * @category Guards
@@ -887,7 +888,7 @@ export class AsyncRes<T, E> implements AsyncResult<T, E> {
 
   match<ROk, RDefect, M extends ExhaustiveMatch<unknown>>(cases: {
     ok: (value: T) => ROk;
-    err: (matcher: ErrMatcher<E>) => M;
+    errCases: (matcher: ErrMatcher<E>) => M;
     defect: (cause: unknown) => RDefect;
   }): Promise<ROk | RDefect | MatchOut<M>> {
     return this.#promise.then((r) => r.match(cases));

--- a/packages/core/src/invariants.spec.ts
+++ b/packages/core/src/invariants.spec.ts
@@ -157,7 +157,7 @@ describe("Invariant 2: a Defect flows through every method except match() and re
     expect(
       defectOf(boom).match({
         ok: () => "o",
-        err: (matcher) => matcher.with(P._, () => "e"),
+        errCases: (matcher) => matcher.with(P._, () => "e"),
         defect: () => "d",
       }),
     ).toBe("d");

--- a/packages/core/src/result.spec.ts
+++ b/packages/core/src/result.spec.ts
@@ -719,7 +719,7 @@ describe("Result.match", () => {
     const fold = (r: Result<number, string>) =>
       r.match({
         ok: (v) => `ok:${v}`,
-        err: (matcher) => matcher.with(P._, (e) => `err:${e}`),
+        errCases: (matcher) => matcher.with(P._, (e) => `err:${e}`),
         defect: (c) => `defect:${(c as Error).message}`,
       });
     expect(fold(Ok(1))).toBe("ok:1");

--- a/packages/core/src/tagged.spec.ts
+++ b/packages/core/src/tagged.spec.ts
@@ -119,20 +119,20 @@ describe("TaggedError", () => {
     const out = (Err(new Retryable()) as Result<number, Retryable>).match({
       ok: (n) => `ok:${n}`,
       defect: () => "defect",
-      err: (matcher) => matcher.with(tag("@my-lib/Retryable"), (e) => `retry:${e.name}`),
+      errCases: (matcher) => matcher.with(tag("@my-lib/Retryable"), (e) => `retry:${e.name}`),
     });
     expect(out).toBe("retry:Retryable");
   });
 });
 
 // The per-tag exhaustive fold that `matchTags` used to provide is now `match`
-// with its `err` handler driven by the ts-pattern error matcher and `tag(t)`.
+// with its `errCases` handler driven by the ts-pattern error matcher and `tag(t)`.
 describe("match — per-tag error matching", () => {
   const fold = (r: Result<number, ApiError>): string =>
     r.match({
       ok: (n) => `ok:${n}`,
       defect: (cause) => `defect:${String(cause)}`,
-      err: (matcher) =>
+      errCases: (matcher) =>
         matcher
           .with(tag("NotFound"), () => "not-found")
           .with(tag("Forbidden"), (e) => `forbidden:${e.user}`)
@@ -168,7 +168,7 @@ describe("match — per-tag error matching", () => {
     const out = await r.match({
       ok: (n) => `ok:${n}`,
       defect: () => "defect",
-      err: (matcher) =>
+      errCases: (matcher) =>
         matcher
           .with(tag("NotFound"), () => "nf")
           .with(tag("Forbidden"), () => "fb")
@@ -182,7 +182,7 @@ describe("match — per-tag error matching", () => {
       r.match({
         ok: (n) => `ok:${n}`,
         defect: () => "defect",
-        err: (matcher) => matcher.with(P._, (e) => `err:${e._tag}`),
+        errCases: (matcher) => matcher.with(P._, (e) => `err:${e._tag}`),
       });
     expect(uniform(Err(new NotFound()))).toBe("err:NotFound");
     expect(uniform(Err(new HttpError({ status: 500 })))).toBe("err:HttpError");
@@ -195,7 +195,7 @@ describe("match — per-tag error matching", () => {
       (Err(rogue) as Result<number, Known>).match({
         ok: () => "ok",
         defect: () => "defect",
-        err: (matcher) => matcher.with(tag("Known"), () => "known"),
+        errCases: (matcher) => matcher.with(tag("Known"), () => "known"),
       }),
     ).toThrow();
   });

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -354,7 +354,7 @@ type _errOf = Expect<Equal<ErrOf<Result<number, "e">>, "e">>;
 type _asyncOkOf = Expect<Equal<AsyncOkOf<AsyncResult<number, "e">>, number>>;
 type _asyncErrOf = Expect<Equal<AsyncErrOf<AsyncResult<number, "e">>, "e">>;
 
-// --- tagged errors: match's `err` matcher is exhaustive ----------------------
+// --- tagged errors: match's `errCases` matcher is exhaustive ----------------------
 
 class TagA extends TaggedError("TagA") {}
 class TagB extends TaggedError("TagB") {}
@@ -364,21 +364,38 @@ declare const tagged: Result<number, TagA | TagB>;
 tagged.match({
   ok: () => 1,
   defect: () => 2,
-  err: (matcher) => matcher.with(tag("TagA"), () => 3).with(tag("TagB"), () => 4),
+  errCases: (matcher) => matcher.with(tag("TagA"), () => 3).with(tag("TagB"), () => 4),
 });
 
 tagged.match({
   ok: () => 1,
   defect: () => 2,
   // @ts-expect-error - the TagB branch is missing, so the builder is not exhaustive
-  err: (matcher) => matcher.with(tag("TagA"), () => 3),
+  errCases: (matcher) => matcher.with(tag("TagA"), () => 3),
+});
+
+// The 4.x call shape — an `err` key taking the error value — no longer compiles:
+// the matcher handler is now `errCases`, so a leftover `err` key is an excess
+// property. This is the loud replacement for the former silent runtime break (a
+// throwing `err` handler returned `never`, vacuously satisfying the matcher
+// constraint, then threw the matcher object at runtime).
+tagged.match({
+  ok: (value) => value,
+  errCases: (matcher) => matcher.with(P._, (e) => e),
+  // @ts-expect-error - `err` is not a valid handler key (renamed to `errCases` in 5.0)
+  err: (error: unknown) => {
+    throw error;
+  },
+  defect: (cause) => {
+    throw cause;
+  },
 });
 
 // The folded type unions the ok/defect returns with the err branches' returns.
 const folded = tagged.match({
   ok: () => "ok" as const,
   defect: () => "defect" as const,
-  err: (matcher) =>
+  errCases: (matcher) =>
     matcher.with(tag("TagA"), () => "a" as const).with(tag("TagB"), () => "b" as const),
 });
 type _folded = Expect<Equal<typeof folded, "ok" | "defect" | "a" | "b">>;
@@ -388,7 +405,7 @@ type _folded = Expect<Equal<typeof folded, "ok" | "defect" | "a" | "b">>;
 const foldedObjects = tagged.match({
   ok: (n) => ({ ok: n }),
   defect: () => ({ bug: true }),
-  err: (matcher) => matcher.with(P._, (e) => ({ err: e._tag })),
+  errCases: (matcher) => matcher.with(P._, (e) => ({ err: e._tag })),
 });
 type _foldedObjects = Expect<
   Equal<typeof foldedObjects, { ok: number } | { bug: boolean } | { err: "TagA" | "TagB" }>
@@ -491,7 +508,7 @@ new WithMsg({ ticketId: "t1" });
   // ok/defect directly, and the err matcher's branches too (no NotThenable here).
   void r.match({
     ok: async (n) => n,
-    err: (matcher) => matcher.with(P._, async (e) => e.length),
+    errCases: (matcher) => matcher.with(P._, async (e) => e.length),
     defect: async () => 0,
   });
 }

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -411,6 +411,28 @@ type _foldedObjects = Expect<
   Equal<typeof foldedObjects, { ok: number } | { bug: boolean } | { err: "TagA" | "TagB" }>
 >;
 
+// Generic-E limitation (documented in the exhaustive-error-matching guide): inside
+// a helper whose error type is still a type parameter, ts-pattern cannot prove any
+// builder exhaustive — not even `.with(P._, …)` — so `match`/`…Cases` do not
+// compile there. Generic boundary helpers use the narrowing guards instead. If a
+// future ts-pattern makes the generic case provable, this @ts-expect-error flips
+// and the guide note can be revisited.
+function _genericMatch<T, E>(result: Result<T, E>): void {
+  result.match({
+    ok: () => undefined,
+    // @ts-expect-error - P._ is not provably exhaustive over an unresolved E
+    errCases: (matcher) => matcher.with(P._, () => undefined),
+    defect: () => undefined,
+  });
+}
+// The guard-based form compiles for any E — the sanctioned generic boundary shape.
+function _genericGuards<T, E>(result: Result<T, E>): T {
+  if (result.isErr()) throw result.error;
+  if (result.isDefect()) throw result.cause;
+  return result.value;
+}
+type _genericGuardsT = Expect<Equal<ReturnType<typeof _genericGuards>, unknown>>;
+
 // `_tag` is the literal; `options.name` is independent (still a literal `_tag`)
 class Named extends TaggedError("@scope/Named", { name: "Named" }) {}
 type _namedTag = Expect<Equal<(typeof Named)["prototype"]["_tag"], "@scope/Named">>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -436,25 +436,26 @@ export type ResultMethods<out T, out E> = {
    * is typically the single place a pipeline is handled at the edge — mapping
    * `Ok`/`Err`/`Defect` to (for example) 2xx / 4xx / 5xx with no `try`/`catch`.
    *
-   * The `err` handler does not take a single blanket callback: it receives
+   * The `errCases` handler does not take a single blanket callback: it receives
    * `match(error)` (an {@link ErrMatcher}) and **matches the error exhaustively**,
-   * exactly like the error combinators. Chain `.with(pattern, handler)` and
-   * **return the un-terminated builder** — `match` calls `.exhaustive()` itself,
-   * so a missing case is a compile error at the call site (no `.exhaustive()` to
-   * forget). Use `.with(P._, …)` for a uniform catch-all. Unlike the combinators
-   * the branches receive **no `defect` helper** — `match` is total elimination
-   * to a value, with no `Defect` output channel; the `defect` case handles a
-   * `Result` that already carries one. (A `Result` is also a discriminated
-   * union — for richer whole-`Result` matching, `match(result).with(…)`.)
+   * exactly like the error combinators — which is why the key carries the same
+   * `…Cases` suffix. Chain `.with(pattern, handler)` and **return the
+   * un-terminated builder** — `match` calls `.exhaustive()` itself, so a missing
+   * case is a compile error at the call site (no `.exhaustive()` to forget). Use
+   * `.with(P._, …)` for a uniform catch-all. Unlike the combinators the branches
+   * receive **no `defect` helper** — `match` is total elimination to a value,
+   * with no `Defect` output channel; the `defect` case handles a `Result` that
+   * already carries one. (A `Result` is also a discriminated union — for richer
+   * whole-`Result` matching, `match(result).with(…)`.)
    *
    * @typeParam ROk - the `ok` handler return type.
    * @typeParam RDefect - the `defect` handler return type.
-   * @typeParam M - the exhaustive builder the `err` handler returns.
-   * @param cases - the `ok`/`defect` handlers plus the `err` matcher builder.
+   * @typeParam M - the exhaustive builder the `errCases` handler returns.
+   * @param cases - the `ok`/`defect` handlers plus the `errCases` matcher builder.
    */
   match<ROk, RDefect, M extends ExhaustiveMatch<unknown>>(cases: {
     ok: (value: T) => ROk;
-    err: (matcher: ErrMatcher<E>) => M;
+    errCases: (matcher: ErrMatcher<E>) => M;
     defect: (cause: unknown) => RDefect;
   }): ROk | RDefect | MatchOut<M>;
   /**
@@ -674,7 +675,7 @@ export type FailureView<E, T = never> = ErrView<E, T> | DefectView<T, E>;
  *
  * const message = half(10).match({
  *   ok: (n) => `got ${n}`,
- *   err: (matcher) => matcher.with(P._, (e) => `failed: ${e}`),
+ *   errCases: (matcher) => matcher.with(P._, (e) => `failed: ${e}`),
  *   defect: (cause) => `bug: ${String(cause)}`,
  * });
  * ```
@@ -901,12 +902,12 @@ export type AsyncResultMethods<out T, out E> = {
 
   /**
    * Asynchronous {@link ResultMethods.match | match}. Handlers are synchronous
-   * (the `err` handler returns an exhaustive {@link ErrMatcher} builder, no
+   * (the `errCases` handler returns an exhaustive {@link ErrMatcher} builder, no
    * `defect` helper); resolves to a `Promise` of the folded value.
    */
   match<ROk, RDefect, M extends ExhaustiveMatch<unknown>>(cases: {
     ok: (value: T) => ROk;
-    err: (matcher: ErrMatcher<E>) => M;
+    errCases: (matcher: ErrMatcher<E>) => M;
     defect: (cause: unknown) => RDefect;
   }): Promise<ROk | RDefect | MatchOut<M>>;
   /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -540,7 +540,11 @@ export type ResultMethods<out T, out E> = {
    * @throws the modeled `error` on `Err`; re-throws the original `cause` on a
    * `Defect` (a panic, like the rest of the `getOr…` family).
    */
-  getOrThrow(this: [E] extends [never] ? never : Result<T, E>): T;
+  getOrThrow(
+    this: [E] extends [never]
+      ? "unthrown: getOrThrow is unnecessary here — the Err channel is empty (E = never), so there is nothing to throw. Use get() instead."
+      : Result<T, E>,
+  ): T;
 
   /** Whether this result is `Ok` — narrows `this` to its {@link OkView} on `true`. */
   isOk(): this is OkView<T, E>;
@@ -931,7 +935,11 @@ export type AsyncResultMethods<out T, out E> = {
    * on a `Defect`), rather than throwing synchronously. Gated the same way: it
    * compiles only when the error channel is non-empty (`E` is not `never`).
    */
-  getOrThrow(this: [E] extends [never] ? never : AsyncResult<T, E>): Promise<T>;
+  getOrThrow(
+    this: [E] extends [never]
+      ? "unthrown: getOrThrow is unnecessary here — the Err channel is empty (E = never), so there is nothing to throw. Use get() instead."
+      : AsyncResult<T, E>,
+  ): Promise<T>;
 };
 
 /**

--- a/packages/effect/README.md
+++ b/packages/effect/README.md
@@ -26,7 +26,7 @@ toExit(Err("e")); // Exit.fail("e")        — a modeled Cause.fail
 // Run an Effect and collect its outcome (die/interrupt become a Defect):
 await fromEffect(Effect.succeed(1)).match({
   ok: (n) => n,
-  err: (matcher) => matcher.with(P._, (e) => e), // the error channel, matched exhaustively
+  errCases: (matcher) => matcher.with(P._, (e) => e), // the error channel, matched exhaustively
   defect: String,
 });
 ```

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -42,7 +42,7 @@ import type { AsyncResult, Result } from "unthrown";
  */
 export function toExit<T, E>(result: Result<T, E>): Exit.Exit<T, E> {
   // Guard-based (not `match`): this bridge is generic in `E`, and `match`'s
-  // exhaustive `err` matcher cannot be proven exhaustive over an unresolved
+  // exhaustive `errCases` matcher cannot be proven exhaustive over an unresolved
   // type parameter.
   if (result.isOk()) return Exit.succeed(result.value);
   if (result.isErr()) return Exit.fail(result.error);

--- a/packages/neverthrow/src/index.ts
+++ b/packages/neverthrow/src/index.ts
@@ -53,7 +53,7 @@ export function toNeverthrow<T, E>(
   onDefect: (cause: unknown) => E,
 ): NeverthrowResult<T, E> {
   // Guard-based (not `match`): this bridge is generic in `E`, and `match`'s
-  // exhaustive `err` matcher cannot be proven exhaustive over an unresolved
+  // exhaustive `errCases` matcher cannot be proven exhaustive over an unresolved
   // type parameter.
   if (result.isOk()) return neverthrowOk(result.value);
   if (result.isErr()) return neverthrowErr(result.error);

--- a/packages/orpc/README.md
+++ b/packages/orpc/README.md
@@ -78,8 +78,8 @@ const greeting = await rc.planet
   .map((planet) => `Hello, ${planet.name}!`)
   .match({
     ok: (msg) => msg,
-    // `err` takes the exhaustive matcher — branch on the ORPCError `code`
-    err: (matcher) =>
+    // `errCases` takes the exhaustive matcher — branch on the ORPCError `code`
+    errCases: (matcher) =>
       matcher.with({ code: "NOT_FOUND" }, () => "Hello, void!").with(P._, () => "Hello, trouble!"),
     defect: () => "Hello, bug tracker!",
   });

--- a/packages/orpc/src/client.ts
+++ b/packages/orpc/src/client.ts
@@ -120,8 +120,8 @@ export type ResultClient<T extends AnyNestedClient> =
  *   .map((planet) => `Hello, ${planet.name}!`)
  *   .match({
  *     ok: (msg) => msg,
- *     // the `err` handler matches the error exhaustively (here on `code`)
- *     err: (matcher) =>
+ *     // the `errCases` handler matches the error exhaustively (here on `code`)
+ *     errCases: (matcher) =>
  *       matcher
  *         .with({ code: "NOT_FOUND" }, () => "Hello, void!")
  *         .with(P._, () => "Hello, trouble!"),

--- a/packages/orpc/src/index.spec.ts
+++ b/packages/orpc/src/index.spec.ts
@@ -207,7 +207,7 @@ describe("createResultClient", () => {
       .map((planet) => `Hello, ${planet.name}!`)
       .match({
         ok: (msg) => msg,
-        err: (matcher) => matcher.with(P._, () => "not found"),
+        errCases: (matcher) => matcher.with(P._, () => "not found"),
         defect: () => "bug",
       });
     expect(greeting).toBe("Hello, Mars!");

--- a/packages/orpc/src/server.ts
+++ b/packages/orpc/src/server.ts
@@ -90,7 +90,7 @@ export function handlerResult<
   return async (opts, input) => {
     const result = await handler(opts, input);
     // Branch via the guards rather than `match`: this library code is generic in
-    // the error type `TError`, and `match`'s exhaustive `err` matcher cannot be
+    // the error type `TError`, and `match`'s exhaustive `errCases` matcher cannot be
     // proven exhaustive by ts-pattern over an unresolved type parameter. The
     // concrete triage (`.mapErrCases((matcher) => …)`) still happens at the endpoint.
     if (result.isOk()) return result.value;

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -31,7 +31,7 @@ const users = db.user.tryFindMany({ select: { id: true } });
 
 await db.user.tryCreate({ data }).match({
   ok: (user) => created(user),
-  err: (matcher) =>
+  errCases: (matcher) =>
     matcher
       .with(tag("UniqueConstraintViolation"), (e) => conflict(e.fields))
       .with(P._, (e) => serverError(e)),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,10 +229,6 @@ importers:
         version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/core:
-    dependencies:
-      ts-pattern:
-        specifier: 'catalog:'
-        version: 5.9.0
     devDependencies:
       '@btravstack/tsconfig':
         specifier: 'catalog:'
@@ -246,6 +242,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.10(vitest@4.1.10)
+      ts-pattern:
+        specifier: 'catalog:'
+        version: 5.9.0
       tsdown:
         specifier: 'catalog:'
         version: 0.22.12(oxc-resolver@11.21.3)(tsx@4.23.1)(typescript@6.0.3)


### PR DESCRIPTION
Fixes the five issues surfaced while migrating an 18-package client project onto
`unthrown@5.0.0-beta`. Rebased onto `main` (beta.4) — the `*Cases` combinator
rename is already on `main`, so this PR is now just the five fixes plus a review
follow-up. One commit per issue:

### `fix(core): make ts-pattern a peerDependency` — Closes #143
`ts-pattern` moves from a nested dependency to a **peer** (`^5`), so a consumer
already using ts-pattern shares one copy — two copies' declarations don't unify.
Kept as a `devDependency` for the workspace. New changeset (major).

### `fix(core): explain getOrThrow's never-channel gate` — Closes #144
The `E = never` gate now brands its `never` receiver with a message, so the
diagnostic says *"getOrThrow is unnecessary here … use get() instead"* instead
of an opaque `this`-context error. Behaviour unchanged.

### `refactor(core)!: rename match's err handler to errCases` — Closes #142
`match({ ok, err, defect })` → `match({ ok, errCases, defect })`. This is the one
5.0 break the compiler *almost* missed: a leftover 4.x throwing `err` handler
returned `never`, vacuously satisfied the matcher constraint, compiled, and threw
the matcher object at runtime. The renamed key makes it an excess-property
compile error. Type-d guard added.

### `docs(core): document the generic-E matcher limitation` — Closes #145
ts-pattern can't prove any builder exhaustive (even `P._`) behind an unresolved
generic `E`, so generic boundary helpers must use the `isOk`/`isErr`/`isDefect`
guards. Documented in the exhaustive-error-matching guide, plus a type-d guard.
(Confirmed `getOrThrow()` is also concrete-`E`-only, so guards are the one
generic-boundary tool — see the discussion on the `rawErr` thread.)

### `docs: add a 4.x to 5.0 migration guide` — Closes #146
New how-to upgrade guide (in the sidebar) + root `MIGRATION.md` with the headline
breaking surface, linked from the core README. `@unthrown/pattern` was already
removed from the repo.

### `docs: fix combinator matrix err() cell and defect-channel anchor`
Review follow-up: the `match` row still showed `err()`, and the `recoverErrCases`
tip linked a stale `#recovererr-…` anchor.

**Still needs a manual step (npm credentials):**
```sh
npm deprecate @unthrown/pattern "merged into unthrown@5 — import match/P/tag from 'unthrown'"
```

### Release
On merge, the changesets workflow publishes the next beta (**5.0.0-beta.5** — a
pending major in pre mode). Gate green: `format --check`, `lint`, `typecheck`,
`knip`, `test`, `build`.