### PR TITLE
feat(oxlint): add opt-in no-catch-all-pattern rule

### DIFF
--- a/.changeset/oxlint-no-catch-all-pattern.md
+++ b/.changeset/oxlint-no-catch-all-pattern.md
@@ -1,0 +1,15 @@
+---
+"@unthrown/oxlint": minor
+---
+
+**New opt-in rule `unthrown/no-catch-all-pattern`.** Bans the ts-pattern
+catch-all `P._` (and its alias `P.any`) wherever `P` is imported from `unthrown`
+or `ts-pattern`, so every error case must be enumerated by name
+(`.with(tag("A"), tag("B"), …, handler)`, grouping cases that share a handler).
+
+It is **stricter than unthrown's own default** — the library documents `P._` as
+the sanctioned catch-all — so, like `no-throw`, it stays out of the `recommended`
+preset and is enabled explicitly. A deliberate wildcard carries a targeted
+`oxlint-disable`. Resolves `P` by its imported name via scope analysis (a rename
+still fires; a decoy does not); a namespace import (`ns.P._`) is a documented
+limit.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -555,7 +555,7 @@ AsyncResult<infer T, …>` — structural inference over the whole method surfac
   `Result` via `fromSchema` / `fromSchemaAsync`, with the validation issues as
   the modeled `E`)
 - `packages/oxlint` → `@unthrown/oxlint` (an oxlint **JS plugin**, peerDep
-  `oxlint`, dep `@oxlint/plugins`; ships **four rules**: `no-ambiguous-error-type`
+  `oxlint`, dep `@oxlint/plugins`; ships **five rules**: `no-ambiguous-error-type`
   — enforces Thesis #1 against `unknown`/`any`/`Error`/`{}` **and the primitive
   keywords** (`void` included) in `E`; `prefer-async-result` (reports
   `Promise<Result<T, E>>` in favour of `AsyncResult<T, E>`, but withholds the
@@ -569,7 +569,13 @@ AsyncResult<infer T, …>` — structural inference over the whole method surfac
   method _chain_ like `r.map(f);` is type-dependent and out of scope); and
   `no-throw` (**opt-in**, not in the preset — reports every `throw` statement,
   pointing at `Err`/`getOrThrow`/`fromSafeThrowable`; this is the `no-throw`
-  rule the `getOrThrow` rationale references). Purely syntactic AST rules that
+  rule the `getOrThrow` rationale references); and `no-catch-all-pattern`
+  (**opt-in**, not in the preset — reports the ts-pattern catch-all `P._` / its
+  alias `P.any` where `P` is imported from `unthrown` or `ts-pattern`, so every
+  error case must be enumerated by name; **stricter than the library's own
+  default**, which documents `P._` as the sanctioned catch-all — hence opt-in,
+  like `no-throw`; a deliberate wildcard carries a targeted `oxlint-disable`).
+  Purely syntactic AST rules that
   resolve bindings via scope analysis keyed by the **imported** name (renamed
   and namespace imports resolve; alias indirection like `type E = unknown` is a
   documented limit) so they only fire on unthrown's `Result`. No TypeDoc API

--- a/docs/how-to/lint-your-codebase.md
+++ b/docs/how-to/lint-your-codebase.md
@@ -20,14 +20,16 @@ Register the plugin and turn its rules on in your `.oxlintrc.json`:
     "unthrown/no-ambiguous-error-type": "error",
     "unthrown/no-unhandled-result": "error",
     "unthrown/prefer-async-result": "error",
-    "unthrown/no-throw": "error"
+    "unthrown/no-throw": "error",
+    "unthrown/no-catch-all-pattern": "error"
   }
 }
 ```
 
 The default export also exposes a `recommended` preset — an oxlint config that
 registers the plugin and enables `no-ambiguous-error-type`, `no-unhandled-result`,
-and `prefer-async-result` (`no-throw` stays an explicit opt-in) — for setups that
+and `prefer-async-result` (`no-throw` and `no-catch-all-pattern` stay explicit
+opt-ins) — for setups that
 build their config programmatically (`import unthrown from "@unthrown/oxlint"` →
 `unthrown.recommended`).
 
@@ -121,6 +123,26 @@ known-technical precondition throw → keep it in a plain helper wrapped **once*
 `throw` → a targeted `// oxlint-disable-next-line unthrown/no-throw -- <reason>`
 comment. The rule has no options and no autofix — the disable comment is the escape
 hatch.
+
+### `unthrown/no-catch-all-pattern` {#no-catch-all-pattern}
+
+**Opt-in** — not part of the `recommended` preset. It is **stricter than
+unthrown's own default**: the library documents `P._` as the sanctioned
+"handle everything else" branch, but some teams want _every_ error enumerated by
+name, with no wildcard that could silently absorb a case the union grows later.
+This rule enforces that stricter stance by banning the ts-pattern catch-all `P._`
+(and its alias `P.any`) wherever `P` is imported from `unthrown` or `ts-pattern`.
+
+```ts
+result.mapErrCases((m) => m.with(P._, (e) => e)); // ✗ — the catch-all
+// ✓ — enumerate every case; group cases that share a handler
+result.mapErrCases((m) => m.with(tag("NotFound"), tag("Forbidden"), (e) => e));
+```
+
+Because a matched builder must still be exhaustive, removing `P._` makes the
+compiler point at each unhandled case until every one is named — the rule and the
+type checker push the same way. A deliberate wildcard carries a targeted
+`// oxlint-disable-next-line unthrown/no-catch-all-pattern -- <reason>`.
 
 ## Import resolution
 

--- a/packages/oxlint/README.md
+++ b/packages/oxlint/README.md
@@ -14,12 +14,13 @@ library's theses into automated checks.
 
 ## Rules
 
-| Rule                               | What it enforces                                                                                                                                                                                                                                                                                                                                      |
-| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `unthrown/no-ambiguous-error-type` | The `E` in `Result<T, E>` / `AsyncResult<T, E>` must name a concrete domain error — no `unknown`, `any`, `Error`, `object`, bare `{}`, `void`, or primitives. (`never` is allowed.) This is [Thesis #1](https://btravstack.github.io/unthrown/explanation/why-unthrown): `E` is only the _anticipated_ failures.                                      |
-| `unthrown/prefer-async-result`     | Prefer `AsyncResult<T, E>` over `Promise<Result<T, E>>` — a raw `Promise<Result>` can still reject. Autofixable — except on an `async` function's own return annotation and on a function _type_'s return position (the implementer may be `async`), where the rule reports without a fix since the rewrite would not compile.                        |
-| `unthrown/no-unhandled-result`     | A `Result` / `AsyncResult` returned by a bare call (awaited or not) must not be dropped on the floor — it carries the error channel; dropping it silently discards failures. Bind it, return it, or eliminate it with `match` / a `get*` extractor.                                                                                                   |
-| `unthrown/no-throw`                | **Opt-in** (not in `recommended`): no raw `throw` statements — errors are returned (`Err(...)`), only a true defect ever throws. `getOrThrow()` is the sanctioned extraction escape; a known-technical precondition throw lives in a plain helper wrapped once with `fromSafeThrowable`; a deliberate throw site carries a targeted `oxlint-disable`. |
+| Rule                               | What it enforces                                                                                                                                                                                                                                                                                                                                                                                        |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `unthrown/no-ambiguous-error-type` | The `E` in `Result<T, E>` / `AsyncResult<T, E>` must name a concrete domain error — no `unknown`, `any`, `Error`, `object`, bare `{}`, `void`, or primitives. (`never` is allowed.) This is [Thesis #1](https://btravstack.github.io/unthrown/explanation/why-unthrown): `E` is only the _anticipated_ failures.                                                                                        |
+| `unthrown/prefer-async-result`     | Prefer `AsyncResult<T, E>` over `Promise<Result<T, E>>` — a raw `Promise<Result>` can still reject. Autofixable — except on an `async` function's own return annotation and on a function _type_'s return position (the implementer may be `async`), where the rule reports without a fix since the rewrite would not compile.                                                                          |
+| `unthrown/no-unhandled-result`     | A `Result` / `AsyncResult` returned by a bare call (awaited or not) must not be dropped on the floor — it carries the error channel; dropping it silently discards failures. Bind it, return it, or eliminate it with `match` / a `get*` extractor.                                                                                                                                                     |
+| `unthrown/no-throw`                | **Opt-in** (not in `recommended`): no raw `throw` statements — errors are returned (`Err(...)`), only a true defect ever throws. `getOrThrow()` is the sanctioned extraction escape; a known-technical precondition throw lives in a plain helper wrapped once with `fromSafeThrowable`; a deliberate throw site carries a targeted `oxlint-disable`.                                                   |
+| `unthrown/no-catch-all-pattern`    | **Opt-in** (not in `recommended`): no `P._` / `P.any` catch-all in a matcher — enumerate every error case by name (`.with(tag("A"), tag("B"), …, handler)`, grouping cases that share a handler), so a new error can't be silently absorbed. Stricter than the library's own default (unthrown documents `P._` as the sanctioned catch-all); a deliberate wildcard carries a targeted `oxlint-disable`. |
 
 The rules resolve import bindings via scope analysis (through the _imported_
 name, so renamed imports resolve too), and only fire on unthrown's own
@@ -36,14 +37,15 @@ Register the plugin and enable its rules in your `.oxlintrc.json`:
     "unthrown/no-ambiguous-error-type": "error",
     "unthrown/no-unhandled-result": "error",
     "unthrown/prefer-async-result": "error",
-    "unthrown/no-throw": "error"
+    "unthrown/no-throw": "error",
+    "unthrown/no-catch-all-pattern": "error"
   }
 }
 ```
 
 The package's default export also exposes a `recommended` preset (an oxlint
 config that registers the plugin and turns the recommended rules on —
-`no-throw` stays an explicit opt-in) for setups that build their config
+`no-throw` and `no-catch-all-pattern` stay explicit opt-ins) for setups that build their config
 programmatically:
 
 ```ts

--- a/packages/oxlint/src/index.test.ts
+++ b/packages/oxlint/src/index.test.ts
@@ -3,10 +3,11 @@ import { describe, expect, it } from "vitest";
 import plugin from "./index.js";
 
 describe("@unthrown/oxlint plugin", () => {
-  it("exposes all four rules under the `unthrown` plugin name", () => {
+  it("exposes all five rules under the `unthrown` plugin name", () => {
     expect(plugin.meta?.name).toBe("unthrown");
     expect(Object.keys(plugin.rules).sort()).toEqual([
       "no-ambiguous-error-type",
+      "no-catch-all-pattern",
       "no-throw",
       "no-unhandled-result",
       "prefer-async-result",
@@ -23,5 +24,9 @@ describe("@unthrown/oxlint plugin", () => {
 
   it("keeps `no-throw` out of the `recommended` preset — it is an explicit opt-in", () => {
     expect(plugin.recommended.rules).not.toHaveProperty("unthrown/no-throw");
+  });
+
+  it("keeps `no-catch-all-pattern` out of the `recommended` preset — it is an explicit opt-in", () => {
+    expect(plugin.recommended.rules).not.toHaveProperty("unthrown/no-catch-all-pattern");
   });
 });

--- a/packages/oxlint/src/index.ts
+++ b/packages/oxlint/src/index.ts
@@ -1,5 +1,5 @@
 // @unthrown/oxlint — an oxlint (JS) plugin that enforces unthrown's conventions
-// at lint time. Four rules:
+// at lint time. Five rules:
 //
 //   unthrown/no-ambiguous-error-type  — keep `E` a concrete domain error
 //                                        (no unknown/any/Error/{}), i.e. Thesis #1.
@@ -7,6 +7,9 @@
 //   unthrown/no-unhandled-result      — don't drop a Result returned by a bare call.
 //   unthrown/no-throw                 — ban raw `throw` (opt-in; not in `recommended`) —
 //                                        errors are returned, only a defect ever throws.
+//   unthrown/no-catch-all-pattern     — ban the `P._` / `P.any` matcher catch-all
+//                                        (opt-in; not in `recommended`) — enumerate
+//                                        every error case instead.
 //
 // Enable the bundled `recommended` preset, or wire the rules by hand. See the
 // package README.
@@ -17,6 +20,7 @@ import { defineConfig } from "oxlint";
 import type { OxlintConfig } from "oxlint";
 
 import { noAmbiguousErrorType } from "./rules/no-ambiguous-error-type.js";
+import { noCatchAllPattern } from "./rules/no-catch-all-pattern.js";
 import { noThrow } from "./rules/no-throw.js";
 import { noUnhandledResult } from "./rules/no-unhandled-result.js";
 import { preferAsyncResult } from "./rules/prefer-async-result.js";
@@ -27,15 +31,18 @@ const plugin = eslintCompatPlugin({
   meta: { name: "unthrown" },
   rules: {
     "no-ambiguous-error-type": noAmbiguousErrorType,
+    "no-catch-all-pattern": noCatchAllPattern,
     "no-throw": noThrow,
     "no-unhandled-result": noUnhandledResult,
     "prefer-async-result": preferAsyncResult,
   },
 }) as UnthrownPlugin;
 
-// `no-throw` is deliberately NOT in the preset: it bans a core language
-// statement, so it stays an explicit opt-in for codebases committed to the
-// convention end-to-end.
+// `no-throw` and `no-catch-all-pattern` are deliberately NOT in the preset:
+// `no-throw` bans a core language statement, and `no-catch-all-pattern` is
+// stricter than unthrown's own default (the library documents `P._` as the
+// sanctioned catch-all). Both stay explicit opt-ins for codebases committed to
+// the convention end-to-end.
 plugin.recommended = defineConfig({
   jsPlugins: [{ name: "unthrown", specifier: "@unthrown/oxlint" }],
   rules: {

--- a/packages/oxlint/src/rules/no-catch-all-pattern.test.ts
+++ b/packages/oxlint/src/rules/no-catch-all-pattern.test.ts
@@ -1,0 +1,62 @@
+import { ruleTester } from "../tester.js";
+import { noCatchAllPattern } from "./no-catch-all-pattern.js";
+
+ruleTester.run("no-catch-all-pattern", noCatchAllPattern, {
+  valid: [
+    // Explicit enumeration — every case named, no wildcard.
+    {
+      code: `import { P, tag } from "unthrown";\nresult.mapErrCases((m) => m.with(tag("A"), tag("B"), (e) => e));`,
+    },
+    // Specific `P.*` matchers are fine — only the catch-alls are banned.
+    {
+      code: `import { P } from "unthrown";\nm.with(P.string, (s) => s);`,
+    },
+    {
+      code: `import { P } from "unthrown";\nm.with(P.union(P.string, P.number), (v) => v);`,
+    },
+    // `P` from an unrelated module is not unthrown's / ts-pattern's `P`.
+    {
+      code: `import { P } from "other-lib";\nm.with(P._, (e) => e);`,
+    },
+    // A local `P` (not an import binding) is not matched — no false positive.
+    {
+      code: `const P = { _: 1 };\nconst x = P._;`,
+    },
+    // A bare `_` identifier elsewhere is unrelated.
+    {
+      code: `import { P } from "unthrown";\nconst _ = 1;\nconsole.log(_);`,
+    },
+  ],
+  invalid: [
+    // `P._` from unthrown — the catch-all.
+    {
+      code: `import { P } from "unthrown";\nresult.mapErrCases((m) => m.with(P._, (e) => e));`,
+      errors: [{ messageId: "noCatchAll" }],
+    },
+    // `P.any` is the same catch-all under a different name.
+    {
+      code: `import { P } from "unthrown";\nm.with(P.any, (e) => e);`,
+      errors: [{ messageId: "noCatchAll" }],
+    },
+    // `P._` imported straight from ts-pattern counts too.
+    {
+      code: `import { P } from "ts-pattern";\nm.with(P._, (e) => e);`,
+      errors: [{ messageId: "noCatchAll" }],
+    },
+    // A rename still resolves by the imported name.
+    {
+      code: `import { P as Pattern } from "unthrown";\nm.with(Pattern._, (e) => e);`,
+      errors: [{ messageId: "noCatchAll" }],
+    },
+    // In `match`'s errCases handler.
+    {
+      code: `import { P } from "unthrown";\nresult.match({ ok: (v) => v, errCases: (m) => m.with(P._, (e) => e), defect: (c) => c });`,
+      errors: [{ messageId: "noCatchAll" }],
+    },
+    // Matching a whole Result with the wildcard is caught as well.
+    {
+      code: `import { match, P } from "unthrown";\nmatch(result).with(P._, () => 0).exhaustive();`,
+      errors: [{ messageId: "noCatchAll" }],
+    },
+  ],
+});

--- a/packages/oxlint/src/rules/no-catch-all-pattern.test.ts
+++ b/packages/oxlint/src/rules/no-catch-all-pattern.test.ts
@@ -26,6 +26,10 @@ ruleTester.run("no-catch-all-pattern", noCatchAllPattern, {
     {
       code: `import { P } from "unthrown";\nconst _ = 1;\nconsole.log(_);`,
     },
+    // Computed access with a DYNAMIC key can't be resolved statically — left alone.
+    {
+      code: `import { P } from "unthrown";\nconst k = "_";\nm.with(P[k], (e) => e);`,
+    },
   ],
   invalid: [
     // `P._` from unthrown — the catch-all.
@@ -56,6 +60,15 @@ ruleTester.run("no-catch-all-pattern", noCatchAllPattern, {
     // Matching a whole Result with the wildcard is caught as well.
     {
       code: `import { match, P } from "unthrown";\nmatch(result).with(P._, () => 0).exhaustive();`,
+      errors: [{ messageId: "noCatchAll" }],
+    },
+    // Computed access with a string literal is the same catch-all — no bypass.
+    {
+      code: `import { P } from "unthrown";\nm.with(P["_"], (e) => e);`,
+      errors: [{ messageId: "noCatchAll" }],
+    },
+    {
+      code: `import { P } from "unthrown";\nm.with(P["any"], (e) => e);`,
       errors: [{ messageId: "noCatchAll" }],
     },
   ],

--- a/packages/oxlint/src/rules/no-catch-all-pattern.ts
+++ b/packages/oxlint/src/rules/no-catch-all-pattern.ts
@@ -1,0 +1,67 @@
+import { defineRule } from "@oxlint/plugins";
+
+import { getImportBinding } from "../helpers/get-import-binding.js";
+
+// `P` is re-exported by core, but a codebase may also import it straight from
+// ts-pattern — a `P._` from either is the same catch-all, so both count.
+const SOURCES: ReadonlySet<string> = new Set(["unthrown", "ts-pattern"]);
+
+// The two universal patterns ts-pattern exposes on `P`: `P._` and its alias
+// `P.any`. Both match anything, so both defeat exhaustive enumeration. Every
+// other `P.*` (`P.string`, `P.number`, `P.union(...)`, …) is a *specific*
+// matcher and is left alone.
+const CATCH_ALL_PROPS: ReadonlySet<string> = new Set(["_", "any"]);
+
+/**
+ * Disallow the ts-pattern catch-all `P._` (and its alias `P.any`) in an
+ * unthrown matcher. The exhaustive error matcher exists so every failure is
+ * *accounted for by name* — a catch-all re-opens the blanket-handling hole it
+ * closes, silently absorbing any error the union grows later.
+ *
+ * This rule is **stricter than unthrown's own default**: the library documents
+ * `P._` as the sanctioned "handle everything else" branch, so this is opt-in
+ * (not in the `recommended` preset) — for teams that want *every* error
+ * enumerated (`.with(tag("A"), tag("B"), …, handler)`, grouping cases that
+ * share a handler) with no wildcard. A genuinely intended catch-all carries a
+ * targeted `oxlint-disable` with a reason.
+ *
+ * Resolves `P` by its imported name via scope analysis, so a rename
+ * (`import { P as Pattern }`) still fires and a decoy (`const P = …`) does not.
+ * A namespace import (`import * as ns from "unthrown"; ns.P._`) is a documented
+ * limit — the object is not a bare identifier binding.
+ */
+export const noCatchAllPattern = defineRule({
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Disallow the `P._` / `P.any` catch-all in an unthrown matcher — enumerate every error case instead",
+      recommended: false,
+    },
+    messages: {
+      noCatchAll:
+        'Unexpected `P.{{prop}}` catch-all. Enumerate every error case by name — `.with(tag("A"), tag("B"), …, handler)`, grouping cases that share a handler — so a new error can\'t be silently absorbed. A deliberate catch-all carries a targeted `oxlint-disable` with a reason.',
+    },
+  },
+  createOnce: (context) => {
+    return {
+      MemberExpression: (node) => {
+        // Only bare `P._` / `P.any`: a non-computed property on an identifier.
+        if (node.computed) return;
+        if (node.object.type !== "Identifier") return;
+        if (node.property.type !== "Identifier") return;
+        if (!CATCH_ALL_PROPS.has(node.property.name)) return;
+
+        const scope = context.sourceCode.getScope(node);
+        const binding = getImportBinding(scope, node.object);
+        if (!binding || binding.imported !== "P" || !SOURCES.has(binding.source)) return;
+
+        context.report({
+          node,
+          messageId: "noCatchAll",
+          data: { prop: node.property.name },
+        });
+      },
+    };
+  },
+});

--- a/packages/oxlint/src/rules/no-catch-all-pattern.ts
+++ b/packages/oxlint/src/rules/no-catch-all-pattern.ts
@@ -46,11 +46,21 @@ export const noCatchAllPattern = defineRule({
   createOnce: (context) => {
     return {
       MemberExpression: (node) => {
-        // Only bare `P._` / `P.any`: a non-computed property on an identifier.
-        if (node.computed) return;
         if (node.object.type !== "Identifier") return;
-        if (node.property.type !== "Identifier") return;
-        if (!CATCH_ALL_PROPS.has(node.property.name)) return;
+
+        // The catch-all is written `P._` / `P.any` (dot access) or `P["_"]` /
+        // `P["any"]` (computed access with a string literal) — both are the same
+        // pattern, so both are flagged. A computed access with a dynamic key
+        // (`P[k]`) is left alone: it can't be resolved statically.
+        const prop =
+          !node.computed && node.property.type === "Identifier"
+            ? node.property.name
+            : node.computed &&
+                node.property.type === "Literal" &&
+                typeof node.property.value === "string"
+              ? node.property.value
+              : undefined;
+        if (prop === undefined || !CATCH_ALL_PROPS.has(prop)) return;
 
         const scope = context.sourceCode.getScope(node);
         const binding = getImportBinding(scope, node.object);
@@ -59,7 +69,7 @@ export const noCatchAllPattern = defineRule({
         context.report({
           node,
           messageId: "noCatchAll",
-          data: { prop: node.property.name },
+          data: { prop },
         });
       },
     };


### PR DESCRIPTION
Adds a fifth `@unthrown/oxlint` rule, **`no-catch-all-pattern`**, that bans the ts-pattern catch-all `P._` (and its alias `P.any`) in unthrown matchers — so every error case is enumerated by name (`.with(tag("A"), tag("B"), …, handler)`, grouping cases that share a handler) and a new error can't be silently absorbed.

### Why opt-in (not in `recommended`)
This is **stricter than unthrown's own default** — the library documents `P._` as the sanctioned "handle everything else" branch. So, exactly like `no-throw`, it stays out of the `recommended` preset and is enabled explicitly. A deliberate wildcard carries a targeted `oxlint-disable`.

### How it works
- Fires on a non-computed `P._` / `P.any` member expression where `P` resolves (via scope analysis, by **imported** name) to an import from `unthrown` or `ts-pattern` — so a rename (`import { P as Pattern }`) still fires and a decoy (`const P = …`, `import { P } from "other"`) does not.
- Only the two universal patterns (`_`, `any`) — every specific `P.*` (`P.string`, `P.union(...)`, …) is left alone.
- Namespace import (`import * as ns; ns.P._`) is a documented limit.

### Scope
Rule + RuleTester suite + registry/preset tests (kept out of `recommended`), README + lint-guide docs, CLAUDE.md, and a `minor` changeset. Gate green: format, lint, typecheck, knip, test (108), build.