### PR TITLE
feat!: built-in exhaustive matcher — drop the ts-pattern peer

### DIFF
--- a/.changeset/built-in-matcher.md
+++ b/.changeset/built-in-matcher.md
@@ -1,0 +1,39 @@
+---
+"unthrown": major
+---
+
+**The exhaustive matcher is now built-in — the `ts-pattern` peer dependency is
+removed.** `match`, `P`, and the new `NonExhaustiveError` are unthrown's own
+(`Matcher` / `PatternMatcher` / `UniversalPattern` types included), keeping the
+exact call-site shape: `.with(pattern, …patterns, handler)`, `tag(t)`, grouped
+patterns, and `P._` / `P.any` / `P.instanceOf` / `P.when` / `P.union` /
+`P.string` / `P.number`. Most code needs **no changes** beyond deleting
+`ts-pattern` from your dependencies (if you only added it for unthrown).
+
+Why: exhaustiveness is unthrown's central promise, and delegating it to a peer
+meant the guarantee could vary with whichever ts-pattern version a consumer
+resolved (ts-pattern changed exhaustiveness semantics in a minor, 5.8). The
+built-in matcher computes exhaustiveness with plain `Exclude` over a tracked
+`Remaining` parameter — shallow, fast, stable — and gives readable diagnostics
+(a non-exhaustive builder's `.exhaustive` is a branded object naming the
+unhandled cases).
+
+**Fixes #145:** the catch-all arm is a state transition to `Remaining = never`
+(not a deferred `Exclude`), so `.with(P._, …)` is provably exhaustive even when
+the error type is an **unresolved generic** — a boundary helper generic in `E`
+can now use `match` / the `…Cases` combinators. Tag arms alone remain correctly
+unprovable over a generic `E`.
+
+Breaking edges:
+
+- Patterns built by the real `ts-pattern` library are no longer accepted by
+  unthrown's matchers (and unthrown's `P` is not ts-pattern's). Import `match`
+  / `P` / `tag` from `"unthrown"` at unthrown call sites; keep `ts-pattern`
+  for unrelated matching if your own code uses it.
+- Deliberately unsupported patterns: deep structural inversion, `P.select`,
+  array patterns, and the other ts-pattern-only `P.*` members. The supported
+  vocabulary is the error channel's: literals, (nested) object discriminants
+  (`{ _tag }` / `{ code }`), `instanceOf`, guards, unions, primitive
+  wildcards, and the catch-all.
+- A rogue unmatched value now throws unthrown's own `NonExhaustiveError`
+  (exported from core), not ts-pattern's.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,15 +64,15 @@ was planned).
    string.
 5. **The error channel is matched exhaustively, never blanket-handled.** The
    error combinators (`mapErrCases`, `flatMapErrCases`, `recoverErrCases`, `tapErrCases`,
-   `flatTapErrCases`) do not take a single callback: their callback receives a
-   **ts-pattern match builder** over the error (`match(error)`, typed
+   `flatTapErrCases`) do not take a single callback: their callback receives the
+   **built-in match builder** over the error (`match(error)`, typed
    `ErrMatcher<E>`) plus the injected `defect` helper, and **returns the
    un-terminated builder** — the combinator calls `.exhaustive()` itself. So a
    match that misses a case **does not compile** (there is no `.exhaustive()`
    to forget, and no `.otherwise()` to smuggle in a fallback), and enriching
    `E` — a new tag, a new `code` — is a compile error at _every_ consuming
    site until each is handled. This is the payoff of errors-as-values: the
-   values cannot be silently dropped. ts-pattern matches by structure, so this
+   values cannot be silently dropped. The matcher matches by structure, so this
    works on any discriminant (`_tag`, `code`, guards, grouped patterns), not
    only `TaggedError`. `P._` is the deliberate catch-all (the uniform "handle
    everything else" branch, replacing the old single callback). Each branch
@@ -106,10 +106,15 @@ was planned).
    `matchTags` fold — per-tag folding at the edge is now `match` with the
    matcher and `tag(t)`, and it works on any discriminant, not only `_tag`.) The
    value-surrendering extractors (`getOr` / `getOrElse` / `getOrNull` /
-   `getOrUndefined`) stay exempt — the value is being surrendered anyway. **Core
-   depends on `ts-pattern`** (a light, types-heavy, dual-copy-safe library —
-   its matcher protocol keys off a global `Symbol.for`), re-exporting `match`
-   and `P` so the matcher is first-class in one import.
+   `getOrUndefined`) stay exempt — the value is being surrendered anyway. **The
+   matcher is built-in** (`matcher.ts` — it replaced the former `ts-pattern`
+   peer, keeping its call-site shape): a purpose-built, shallow matcher whose
+   exhaustiveness is plain `Exclude` over a tracked `Remaining` parameter, with
+   `match`, `P` (`_`/`any`, `instanceOf`, `when`, `union`, `string`, `number`),
+   and `NonExhaustiveError` exported from core — first-class in one import,
+   dual-copy-safe (patterns carry a `Symbol.for` brand). Deliberately **not**
+   supported: deep structural inversion, `P.select`, array patterns — the
+   complexity (and cross-version instability) the replacement removed.
 
 ## Load-bearing runtime invariants (tests must guard these)
 
@@ -130,21 +135,22 @@ was planned).
   does the same with a non-`Result` callback return, instead of letting a
   poison value throw a raw `TypeError` further down the pipeline.
 - **A non-exhaustive error match becomes a `Defect` (in the combinators).** In
-  the error combinators, the callback returns a ts-pattern builder and the
+  the error combinators, the callback returns the match builder and the
   combinator runs `.run()` (which executes `.exhaustive()`). For well-typed
   callers the match is exhaustive by construction; a value that slips past the
-  types (a widened cast, a JS caller) with no matching case throws ts-pattern's
-  `NonExhaustiveError`, which the throw-to-defect net turns into a `Defect` — an
-  unmodeled failure. In **`match`** (an edge eliminator, exempt from
+  types (a widened cast, a JS caller) with no matching case throws the matcher's
+  `NonExhaustiveError` (exported from core), which the throw-to-defect net turns
+  into a `Defect` — an unmodeled failure. In **`match`** (an edge eliminator, exempt from
   throw→defect) the same non-exhaustive rogue value instead **throws**
   `NonExhaustiveError` outright — a genuinely unmodeled tag at the edge is a
   bug, not a routed value.
 - **Exhaustiveness is type-enforced, with no forgettable step.** `mapErrCases` /
   `flatMapErrCases` / `recoverErrCases` / `tapErrCases` / `flatTapErrCases` require the callback to
-  return an `ExhaustiveMatch` — `.exhaustive` is typed callable only when
-  ts-pattern has narrowed the input to `never` (all cases covered); a
-  non-exhaustive builder types `.exhaustive` as `NonExhaustiveError` and fails
-  the constraint at the call site. For code that builds the match through the
+  return an `ExhaustiveMatch` — `.exhaustive` is typed callable only when the
+  builder's tracked `Remaining` parameter has been excluded down to `never`
+  (all cases covered); a non-exhaustive builder types `.exhaustive` as the
+  branded `NonExhaustive<Remaining>` diagnostic (naming the unhandled cases)
+  and fails the constraint at the call site. For code that builds the match through the
   provided matcher there is no path where a case slips past an error combinator
   uncovered without a compile error, and no `.exhaustive()` / `.otherwise()`
   for a caller to reach (the combinator owns termination). One honest caveat:
@@ -189,15 +195,19 @@ was planned).
   combinators can't be swapped out from under every instance), `AsyncRes`'s
   wrapped promise is a native `#private` field, and the qualify-time `defect`
   marker is frozen.
-- **`match`'s `errCases` matcher is type-forced exhaustive, and library code generic
-  in `E` uses the guards instead.** For well-typed concrete callers a missing
-  branch does not compile; a rogue value slipping past the types throws
-  `NonExhaustiveError` (see above). Because ts-pattern cannot prove `.with(P._,
-…)` exhaustive over an **unresolved type parameter**, code that folds a
-  generic `Result<T, E>` (the interop `to*` bridges, `@unthrown/orpc`'s
-  `handlerResult`) branches via the `isOk` / `isErr` / `isDefect` guards rather
-  than `match` — the guards narrow to `OkView` / `ErrView` / `DefectView` with
-  no exhaustiveness obligation. Concrete application code uses `match` normally.
+- **`match`'s `errCases` matcher is type-forced exhaustive — and the catch-all
+  is provably exhaustive even over a generic `E`.** For well-typed concrete
+  callers a missing branch does not compile; a rogue value slipping past the
+  types throws `NonExhaustiveError` (see above). The catch-all `.with(P._, …)`
+  arm is a **state transition** (an overload keyed on the statically-universal
+  `UniversalPattern` type returning `Matcher<E, never, …>` — literal `never`,
+  no deferred `Exclude`), so a catch-all-terminated builder compiles inside
+  code **generic in `E`** — the fix for #145; tag/pattern arms alone remain
+  correctly unprovable over an unresolved type parameter. Library code that
+  folds a generic `Result<T, E>` per-channel (the interop `to*` bridges,
+  `@unthrown/orpc`'s `handlerResult`) still uses the `isOk` / `isErr` /
+  `isDefect` guards — the simplest shape when no per-case branching is needed.
+  Concrete application code uses `match` normally.
 - **`get()` / `getErr()` are type-gated.** `get()` compiles only when the
   error channel is empty (`this: Result<T, never>`); `getErr()` only when the
   success channel is empty (`this: Result<never, E>`). Eliminate the opposite
@@ -220,8 +230,8 @@ was planned).
 
 `Result<T, E>` is a **discriminated union** — `{ tag: "Ok"; value } | { tag:
 "Err"; error } | { tag: "Defect"; cause }`, each intersected with the shared
-method surface — so it matches **natively** (a `switch` on `tag`, or
-`ts-pattern`'s `match(r).with({ tag: "Ok" }, …).exhaustive()`) **and** chains
+method surface — so it matches **natively** (a `switch` on `tag`, or the
+built-in `match(r).with({ tag: "Ok" }, …).exhaustive()`) **and** chains
 fluently. The payload is reachable only after narrowing, so "check before you
 access" still holds.
 
@@ -249,7 +259,7 @@ async work re-enters via `fromPromise` / `fromSafePromise` and composes with
   `AsyncResult`. A throw in either becomes a `Defect`; `Err`/`Defect`
   short-circuits/passes through. To go async, lift with `toAsync()`.
 - error: `mapErrCases`, `flatMapErrCases`, `recoverErrCases`, `tapErrCases`, `flatTapErrCases` all take
-  the Thesis-#5 **ts-pattern matcher callback** `(m: ErrMatcher<E>, defect) => M`
+  the Thesis-#5 **matcher callback** `(m: ErrMatcher<E>, defect) => M`
   where `M extends ExhaustiveMatch<…>` (the callback returns the un-terminated
   builder; the combinator runs `.run()`). Outgoing types are computed from the
   builder output `MatchOut<M>` — mapErrCases: `MatchErrOut<M>` (= `Exclude<MatchOut,
@@ -272,7 +282,7 @@ Defect>`); flatMapErrCases: `OkOf`/`ErrOf` — plus `AsyncOkOf`/`AsyncErrOf` on 
   good is `match`), and no channel-moving operators (`Err`→`Defect` erases the
   modeled type; `Defect`→`Err` would put `unknown` in `E`, violating Thesis #1)
 - eliminate: `match` (the `{ ok, defect }` handlers plus an `errCases` handler that
-  takes the **exhaustive ts-pattern matcher** `(matcher) => matcher.with(…)` —
+  takes the **exhaustive matcher** `(matcher) => matcher.with(…)` —
   same as the error combinators, but with no `defect` helper since `match` folds
   to a value; the folded type unions all branch returns), `get`/`getErr`
   (type-gated — `get` only compiles on
@@ -300,11 +310,13 @@ Defect>`); flatMapErrCases: `OkOf`/`ErrOf` — plus `AsyncOkOf`/`AsyncErrOf` on 
   (they were runtime-identical delegates); the error-channel aliases
   `orElse`/`recover` were removed earlier in the same major. One concept, one
   name — no deprecated surface survives into v5.
-- ts-pattern re-exports: `match` and `P` are re-exported from `ts-pattern` (core
-  depends on it), and `tag(t)` (the `{ _tag: t }` pattern, narrowing to the
-  variant + payload) lives in `tagged.ts`. These make the error matcher, and
-  matching a whole `Result` (`match(r).with(P.…)`), first-class in one import —
-  the former `@unthrown/pattern` package, now folded in.
+- matcher exports: `match`, `P`, and `NonExhaustiveError` come from the
+  built-in `matcher.ts` (plus the types `Matcher`/`PatternMatcher`/
+  `UniversalPattern`), and `tag(t)` (the `{ _tag: t }` pattern, narrowing to
+  the variant + payload) lives in `tagged.ts`. These make the error matcher,
+  and matching a whole `Result` (`match(r).with({ tag: "Ok" }, …)`),
+  first-class in one import — the former `@unthrown/pattern` package and the
+  former `ts-pattern` re-exports, now one owned module.
 - guards: methods `isOk`/`isErr`/`isDefect` **and** standalone
   `isOk`/`isErr`/`isDefect` both narrow (to `OkView`/`ErrView`/`DefectView`) — the
   methods are `this is …` type predicates, so `if (r.isErr()) r.error` compiles.
@@ -318,16 +330,18 @@ Defect>`); flatMapErrCases: `OkOf`/`ErrOf` — plus `AsyncOkOf`/`AsyncErrOf` on 
   combinator callback that returns one is a compile error instead of a silently
   unqualified rejection. `FailureView<E, T>` — the exported `ErrView | DefectView`
   union a `tapFailure` callback receives (error-type-first, like `ErrView`).
-  `ErrMatcher<E>` — the ts-pattern builder over the error (`ReturnType<typeof
-match<E>>`, so ts-pattern's non-exported `Match` type is never imported).
+  `ErrMatcher<E>` — the built-in match builder over the error
+  (`ReturnType<typeof match<E>>`, i.e. `Matcher<E, E, never>`).
   The supporting `ExhaustiveMatch`/`MatchOut`/`MatchErrOut` are exported for the
   d.ts but not re-exported from `index.ts`. `ExhaustiveMatch<O>` requires
-  `.exhaustive` to be _callable_ (ts-pattern types it as `NonExhaustiveError` on
-  a non-exhaustive builder) and carries the output via `run: () => O`, from which
-  `MatchOut`/`MatchErrOut` extract. Note `ErrMatcher<E>` must appear only as a
-  callback **parameter** type (contravariant), never combined with the class `E`
-  in a covariant return — ts-pattern's `Match` is invariant in its input, which
-  would poison `E` inference (why `flatTapErrCases` infers a plain `E2` instead).
+  `.exhaustive` to be _callable_ (the builder types it as the branded
+  `NonExhaustive<Remaining>` diagnostic while cases remain) and carries the
+  output via `run: () => O`, from which `MatchOut`/`MatchErrOut` extract. Note
+  `ErrMatcher<E>` should still appear only as a callback **parameter** type,
+  never combined with the class `E` in a covariant return — the historical
+  ts-pattern `Match` invariance forced that rule (and `flatTapErrCases`'s plain
+  `E2` inference); the built-in `Matcher` is kinder but the discipline is kept,
+  guarded by the `combine` inference regression test.
 - constructors: `Ok` (a no-arg overload — `Ok()` — constructs a `void` success,
   `Result<void, never>`, sparing `Ok(undefined)`; `OkAsync()` mirrors it),
   `Err` (there is **no** `Defect` constructor — a defect-state
@@ -403,7 +417,7 @@ match<E>>`, so ts-pattern's non-exported `Match` type is never imported).
   name; the payload reserves `name`, `message`, **and** `stack` via `?: never`
   (`cause` stays allowed — see Thesis #4), so the
   message is set per subclass with `override message = "…"`, never as a payload
-  field) and `tag(t)` (the `{ _tag: t }` ts-pattern pattern, for use in the
+  field) and `tag(t)` (the `{ _tag: t }` matcher pattern, for use in the
   error matchers, in `match`'s `errCases` handler, and in `match(result)`); see the
   `TaggedError` convention in Thesis #4. **There is no `matchTags`** — a per-tag
   exhaustive fold over a tagged error union is `result.match({ ok, defect, errCases:
@@ -455,7 +469,7 @@ library can be "done".
   neverthrow's class surface widens without annotations); the exhaustive matcher
   is what made declared variance mandatory. TS **verifies** every annotation
   (TS2636 if unprovable); `Result` (a union of the annotated views) inherits the
-  fast path. **`ErrMatcher<E>` (ts-pattern's `Match`,
+  fast path. **`ErrMatcher<E>` (the built-in `Matcher`,
   invariant in its input) must stay in a callback parameter position only**: it
   is contravariant there and harmless, but unioning an `M`-derived output with
   the class `E` in a covariant return re-invaded `E`'s variance and collapsed
@@ -533,18 +547,17 @@ AsyncResult<infer T, …>` — structural inference over the whole method surfac
   `constructors.ts` (`Ok`/`Err` + guards), `do.ts` (the `Do()` do-notation entry
   — the `bind`/`let` steps themselves live on the method surface in `core.ts`),
   `interop.ts` (`from*`/`qualify`/`all`), `facade.ts` (the `Result` object),
-  `tagged.ts` (`TaggedError`/`tag`), and `index.ts` (the curated
-  public re-exports, including `match`/`P` from `ts-pattern` — the one place the
-  API is decided).
+  `tagged.ts` (`TaggedError`/`tag`), `matcher.ts` (the built-in matcher —
+  `match`/`P`/`NonExhaustiveError` + the `Matcher` types), and `index.ts` (the
+  curated public re-exports — the one place the API is decided).
 
 ## Monorepo layout
 
-- `packages/core` → `unthrown` (one runtime peer dependency: `ts-pattern`
-  `^5`, which powers the exhaustive error matchers and is re-exported as
-  `match`/`P`. A **peer**, not a plain dependency, so a consumer that already
-  uses ts-pattern shares one copy — two copies' declarations don't unify, and
-  mixing them is a type error. Kept as a `devDependency` (catalog) for the
-  workspace's own build/test.)
+- `packages/core` → `unthrown` (**zero runtime dependencies** — the exhaustive
+  error matcher is built-in (`matcher.ts`, exported as `match`/`P`/
+  `NonExhaustiveError`); it replaced the former `ts-pattern` peer so the
+  exhaustiveness guarantee can never vary with a consumer-resolved third-party
+  version, and nothing needs installing alongside `unthrown`)
 - `packages/vitest` → `@unthrown/vitest` (peerDep `vitest`)
 - `packages/effect` → `@unthrown/effect` (peerDep `effect`)
 - `packages/neverthrow` → `@unthrown/neverthrow` (peerDep `neverthrow`)
@@ -648,9 +661,9 @@ code: "NOT_FOUND" }, …))`); non-inferable →
   `.github/scripts/inject-docs-version-nav.ts`). With no prerelease, main
   deploys alone to the root as before
 
-Core takes `ts-pattern` as a **peer** dependency (it powers the error matchers).
-Never pull `vitest` or any interop peer (`effect`, `neverthrow`,
-`@bloodyowl/boxed`, `@orpc/*`) into core.
+Core has **no runtime dependencies** (the error matcher is built-in). Never
+pull `vitest` or any interop peer (`effect`, `neverthrow`, `@bloodyowl/boxed`,
+`@orpc/*`) into core.
 
 Every satellite package depends on core via `workspace:^` (an exact pin would
 create a dual-copy hazard with the `instanceof`-based `isResult`); for the same
@@ -689,8 +702,8 @@ channel?**
 2. ✅ **`packages/core/src/tagged.ts`** — Done. `TaggedError(tag)` factory
    (extends `Error`, `_tag`, no-arg constructor when payload is empty via the
    `keyof A extends never ? void : A` trick) and `tag(t)` (the `{ _tag: t }`
-   ts-pattern pattern). A per-tag exhaustive fold is `match`'s `errCases` handler
-   with the ts-pattern matcher (`matcher.with(tag("…"), …)`), not a dedicated
+   matcher pattern). A per-tag exhaustive fold is `match`'s `errCases` handler
+   with the matcher (`matcher.with(tag("…"), …)`), not a dedicated
    `matchTags` — that former helper was folded into `match` when the matcher
    became the error-channel convention.
 3. ✅ **`packages/vitest`** — Done. Custom matchers `toBeOk`, `toBeOkWith`,
@@ -706,12 +719,15 @@ channel?**
    (`failOnForgottenAwait`) fails the test at its end, naming the pending
    matchers — the abandoned assertion is reported exactly once, correctly
    attributed, and can never late-fire as an unhandled rejection.
-4. ✅ **ts-pattern integration** — Done. `ts-pattern` is a core dependency: it
-   powers the exhaustive error matchers (Thesis #5) and is re-exported as
-   `match`/`P`, plus `tag(t)` (the `{ _tag: t }` pattern). Because `Result` is a
-   discriminated union (Thesis #1), `match(result).with(P.…)` also matches a
-   whole `Result` natively. (The former standalone `@unthrown/pattern` package
-   was folded into core when the dependency was taken.)
+4. ✅ **The built-in matcher** — Done. `matcher.ts` powers the exhaustive error
+   matchers (Thesis #5), exporting `match`/`P`/`NonExhaustiveError`, plus
+   `tag(t)` (the `{ _tag: t }` pattern). Because `Result` is a discriminated
+   union (Thesis #1), `match(result).with({ tag: "Ok" }, …)` also matches a
+   whole `Result` natively. (History: the standalone `@unthrown/pattern`
+   package was folded into core when a `ts-pattern` dependency was taken in
+   early v5; the built-in matcher then replaced that dependency entirely —
+   same call-site shape, owned type machinery, catch-all provable over a
+   generic `E` (#145), zero runtime deps.)
 
 Also shipped: a root `README` + `LICENSE`, per-package READMEs, and the VitePress
 docs site (guide + generated API reference). Both the npm packages and the
@@ -755,7 +771,7 @@ configured outside the repo).
 - One concept = one name. Resist convenience aliases.
 - **The error-matcher combinators carry a `*Cases` suffix** (`mapErrCases`,
   `flatMapErrCases`, `recoverErrCases`, `tapErrCases`, `flatTapErrCases`) —
-  **not** the bare `mapErr`/`tapErr`. The callback receives a ts-pattern matcher
+  **not** the bare `mapErr`/`tapErr`. The callback receives a matcher
   over the error's _cases_, not the value, so the suffix names the protocol and
   keeps it distinct from the value-taking success surface (`map`/`tap`). This
   reverses the earlier plan to keep the bare `map*`/`tap*` names (weighed and
@@ -764,9 +780,9 @@ configured outside the repo).
   that would reopen the blanket-handling hole the matcher closes. Do not
   re-litigate or add bare aliases. Documented user-side in the
   exhaustive-error-matching guide.
-- The core has **one runtime dependency, `ts-pattern`**, declared as a
-  **peerDependency** (`^5`) so a consumer already using ts-pattern shares a
-  single copy (two copies' declarations don't unify — a type error five layers
-  deep in a conditional type; the same dual-copy hazard `isResult` guards
-  against at runtime). It powers the error matchers and is re-exported. Add no
-  others — protect that minimalism.
+- The core has **zero runtime dependencies** — the error matcher is built-in
+  (`matcher.ts`). It replaced the former `ts-pattern` peer deliberately: the
+  exhaustiveness guarantee (unthrown's central promise) must not vary with a
+  consumer-resolved third-party version (ts-pattern changed exhaustiveness
+  semantics in a _minor_, 5.8), and a peer imposed install friction plus a
+  dual-copy type hazard. Add no dependencies — protect that zero.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -7,7 +7,7 @@ The full, worked guide lives in the docs:
 The headline breaking surface, so you have it up front:
 
 - **Error combinators renamed** with a `…Cases` suffix (each takes an exhaustive
-  ts-pattern matcher): `mapErr` → `mapErrCases`, `flatMapErr` → `flatMapErrCases`,
+  matcher): `mapErr` → `mapErrCases`, `flatMapErr` → `flatMapErrCases`,
   `recoverErr` → `recoverErrCases`, `tapErr` → `tapErrCases`,
   `flatTapErr` → `flatTapErrCases`.
 - **`match`'s error handler renamed** `err` → `errCases` (it takes the matcher,
@@ -21,8 +21,9 @@ The headline breaking surface, so you have it up front:
 - **Renamed export:** `UnwrapError` → `GetError`.
 - **`getOrThrow()`** is now gated to a non-empty error channel; on a
   `Result<T, never>` use `get()`.
-- **`ts-pattern` is a peer dependency** (`^5`) — install it yourself so you own
-  the single copy.
+- **The matcher is built-in** — nothing to install alongside `unthrown`. (The
+  early v5 betas took `ts-pattern` as a peer; the built-in matcher replaced it,
+  keeping the same `.with(…)` / `tag` / `P` call-site shape.)
 - **`@unthrown/pattern` was absorbed into core** — import `match` / `P` / `tag`
   from `unthrown`.
 - **New:** `ensure`, `DoAsync`, and the `match` / `P` / `tag` re-exports.

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ defect that short-circuits to the edge, where you log it and return a 500.
 - 🛂 **Qualification at every boundary** — `fromPromise` / `fromThrowable` force
   you to triage each failure into a modeled error or a defect; no path yields
   `unknown` in `E`.
-- 🪶 **Small and done-able** — one tiny runtime dependency (`ts-pattern`, which
-  powers the exhaustive error matchers), ESM-first, dual CJS/ESM, fully typed.
+- 🪶 **Small and done-able** — **zero runtime dependencies** (the exhaustive
+  error matcher is built-in), ESM-first, dual CJS/ESM, fully typed.
 
 See [Why unthrown?](https://btravstack.github.io/unthrown/explanation/why-unthrown) for
 the comparison with `neverthrow`, `boxed`, and `effect`.
@@ -46,13 +46,11 @@ the comparison with `neverthrow`, `boxed`, and `effect`.
 ## Install
 
 ```sh
-pnpm add unthrown ts-pattern
+pnpm add unthrown
 ```
 
-`ts-pattern` (`^5`) is a peer dependency — it powers the exhaustive error
-matchers and is re-exported by `unthrown` as `match` / `P`. Owning the single
-copy yourself means `import { P } from "ts-pattern"` composes with unthrown's
-matchers instead of colliding with a second, nested copy.
+No peer dependencies — the exhaustive error matcher is built-in and exported as
+`match` / `P` / `tag`.
 
 ## Quick Example
 
@@ -73,7 +71,7 @@ const user = fromPromise(fetchUser(id), (cause, defect) =>
 // Handle every channel once, at the edge — no surrounding try/catch.
 const status = await user.match({
   ok: () => 200,
-  // `errCases` receives the exhaustive ts-pattern matcher; `.with(P._, …)` handles every error:
+  // `errCases` receives the exhaustive matcher; `.with(P._, …)` handles every error:
   errCases: (matcher) => matcher.with(P._, () => 404), // your modeled NotFound
   defect: (cause) => {
     logger.error(cause); // everything unexpected
@@ -89,7 +87,7 @@ defect, so the edge of your program needs a single `match` and no `try`/`catch`.
 
 | Package                                                   | Description                                                                                         |
 | --------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| [`unthrown`](./packages/core)                             | The core `Result` / `AsyncResult`, interop, `TaggedError`, ts-pattern error matching.               |
+| [`unthrown`](./packages/core)                             | The core `Result` / `AsyncResult`, interop, `TaggedError`, built-in exhaustive error matching.      |
 | [`@unthrown/vitest`](./packages/vitest)                   | Vitest matchers: `toBeOk`, `toBeOkWith`, `toBeErr`, `toBeErrWith`, `toBeErrTagged`, `toBeDefect`.   |
 | [`@unthrown/effect`](./packages/effect)                   | Effect interop: `Result ↔ Exit` (bijection), `Either`, `Effect`.                                    |
 | [`@unthrown/neverthrow`](./packages/neverthrow)           | neverthrow interop: `Result ↔ Result`, `AsyncResult ↔ ResultAsync`.                                 |

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -10,7 +10,7 @@ This reference is generated from the source with
   boundaries), guards, boundary interop (`fromNullable`, `fromThrowable`,
   `fromSafeThrowable`, `fromPromise`, `fromSafePromise`), aggregation (`all` /
   `allFromDict`), the tagged-error utilities (`TaggedError`, `tag`), and the
-  re-exported `ts-pattern` `match` / `P` that drive the exhaustive error matcher.
+  built-in `match` / `P` that drive the exhaustive error matcher.
 - [**@unthrown/vitest**](./vitest/) — custom Vitest matchers (`toBeOk`,
   `toBeOkWith`, `toBeErr`, `toBeErrWith`, `toBeErrTagged`, `toBeDefect`).
 - [**@unthrown/effect**](./effect/) — bijective `Result ↔ Exit` bridges

--- a/docs/explanation/comparison.md
+++ b/docs/explanation/comparison.md
@@ -22,7 +22,7 @@ callback throws**.
 | `Option` type                      | ❌ (deliberate)                   | ❌                     | ✅         | ✅                    | ❌                                  |
 | Tagged errors                      | ✅ `TaggedError`                  | ❌                     | ❌         | ✅ `Data.TaggedError` | ❌                                  |
 | Error accumulation                 | ❌ (deliberate)                   | `combineWithAllErrors` | ❌         | ✅                    | ✅ `collect`                        |
-| Runtime dependencies (core)        | **1** (`ts-pattern`)              | 0                      | 0          | a runtime             | 0                                   |
+| Runtime dependencies (core)        | **0** (matcher built-in)          | 0                      | 0          | a runtime             | 0                                   |
 
 ¹ byethrow's combinators don't `try/catch`; it relies on an oxlint rule
 (`no-throw-in-callback`) to keep throws out of callbacks. ² They force typing at

--- a/docs/explanation/exhaustive-error-matching.md
+++ b/docs/explanation/exhaustive-error-matching.md
@@ -1,7 +1,7 @@
 # Exhaustive error matching
 
 > **Explanation.** This page explains _why_ the error combinators take a
-> ts-pattern matcher instead of a plain callback, and why they carry a `*Cases`
+> matcher instead of a plain callback, and why they carry a `*Cases`
 > suffix (`mapErrCases`, `tapErrCases`, …) rather than a bare `map`/`tap`-style
 > name. For the mechanics — the rules, the `P._` catch-all, the per-method
 > signatures — see the [combinator reference](../reference/combinators#the-error-channel).
@@ -30,7 +30,7 @@ values is so the compiler forces you to _account for each one_.
 
 So the error combinators — `mapErrCases`, `flatMapErrCases`, `recoverErrCases`, `tapErrCases`,
 `flatTapErrCases` — do not take a single callback. Their callback receives a
-[ts-pattern](https://github.com/gvergnaud/ts-pattern) **match builder** over the
+built-in **match builder** over the
 error, and you **return the un-terminated builder**. The combinator calls
 `.exhaustive()` itself:
 
@@ -126,16 +126,17 @@ left to silently drop a case. Its `errCases` handler receives the matcher but **
 channel, and a `Result` that already carries a defect is handled by the separate
 `defect:` case.
 
-## Generic boundary helpers: use the guards, not the matcher
+## Generic boundary helpers: the catch-all works, tags don't
 
-The exhaustiveness that makes the matcher safe is proven by ts-pattern _at the
-call site_, from the concrete error union. Inside a **generic** helper — one
-whose error type is still a type parameter `E` — ts-pattern cannot prove any
-builder exhaustive, **not even `.with(P._, …)`**, because `E` is unresolved. So
-this does not compile:
+Exhaustiveness is proven _at the call site_, from the error union. Inside a
+**generic** helper — one whose error type is still a type parameter `E` — no
+list of tag arms can prove coverage, because the compiler cannot know what `E`
+will contain. But the **catch-all can**: `.with(P._, …)` is a state transition
+to "nothing remains" that does not depend on `E` at all, so a
+catch-all-terminated builder compiles even in fully generic code:
 
 ```ts
-// ❌ Won't compile: E is a type parameter, so no builder is provably exhaustive.
+// ✅ Compiles for any E: the catch-all is provably exhaustive by construction.
 function toPromise<T, E>(result: Result<T, E>): T {
   return result.match({
     ok: (value) => value,
@@ -150,28 +151,29 @@ function toPromise<T, E>(result: Result<T, E>): T {
 }
 ```
 
-This is a real limitation, not a bug you can pattern your way around: the same
-body compiles the moment `E` is a concrete union. It means the `…Cases` / `match`
-API is effectively unavailable to code that is generic in the error — a library
-boundary helper, a generic HTTP responder, a test utility.
+```ts
+// ❌ Still won't compile — and shouldn't: tag arms can never be shown to cover
+// an unresolved E. Only the catch-all (or a concrete union) can.
+function partial<T, E>(result: Result<T, E>) {
+  return result.mapErrCases((matcher) => matcher.with(tag("NotFound"), () => 404));
+}
+```
 
-At such a boundary you are usually **leaving** the `Result` world anyway, so
-reach for the narrowing guards instead — they narrow to `OkView` / `ErrView` /
-`DefectView` with no exhaustiveness obligation, and read clearly:
+(Earlier v5 betas, which delegated matching to ts-pattern, rejected even the
+catch-all form here — the original issue #145. The built-in matcher fixed it.)
+
+The narrowing guards remain a fine alternative when a boundary just splits by
+channel with no per-case branching — it is what unthrown's own interop bridges
+use, simply because nothing there needs a matcher:
 
 ```ts
-// ✅ Guards carry no exhaustiveness obligation, so they work for any E.
+// ✅ Also fine: guards carry no exhaustiveness obligation.
 function toPromise<T, E>(result: Result<T, E>): T {
   if (result.isErr()) throw result.error;
   if (result.isDefect()) throw result.cause;
   return result.value;
 }
 ```
-
-This is exactly what unthrown's own generic code does — the interop `to*`
-bridges and `@unthrown/orpc`'s `handlerResult` all branch on the guards, not
-`match`, for the same reason. Concrete application code, where `E` is a known
-union, uses `match` and the `…Cases` combinators normally.
 
 ## Where to go next
 

--- a/docs/how-to/migrate-from-neverthrow.md
+++ b/docs/how-to/migrate-from-neverthrow.md
@@ -7,22 +7,22 @@
 
 ## API mapping
 
-| neverthrow                           | unthrown                                          | Notes                                                                                                          |
-| ------------------------------------ | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `ok(v)` / `err(e)`                   | `Ok(v)` / `Err(e)`                                | constructors are capitalized                                                                                   |
-| `result.andThen(f)`                  | `result.flatMap(f)`                               | one name per concept                                                                                           |
-| `result.map(f)`                      | same                                              | callbacks must be synchronous                                                                                  |
-| `result.mapErr(f)`                   | `result.mapErrCases((matcher) => …)`              | an exhaustive [ts-pattern](https://github.com/gvergnaud/ts-pattern) match; `.with(P._, f)` is the uniform form |
-| `result.orElse(f)`                   | `result.flatMapErrCases((matcher) => …)`          | `flatMap` on the error channel; same exhaustive matcher                                                        |
-| `result.match(okFn, errFn)`          | `match({ ok, errCases: (matcher) => …, defect })` | the third channel is new, and `errCases` takes the same exhaustive matcher — see below                         |
-| `result.unwrapOr(v)`                 | `result.getOr(v)`                                 | still throws on a Defect (a bug is not an absent value)                                                        |
-| `ResultAsync`                        | `AsyncResult`                                     | `await` collapses it to a `Result`; it never rejects                                                           |
-| `ResultAsync.fromPromise(p, mapErr)` | `fromPromise(p, qualify)`                         | `qualify` must return `E` **or** `defect(cause)` — triage is forced                                            |
-| `ResultAsync.fromSafePromise(p)`     | `fromSafePromise(p)`                              | a rejection becomes a `Defect`, not an `Err`                                                                   |
-| `Result.combine([...])`              | `all([...])`                                      | any `Defect` dominates                                                                                         |
-| `Result.combineWithAllErrors`        | —                                                 | error accumulation is deliberately excluded                                                                    |
-| `safeTry(function* …)`               | `Do().bind(…).let(…)`                             | see [do-notation](./sequence-dependent-steps)                                                                  |
-| `fromThrowable(fn, mapErr)`          | `fromThrowable(fn, qualify)`                      | same idea, plus the defect arm                                                                                 |
+| neverthrow                           | unthrown                                          | Notes                                                                                  |
+| ------------------------------------ | ------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `ok(v)` / `err(e)`                   | `Ok(v)` / `Err(e)`                                | constructors are capitalized                                                           |
+| `result.andThen(f)`                  | `result.flatMap(f)`                               | one name per concept                                                                   |
+| `result.map(f)`                      | same                                              | callbacks must be synchronous                                                          |
+| `result.mapErr(f)`                   | `result.mapErrCases((matcher) => …)`              | an exhaustive match over the error's cases; `.with(P._, f)` is the uniform form        |
+| `result.orElse(f)`                   | `result.flatMapErrCases((matcher) => …)`          | `flatMap` on the error channel; same exhaustive matcher                                |
+| `result.match(okFn, errFn)`          | `match({ ok, errCases: (matcher) => …, defect })` | the third channel is new, and `errCases` takes the same exhaustive matcher — see below |
+| `result.unwrapOr(v)`                 | `result.getOr(v)`                                 | still throws on a Defect (a bug is not an absent value)                                |
+| `ResultAsync`                        | `AsyncResult`                                     | `await` collapses it to a `Result`; it never rejects                                   |
+| `ResultAsync.fromPromise(p, mapErr)` | `fromPromise(p, qualify)`                         | `qualify` must return `E` **or** `defect(cause)` — triage is forced                    |
+| `ResultAsync.fromSafePromise(p)`     | `fromSafePromise(p)`                              | a rejection becomes a `Defect`, not an `Err`                                           |
+| `Result.combine([...])`              | `all([...])`                                      | any `Defect` dominates                                                                 |
+| `Result.combineWithAllErrors`        | —                                                 | error accumulation is deliberately excluded                                            |
+| `safeTry(function* …)`               | `Do().bind(…).let(…)`                             | see [do-notation](./sequence-dependent-steps)                                          |
+| `fromThrowable(fn, mapErr)`          | `fromThrowable(fn, qualify)`                      | same idea, plus the defect arm                                                         |
 
 Most rows are a rename. `andThen` → `flatMap` is unthrown's
 [one-name-per-concept](../explanation/design-decisions#one-name-per-concept-no-aliases)

--- a/docs/how-to/model-errors.md
+++ b/docs/how-to/model-errors.md
@@ -82,7 +82,7 @@ e.name; // "RetryableError"          — clean stack-trace label
 
 To fold a `Result` whose error is a tagged union straight to a value, use
 `match`. Its `ok` and `defect` handlers are plain callbacks; its **`errCases` handler
-receives the ts-pattern matcher** — add one branch per tag with `tag(t)` and
+receives the matcher** — add one branch per tag with `tag(t)` and
 **return the un-terminated builder** (`match` calls `.exhaustive()` for you):
 
 ```ts
@@ -110,7 +110,7 @@ no `.exhaustive()` to forget. For an `AsyncResult`, `match` resolves to a
 
 ## Match on more than `_tag`
 
-Because ts-pattern matches by structure, you can also branch on a `code`, on a
+Because the matcher matches by structure, you can also branch on a `code`, on a
 guard, or on grouped patterns, and `.with(P._, …)` is the deliberate catch-all
 when every error is handled the same way:
 

--- a/docs/how-to/upgrade-to-v5.md
+++ b/docs/how-to/upgrade-to-v5.md
@@ -15,31 +15,35 @@
 | **Removed** (aliases)  | `orElse` / `recover`                                             | `flatMapErrCases` / `recoverErrCases`                                                     |
 | **Removed**            | `matchTags` / the `TagHandlers` type                             | `match({ …, errCases: (m) => m.with(tag("…"), …) })`                                      |
 | **Changed, same name** | `getOrThrow()` on any `Result`                                   | gated to a **non-empty** error channel (use `get()` otherwise)                            |
-| **Packaging**          | `ts-pattern` bundled as a dependency                             | `ts-pattern` is now a **peer** — install it yourself                                      |
+| **Packaging**          | `ts-pattern` bundled as a dependency                             | the matcher is **built-in** — no dependency at all                                        |
 | **Packaging**          | `@unthrown/pattern` (`match` / `P` / `tag`)                      | absorbed into core — import them from `unthrown`                                          |
-| **New**                | —                                                                | `ensure`, `DoAsync`, and `match` / `P` / `tag` re-exports                                 |
+| **New**                | —                                                                | `ensure`, `DoAsync`, and the built-in `match` / `P` / `tag` / `NonExhaustiveError`        |
 
 Everything except the two rows below is a compile error at the old call site, so
 `pnpm typecheck` is your migration to-do list.
 
-## 1. Install `ts-pattern`
+## 1. Nothing to install — the matcher is built-in
 
-`ts-pattern` (`^5`) moved from a bundled dependency to a **peer** so a codebase
-that already uses ts-pattern shares one copy — two copies' declarations don't
-unify, and feeding a `P.union(...)` built by one into an unthrown matcher fails
-deep in a conditional type.
+unthrown's exhaustive matcher is its own module (same `.with(…)` / `tag` / `P`
+call-site shape ts-pattern users know), exported as `match` / `P` / `tag` /
+`NonExhaustiveError`. There is **no dependency to install** alongside
+`unthrown` — and no version of any third-party library can change what
+"exhaustive" means.
 
-```sh
-pnpm add ts-pattern   # if you don't already depend on it
-```
+(History, if you followed the betas: early v5 bundled `ts-pattern`, then
+briefly declared it a peer; the built-in matcher replaced it. If you added
+`ts-pattern` for unthrown's sake, you can remove it — unless your own code
+imports it directly for other matching.)
 
-Your package manager will otherwise warn about a missing peer. If you already use
-ts-pattern, keep your own version — unthrown works with any `^5`.
+One boundary to know: patterns built by the real `ts-pattern` library are
+**not** accepted by unthrown's matchers (and vice versa). Import `P` / `match`
+/ `tag` from `"unthrown"` at unthrown call sites; keep `ts-pattern` for your
+own unrelated matching if you use it.
 
 ## 2. Rename the error-channel combinators
 
 Every Err-channel combinator gained a `…Cases` suffix, because each takes a
-ts-pattern matcher over the error's _cases_, not a plain `(error) => …` callback.
+matcher over the error's _cases_, not a plain `(error) => …` callback.
 The old names no longer exist, so the compiler flags each site:
 
 ```diff

--- a/docs/how-to/use-with-orpc.md
+++ b/docs/how-to/use-with-orpc.md
@@ -131,7 +131,7 @@ The error channel is the raw inferable `ORPCError` union, discriminated by `code
 — deliberately **not** re-wrapped into [tagged errors](./model-errors): oRPC
 already ships a discriminated error type, and one concept should have one name.
 Branch on `code` — in `match`'s `errCases` matcher (as above), a `switch`, or a
-standalone ts-pattern `match`. Because these are plain `ORPCError`s rather than
+standalone `match`. Because these are plain `ORPCError`s rather than
 `TaggedError`s, `tag(...)` doesn't apply — match on the `code` field instead.
 
 Anything non-inferable — a network failure, an undeclared throw collapsed to

--- a/docs/how-to/use-with-prisma.md
+++ b/docs/how-to/use-with-prisma.md
@@ -64,7 +64,7 @@ error you want to model (`RecordNotFound`).
 ## Handle the errors
 
 Because the errors are [tagged](./model-errors), driving `match`'s `errCases` handler
-with the ts-pattern matcher gives you an exhaustive fold — the compiler lists
+with the matcher gives you an exhaustive fold — the compiler lists
 exactly the cases the operation can hit:
 
 ```ts

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ features:
     details: fromPromise / fromThrowable force you to triage each failure into a modeled error or a defect. No path ever yields `unknown` in E.
   - icon: { src: /icons/check.svg }
     title: Small and done-able
-    details: One tiny runtime dependency (ts-pattern), ESM-first, dual CJS/ESM, fully typed. One concept, one name. Small enough to be "done".
+    details: Zero runtime dependencies (the matcher is built-in), ESM-first, dual CJS/ESM, fully typed. One concept, one name. Small enough to be "done".
 ---
 
 ## At a glance

--- a/docs/reference/combinators.md
+++ b/docs/reference/combinators.md
@@ -20,7 +20,7 @@ and its binds also accept an `AsyncResult`). The
 The `→ Result<…>` half of each signature is the tell — it shows how the combinator
 moves the channels: `flatMap` widens `E` to `E | E2`, `recoverErrCases` empties it to
 `never`, `flatMapErrCases` widens the value to `T | U`. The error combinators take an
-[exhaustive ts-pattern matcher](#the-error-channel) rather than a single callback;
+[exhaustive matcher](#the-error-channel) rather than a single callback;
 the signatures below abbreviate its callback as `(matcher) => …`.
 
 | I want to…                                     | use               | signature                                                    | channel      |
@@ -77,7 +77,7 @@ present at runtime and flows past it untouched. See
 
 The error combinators — `mapErrCases`, `flatMapErrCases`, `recoverErrCases`, `tapErrCases`,
 `flatTapErrCases` — do not take a single callback. Their callback receives a
-[ts-pattern](https://github.com/gvergnaud/ts-pattern) match builder over the
+built-in match builder over the
 error (`match(error)`; the patterns are re-exported from `unthrown` as `P`), and
 you **return the un-terminated builder** — the combinator calls `.exhaustive()`
 for you:
@@ -97,7 +97,7 @@ A match that misses a case **does not compile** — there is no `.exhaustive()` 
 forget, and no `.otherwise()` to slip in a fallback. The rationale is in
 [Exhaustive error matching](../explanation/exhaustive-error-matching). The rules:
 
-- **Match on anything, not just `_tag`.** ts-pattern matches by structure, so a
+- **Match on anything, not just `_tag`.** The matcher matches by structure, so a
   `code`-discriminated union (the oRPC shape), a plain string, a guard
   (`.with({ code: "NOT_FOUND", id: "special" }, …)`), or grouped patterns
   (`.with(a, b, handler)` — one strategy for several cases) all work. `tag("X")`
@@ -127,7 +127,7 @@ forget, and no `.otherwise()` to slip in a fallback. The rationale is in
   _new_ effect failure (`flatTapErrCases`). `tapDefect` / `tapFailure` keep single
   callbacks — their payloads carry no discriminant to match.
 - **A non-exhaustive match is a `Defect` if it ever slips past the types.** Only
-  reachable outside the typed contract (a widened cast, a JS caller): ts-pattern
+  reachable outside the typed contract (a widened cast, a JS caller): the matcher
   throws `NonExhaustiveError`, which the combinator's throw-to-defect net turns
   into a `Defect`.
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -50,13 +50,13 @@ only the tag-aware utilities require `E extends { _tag: string }`. See
 [Model errors](../how-to/model-errors).
 
 **matcher**
-: The [ts-pattern](https://github.com/gvergnaud/ts-pattern) `match(error)` builder
+: The built-in `match(error)` builder
 handed to every error combinator's callback. You return it un-terminated; the
 combinator runs `.exhaustive()`, so a missing case does not compile. See
 [Exhaustive error matching](../explanation/exhaustive-error-matching).
 
 **`P` / `tag(t)`**
-: `P` is ts-pattern's pattern namespace, re-exported from `unthrown`; `P._` is the
+: `P` is unthrown's pattern namespace (`P._`, `P.instanceOf`, `P.when`, `P.union`, `P.string`, `P.number`); `P._` is the
 catch-all pattern. `tag(t)` is sugar for the `{ _tag: t }` pattern, narrowing to
 a tagged variant and its payload.
 

--- a/docs/reference/result-surface.md
+++ b/docs/reference/result-surface.md
@@ -37,7 +37,7 @@ Every `Result` shares one method surface, grouped by the channel it touches:
 - **do-notation** (runs on `Ok`): `bind`, `let` — accumulate a named scope; see
   [Sequence dependent steps](../how-to/sequence-dependent-steps)
 - **error** (runs on `Err`): `mapErrCases`, `flatMapErrCases`, `recoverErrCases`, `tapErrCases`,
-  `flatTapErrCases` — all take an **exhaustive ts-pattern matcher** over the error
+  `flatTapErrCases` — all take an **exhaustive matcher** over the error
 - **defect** (the only door to a `Defect`): `recoverDefect`, `tapDefect`
 - **failure** (runs on `Err` **or** `Defect`): `tapFailure` — observe either
   failing channel without consuming it

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -12,24 +12,22 @@ outcome as a value — with no `try`/`catch` to write. It takes about ten minute
 ::: code-group
 
 ```sh [pnpm]
-pnpm add unthrown ts-pattern
+pnpm add unthrown
 ```
 
 ```sh [npm]
-npm install unthrown ts-pattern
+npm install unthrown
 ```
 
 ```sh [yarn]
-yarn add unthrown ts-pattern
+yarn add unthrown
 ```
 
 :::
 
-`unthrown` is ESM-first, ships dual CJS/ESM builds with full types, and has one
-tiny runtime dependency, `ts-pattern` (`^5`) — a **peer** you install alongside
-it, so you own the single copy that powers the error matchers (and that
-`unthrown` re-exports as `match` / `P`). Use it with TypeScript in `strict`
-mode.
+`unthrown` is ESM-first, ships dual CJS/ESM builds with full types, and has
+**zero runtime dependencies** — the exhaustive error matcher is built-in
+(exported as `match` / `P` / `tag`). Use it with TypeScript in `strict` mode.
 
 ## Step 2 — Return a failure instead of throwing
 
@@ -96,7 +94,7 @@ _unexpected_ (you'll meet it in the next step):
 ```ts
 const message = parseAge("-3").match({
   ok: (age) => `age is ${age}`,
-  // `errCases` receives an exhaustive matcher — one branch per error. ts-pattern
+  // `errCases` receives an exhaustive matcher — one branch per error. It
   // matches plain strings too (no tag required), and a missing case won't compile.
   errCases: (matcher) =>
     matcher.with("negative", () => "must be positive").with("not_a_number", () => "not a number"),

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -7,13 +7,11 @@
 [API Reference](https://btravstack.github.io/unthrown/api/core/)
 
 ```sh
-pnpm add unthrown ts-pattern
+pnpm add unthrown
 ```
 
-`ts-pattern` (`^5`) is a peer dependency — it powers the exhaustive error
-matchers and is re-exported as `match` / `P`. Declaring it a peer means you own
-the single copy, so `import { P } from "ts-pattern"` composes with unthrown's
-matchers.
+No peer dependencies — the exhaustive error matcher is built-in and exported as
+`match` / `P` / `tag`.
 
 ```ts
 import { fromPromise, P, TaggedError } from "unthrown";
@@ -38,8 +36,8 @@ const status = await user.match({
 - **Qualification at every boundary** — `fromPromise` / `fromThrowable` force you
   to triage each failure into a modeled error or a defect.
 - **Tagged errors** — `TaggedError(tag)` + `tag(t)`, folded exhaustively through
-  `match`'s ts-pattern error matcher.
-- One tiny runtime dependency (`ts-pattern`, a peer you share), ESM-first, dual
+  `match`'s built-in error matcher.
+- **Zero runtime dependencies** (the matcher is built-in), ESM-first, dual
   CJS/ESM.
 
 See the [full documentation](https://btravstack.github.io/unthrown/) for the guide

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,15 +58,11 @@
     "@btravstack/typedoc": "catalog:",
     "@types/node": "catalog:",
     "@vitest/coverage-v8": "catalog:",
-    "ts-pattern": "catalog:",
     "tsdown": "catalog:",
     "typedoc": "catalog:",
     "typedoc-plugin-markdown": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
-  },
-  "peerDependencies": {
-    "ts-pattern": "^5"
   },
   "engines": {
     "node": ">=20"

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -14,9 +14,8 @@
 // The only other casts are the builders' construction (`as OkView`/…) and the
 // `bind`/`let` scope merge (a computed key can't be spelled at the type level).
 
-import { match } from "ts-pattern";
-
 import { type Defect, defect, isDefectMarker } from "./defect.js";
+import { match } from "./matcher.js";
 import type {
   AsyncResult,
   Bound,
@@ -307,7 +306,7 @@ class Res<T, E> {
         // The `errCases` handler returns the un-terminated builder; `.run()`
         // executes `.exhaustive()`. Type-forced exhaustive for well-typed
         // callers; a value slipping past the types (widened cast, JS caller) with
-        // no matching case throws ts-pattern's `NonExhaustiveError` — `match` is
+        // no matching case throws the matcher's `NonExhaustiveError` — `match` is
         // an edge eliminator, so it surfaces rather than being caught into a Defect.
         return cases.errCases(match(this.error) as ErrMatcher<E>).run() as MatchOut<M>;
       case "Defect":

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,11 @@
-// ts-pattern powers the error-matching combinators (`mapErrCases`/`flatMapErrCases`/…),
-// and is re-exported so `P` (wildcards, `P.union`, guards) and `match` (for
-// eliminating a `Result` directly) are available from one import.
-export { match, P } from "ts-pattern";
+// The built-in matcher powers the error-matching combinators
+// (`mapErrCases`/`flatMapErrCases`/…): `match` starts a match (over an error or
+// any discriminated value, a `Result` included), `P` carries the pattern
+// helpers (`P._`, `P.instanceOf`, `P.when`, `P.union`, `P.string`, `P.number`),
+// and `NonExhaustiveError` is what a rogue unmatched value throws at the
+// `match` edge.
+export { match, NonExhaustiveError, P } from "./matcher.js";
+export type { Matcher, PatternMatcher, UniversalPattern } from "./matcher.js";
 
 export { Err, ErrAsync, isDefect, isErr, isOk, Ok, OkAsync } from "./constructors.js";
 export { isResult, GetError } from "./core.js";

--- a/packages/core/src/matcher.spec.ts
+++ b/packages/core/src/matcher.spec.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+
+import { match, NonExhaustiveError, P } from "./matcher.js";
+import { tag } from "./tagged.js";
+
+describe("the built-in matcher engine", () => {
+  it("matches a primitive literal (Object.is semantics)", () => {
+    expect(
+      match("a" as "a" | "b")
+        .with("a", () => 1)
+        .with("b", () => 2)
+        .run(),
+    ).toBe(1);
+    expect(
+      match(Number.NaN as number)
+        .with(Number.NaN, () => "nan")
+        .with(P.number, () => "num")
+        .run(),
+    ).toBe("nan");
+  });
+
+  it("matches an object pattern structurally (extra keys ignored, nested literals)", () => {
+    type E = { code: "NOT_FOUND"; status: number } | { code: "FORBIDDEN"; status: number };
+    const e: E = { code: "NOT_FOUND", status: 404 };
+    expect(
+      match(e)
+        .with({ code: "NOT_FOUND" }, (n) => n.status)
+        .with({ code: "FORBIDDEN" }, () => -1)
+        .run(),
+    ).toBe(404);
+    // nested object literal
+    const nested = { kind: "x", meta: { level: 2 } } as
+      | { kind: "x"; meta: { level: number } }
+      | { kind: "y" };
+    expect(
+      match(nested)
+        .with({ meta: { level: 2 } }, () => "deep")
+        .with(P._, () => "other")
+        .run(),
+    ).toBe("deep");
+    // an object pattern never matches a primitive value
+    expect(
+      match("prim" as "prim" | { code: "X" })
+        .with({ code: "X" }, () => "obj")
+        .with(P._, () => "prim")
+        .run(),
+    ).toBe("prim");
+  });
+
+  it("matches tag() patterns and grouped patterns with one handler", () => {
+    type E = { _tag: "A"; a: number } | { _tag: "B" } | { _tag: "C" };
+    const run = (e: E) =>
+      match(e)
+        .with(tag("A"), (a) => `a:${a.a}`)
+        .with(tag("B"), tag("C"), (bc) => `bc:${bc._tag}`)
+        .run();
+    expect(run({ _tag: "A", a: 1 })).toBe("a:1");
+    expect(run({ _tag: "B" })).toBe("bc:B");
+    expect(run({ _tag: "C" })).toBe("bc:C");
+  });
+
+  it("first matching arm wins; later arms are not evaluated", () => {
+    let later = 0;
+    const out = match("x" as string)
+      .with(P.string, () => "first")
+      .with(P._, () => {
+        later += 1;
+        return "second";
+      })
+      .run();
+    expect(out).toBe("first");
+    expect(later).toBe(0);
+  });
+
+  it("P._ and P.any match anything", () => {
+    expect(
+      match(123 as unknown)
+        .with(P._, (v) => v)
+        .run(),
+    ).toBe(123);
+    expect(
+      match(undefined as unknown)
+        .with(P.any, () => "caught")
+        .run(),
+    ).toBe("caught");
+  });
+
+  it("P.instanceOf narrows by class, P.when by guard, P.string/P.number by typeof", () => {
+    class Boom extends Error {}
+    const e: Boom | string | number = new Boom("x");
+    expect(
+      match(e)
+        .with(P.instanceOf(Boom), (b) => b.message)
+        .with(P.string, (s) => s)
+        .with(P.number, (n) => String(n))
+        .run(),
+    ).toBe("x");
+    expect(
+      match(7 as Boom | string | number)
+        .with(P.instanceOf(Boom), (b) => b.message)
+        .with(P.string, (s) => s)
+        .with(P.number, (n) => `n:${n}`)
+        .run(),
+    ).toBe("n:7");
+    const isEven = (v: unknown): v is number => typeof v === "number" && v % 2 === 0;
+    expect(
+      match(4 as number | string)
+        .with(P.when(isEven), () => "even")
+        .with(P._, () => "other")
+        .run(),
+    ).toBe("even");
+  });
+
+  it("P.union matches when any sub-pattern matches", () => {
+    type E = { _tag: "A" } | { _tag: "B" } | { _tag: "C" };
+    const run = (e: E) =>
+      match(e)
+        .with(P.union(tag("A"), tag("B")), (ab) => `ab:${ab._tag}`)
+        .with(tag("C"), () => "c")
+        .run();
+    expect(run({ _tag: "A" })).toBe("ab:A");
+    expect(run({ _tag: "B" })).toBe("ab:B");
+    expect(run({ _tag: "C" })).toBe("c");
+  });
+
+  it("exhaustive() returns the result; a rogue unmatched value throws NonExhaustiveError", () => {
+    expect(
+      match("a" as "a")
+        .with("a", () => 1)
+        .exhaustive(),
+    ).toBe(1);
+    // A value that slipped past the types (cast) with no matching arm:
+    const rogue = match("zzz" as "a").with("a", () => 1);
+    expect(() => rogue.run()).toThrowError(NonExhaustiveError);
+    try {
+      rogue.run();
+    } catch (error) {
+      expect(error).toBeInstanceOf(NonExhaustiveError);
+      expect((error as NonExhaustiveError).input).toBe("zzz");
+      expect((error as NonExhaustiveError).message).toContain('"zzz"');
+    }
+  });
+
+  it("NonExhaustiveError prints non-JSON-serializable inputs via String()", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic["self"] = cyclic;
+    const builder = match(cyclic as unknown as "a").with("a", () => 1);
+    expect(() => builder.run()).toThrowError(NonExhaustiveError);
+    try {
+      builder.run();
+    } catch (error) {
+      expect((error as NonExhaustiveError).message).toContain("[object Object]");
+    }
+  });
+
+  it("arms after a match are inert (builder short-circuits)", () => {
+    let sideEffect = 0;
+    const out = match({ _tag: "A" } as { _tag: "A" } | { _tag: "B" })
+      .with(tag("A"), () => "a")
+      .with(tag("B"), () => {
+        sideEffect += 1;
+        return "b";
+      })
+      .run();
+    expect(out).toBe("a");
+    expect(sideEffect).toBe(0);
+  });
+});

--- a/packages/core/src/matcher.spec.ts
+++ b/packages/core/src/matcher.spec.ts
@@ -153,6 +153,39 @@ describe("the built-in matcher engine", () => {
     }
   });
 
+  it("a non-plain object pattern never matches structurally — identity only", () => {
+    // A keyless class instance (Date, Error) or a foreign symbol-keyed pattern
+    // object (e.g. a real ts-pattern matcher) must NOT vacuously match every
+    // object via empty Object.entries — only reference identity matches.
+    const value = { anything: true } as unknown as "fallback";
+    const datePattern = new Date(0) as unknown as "fallback";
+    const errorPattern = new Error("x") as unknown as "fallback";
+    const foreignPattern = { [Symbol.for("@ts-pattern/matcher")]: () => ({ matched: true }) };
+    expect(
+      match(value)
+        .with(datePattern, () => "date")
+        .with(errorPattern, () => "error")
+        .with(foreignPattern as unknown as "fallback", () => "foreign")
+        .with(P._, () => "catch-all")
+        .run(),
+    ).toBe("catch-all");
+    // Identity still matches a non-plain object pattern:
+    const exact = new Date(0);
+    expect(
+      match(exact as unknown as "x")
+        .with(exact as unknown as "x", () => "same")
+        .run(),
+    ).toBe("same");
+    // Object.create(null) counts as plain (a null-prototype record):
+    const bare = Object.create(null) as Record<string, unknown>;
+    bare["k"] = 1;
+    expect(
+      match({ k: 1 } as unknown as "x")
+        .with(bare as unknown as "x", () => "bare")
+        .run(),
+    ).toBe("bare");
+  });
+
   it("arms after a match are inert (builder short-circuits)", () => {
     let sideEffect = 0;
     const out = match({ _tag: "A" } as { _tag: "A" } | { _tag: "B" })

--- a/packages/core/src/matcher.ts
+++ b/packages/core/src/matcher.ts
@@ -1,0 +1,279 @@
+// unthrown — the built-in error matcher.
+//
+// A purpose-built, shallow pattern matcher for the error channel (it replaced
+// the former ts-pattern peer dependency, keeping its call-site shape:
+// `matcher.with(pattern, …patterns, handler)`, with the combinator running
+// `.exhaustive()` via `.run()`). Owning the type machinery means:
+//
+//   - Exhaustiveness is computed with plain `Exclude` over the tracked
+//     `Remaining` parameter — shallow, fast, and stable (no third-party minor
+//     release can change what "exhaustive" means).
+//   - The universal pattern (`P._` / `P.any`) carries phantom type `unknown`,
+//     and `Exclude<Remaining, unknown>` reduces to `never` even when the input
+//     is an UNRESOLVED generic — so a catch-all-terminated builder is provably
+//     exhaustive inside code generic in `E` (fixes #145 by construction).
+//   - A non-exhaustive builder's `exhaustive` is a branded object naming the
+//     unhandled cases — a readable diagnostic instead of a deep conditional.
+//
+// Supported patterns (the vocabulary the error channel actually uses):
+// primitive literals, shallow(-ly nested) object literals (`{ _tag: "X" }`,
+// `{ code: "X" }` — `tag(t)` produces the former), and the `P.*` matchers
+// (`_`/`any`, `instanceOf`, `when`, `union`, `string`, `number`). Deliberately
+// NOT supported: deep structural inversion, selections, array/variadic
+// patterns — that is the complexity (and instability) being left behind.
+
+/**
+ * Cross-copy brand for `P.*` pattern objects: `Symbol.for` yields the same
+ * symbol in every copy of the library (dual CJS/ESM, duplicated install,
+ * another realm), so a pattern built by one copy is recognised by another —
+ * the same rationale as `isResult`'s prototype brand.
+ *
+ * @internal
+ */
+const PATTERN_BRAND = Symbol.for("unthrown.matcher.pattern");
+
+declare const MATCHES: unique symbol;
+declare const UNIVERSAL: unique symbol;
+
+/**
+ * A `P.*` pattern: a runtime predicate plus the phantom type `M` it matches.
+ * The phantom is declaration-only (never present at runtime); it drives the
+ * type-level narrowing (`Extract`) and exhaustiveness (`Exclude`).
+ *
+ * @typeParam M - the type this pattern matches.
+ * @category Types
+ */
+export type PatternMatcher<M> = {
+  readonly [PATTERN_BRAND]: (value: unknown) => boolean;
+  readonly [MATCHES]?: M;
+};
+
+/**
+ * The statically-known universal pattern — the type of `P._` / `P.any` only.
+ * The phantom `UNIVERSAL` marker is *required*, so no other
+ * `PatternMatcher<unknown>` (e.g. a `P.when` guard that happens to be
+ * universal) is assignable: the catch-all `.with` overload must only fire for
+ * a pattern the type system KNOWS covers everything.
+ *
+ * @category Types
+ */
+export type UniversalPattern = PatternMatcher<unknown> & {
+  readonly [UNIVERSAL]: true;
+};
+
+/**
+ * The type a single pattern matches: a `P.*` matcher's phantom, an object
+ * literal mapped key-by-key (so `{ _tag: "A" }` matches the `"A"`-tagged
+ * variant), or the primitive literal itself.
+ *
+ * @internal
+ */
+export type MatchedOf<Pt> =
+  Pt extends PatternMatcher<infer M>
+    ? M
+    : Pt extends object
+      ? { [K in keyof Pt]: MatchedOf<Pt[K]> }
+      : Pt;
+
+/**
+ * The diagnostic type of `.exhaustive` on a builder that has NOT covered every
+ * case: not callable (so it fails the `ExhaustiveMatch` constraint at the call
+ * site), and it names the remaining cases so the error reads as a to-do list.
+ *
+ * @internal
+ */
+export type NonExhaustive<Remaining> = {
+  readonly "unthrown: this match is not exhaustive — add a `.with(…)` for the remaining cases": Remaining;
+};
+
+/**
+ * The match builder over an input union `E`. `Remaining` tracks the cases not
+ * yet covered by a `.with(…)` arm; `O` accumulates the branch output union.
+ * `.exhaustive` is callable only once `Remaining` is `never` — which is what
+ * the `ExhaustiveMatch` constraint requires — and `.run()` executes it.
+ *
+ * @typeParam E - the full input union being matched.
+ * @typeParam Remaining - the cases not yet covered.
+ * @typeParam O - the union of branch return types so far.
+ * @category Types
+ */
+export type Matcher<E, Remaining, O> = {
+  /**
+   * The catch-all arm: `.with(P._, handler)` / `.with(P.any, handler)`. A
+   * **state transition**, not a computation — it returns `Matcher<E, never, …>`
+   * with the remaining cases literally `never`, so the builder is provably
+   * exhaustive even when `E` is an unresolved type parameter (a lazily-deferred
+   * `Exclude<E, unknown>` would not resolve there). This is what lets a
+   * boundary helper generic in `E` terminate with the catch-all (issue #145).
+   */
+  with<O2>(pattern: UniversalPattern, handler: (value: Remaining) => O2): Matcher<E, never, O | O2>;
+  /**
+   * Add an arm: one or more patterns sharing a single handler (grouped
+   * patterns — `matcher.with(tag("A"), tag("B"), handler)`). The handler
+   * receives the input narrowed to what the patterns match (computed against
+   * `Remaining`, so cases already handled by earlier arms are excluded); the
+   * matched cases are subtracted from `Remaining`.
+   */
+  with<const Pts extends readonly [unknown, ...unknown[]], O2>(
+    ...args: [...patterns: Pts, handler: (value: Extract<Remaining, MatchedOf<Pts[number]>>) => O2]
+  ): Matcher<E, Exclude<Remaining, MatchedOf<Pts[number]>>, O | O2>;
+
+  /**
+   * Terminate the match. Typed callable only when every case is covered
+   * (`Remaining` is `never`); otherwise it is a branded diagnostic object
+   * naming the remaining cases, and the builder fails the `ExhaustiveMatch`
+   * constraint at the combinator call site.
+   */
+  exhaustive: [Remaining] extends [never] ? () => O : NonExhaustive<Remaining>;
+
+  /**
+   * Execute the match (the combinators call this; it runs `.exhaustive()`).
+   * A value with no matching arm throws {@link NonExhaustiveError} —
+   * unreachable for well-typed callers.
+   */
+  run(): O;
+};
+
+/**
+ * Thrown by `.run()` / `.exhaustive()` when no arm matched the value. For
+ * well-typed callers the match is exhaustive by construction, so this is only
+ * reachable by a value that slipped past the types (a widened cast, a raw-JS
+ * caller); inside the error combinators the throw-to-defect net converts it to
+ * a `Defect`, and at the `match` edge it surfaces (a genuinely unmodeled value
+ * is a bug).
+ *
+ * @category Errors
+ */
+export class NonExhaustiveError extends Error {
+  /** The value no arm matched. */
+  readonly input: unknown;
+  constructor(input: unknown) {
+    let printed: string;
+    try {
+      printed = JSON.stringify(input);
+    } catch {
+      printed = String(input);
+    }
+    super(`unthrown: no pattern matched the value ${printed}`);
+    this.name = "NonExhaustiveError";
+    this.input = input;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * Runtime test: does `pattern` match `value`? A branded `P.*` pattern applies
+ * its predicate; a plain object matches when every key matches recursively
+ * (extra keys on the value are ignored — matching is structural); anything
+ * else is compared with `Object.is`.
+ *
+ * @internal
+ */
+function matches(pattern: unknown, value: unknown): boolean {
+  if (typeof pattern === "object" && pattern !== null) {
+    const predicate = (pattern as PatternMatcher<unknown>)[PATTERN_BRAND];
+    if (typeof predicate === "function") return predicate(value);
+    if (typeof value !== "object" || value === null) return false;
+    return Object.entries(pattern).every(([key, sub]) =>
+      matches(sub, (value as Record<string, unknown>)[key]),
+    );
+  }
+  return Object.is(pattern, value);
+}
+
+/**
+ * The runtime builder: first matching arm wins; later arms are skipped once a
+ * result is captured. `exhaustive` is a *method* at runtime (the conditional
+ * type gates its callability per instantiation).
+ *
+ * @internal
+ */
+class MatcherImpl {
+  readonly #value: unknown;
+  #matched = false;
+  #result: unknown;
+
+  constructor(value: unknown) {
+    this.#value = value;
+  }
+
+  with(...args: readonly unknown[]): this {
+    if (this.#matched) return this;
+    const handler = args[args.length - 1] as (value: unknown) => unknown;
+    for (let i = 0; i < args.length - 1; i++) {
+      if (matches(args[i], this.#value)) {
+        this.#matched = true;
+        this.#result = handler(this.#value);
+        return this;
+      }
+    }
+    return this;
+  }
+
+  exhaustive(): unknown {
+    if (this.#matched) return this.#result;
+    throw new NonExhaustiveError(this.#value);
+  }
+
+  run(): unknown {
+    return this.exhaustive();
+  }
+}
+Object.freeze(MatcherImpl.prototype);
+
+/**
+ * Begin a match over `value`. Chain `.with(pattern, …patterns, handler)` arms;
+ * terminate with `.exhaustive()` — or return the un-terminated builder to an
+ * unthrown error combinator / `match({ errCases })`, which runs it for you.
+ *
+ * @remarks
+ * This is unthrown's own matcher (the former ts-pattern re-export): the same
+ * call-site shape, with exhaustiveness computed by plain `Exclude` over the
+ * builder's `Remaining` parameter. A `P._` catch-all is provably exhaustive
+ * even over an unresolved generic input.
+ *
+ * @category Constructors
+ */
+export function match<const E>(value: E): Matcher<E, E, never> {
+  return new MatcherImpl(value) as unknown as Matcher<E, E, never>;
+}
+
+/** @internal */
+function pattern<M>(predicate: (value: unknown) => boolean): PatternMatcher<M> {
+  return Object.freeze({ [PATTERN_BRAND]: predicate }) as PatternMatcher<M>;
+}
+
+// The `UNIVERSAL` marker is phantom (declaration-only): the cast brands the
+// runtime object with the statically-known-universal type so the catch-all
+// `.with` overload fires for `P._` / `P.any` and for nothing else.
+const universal = pattern<unknown>(() => true) as UniversalPattern;
+
+/**
+ * The pattern namespace (unthrown's own; the former ts-pattern `P`):
+ *
+ * - `P._` / `P.any` — the universal catch-all. Matches anything, and (because
+ *   its phantom type is `unknown`) makes the builder provably exhaustive even
+ *   when the matched input is an unresolved type parameter.
+ * - `P.instanceOf(Cls)` — an `instanceof` check, narrowing to the class
+ *   instance type (for union members that are not tagged, e.g. a third-party
+ *   error class).
+ * - `P.when(guard)` — an arbitrary type-guard predicate.
+ * - `P.union(…patterns)` — matches when any sub-pattern matches.
+ * - `P.string` / `P.number` — primitive-type wildcards.
+ *
+ * @category Constructors
+ */
+export const P = Object.freeze({
+  _: universal,
+  any: universal,
+  instanceOf: <C extends abstract new (...args: never[]) => unknown>(
+    cls: C,
+  ): PatternMatcher<InstanceType<C>> => pattern((value) => value instanceof cls),
+  when: <G>(guard: (value: unknown) => value is G): PatternMatcher<G> => pattern(guard),
+  union: <const Pts extends readonly [unknown, ...unknown[]]>(
+    ...patterns: Pts
+  ): PatternMatcher<MatchedOf<Pts[number]>> =>
+    pattern((value) => patterns.some((sub) => matches(sub, value))),
+  string: pattern<string>((value) => typeof value === "string"),
+  number: pattern<number>((value) => typeof value === "number"),
+});

--- a/packages/core/src/matcher.ts
+++ b/packages/core/src/matcher.ts
@@ -162,10 +162,27 @@ export class NonExhaustiveError extends Error {
 }
 
 /**
+ * Is `x` a *plain* object (prototype `Object.prototype` or `null`) — an object
+ * literal, the only object shape that acts as a structural pattern?
+ *
+ * @internal
+ */
+function isPlainObject(x: object): x is Record<string, unknown> {
+  const proto: unknown = Object.getPrototypeOf(x);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
  * Runtime test: does `pattern` match `value`? A branded `P.*` pattern applies
- * its predicate; a plain object matches when every key matches recursively
+ * its predicate; a **plain-object** pattern (an object literal, e.g. the
+ * `{ _tag }` produced by `tag()`) matches when every key matches recursively
  * (extra keys on the value are ignored — matching is structural); anything
- * else is compared with `Object.is`.
+ * else — primitives, but also class instances, arrays, and foreign pattern
+ * objects (e.g. a real ts-pattern matcher, whose keys are symbols) — is
+ * compared with `Object.is`. Restricting structural matching to plain objects
+ * is load-bearing: a keyless non-plain object (`new Date()`, `new Error()`, a
+ * symbol-keyed foreign pattern) would otherwise vacuously match *every* object
+ * via an empty `Object.entries`.
  *
  * @internal
  */
@@ -173,6 +190,12 @@ function matches(pattern: unknown, value: unknown): boolean {
   if (typeof pattern === "object" && pattern !== null) {
     const predicate = (pattern as PatternMatcher<unknown>)[PATTERN_BRAND];
     if (typeof predicate === "function") return predicate(value);
+    // A symbol-keyed plain object is a *foreign* pattern protocol (e.g. a raw
+    // ts-pattern matcher object) — it would look empty to `Object.entries` and
+    // vacuously match everything. Fail closed: identity only.
+    if (!isPlainObject(pattern) || Object.getOwnPropertySymbols(pattern).length > 0) {
+      return Object.is(pattern, value);
+    }
     if (typeof value !== "object" || value === null) return false;
     return Object.entries(pattern).every(([key, sub]) =>
       matches(sub, (value as Record<string, unknown>)[key]),

--- a/packages/core/src/result.spec.ts
+++ b/packages/core/src/result.spec.ts
@@ -251,7 +251,7 @@ type TagB = { _tag: "B"; b: string };
 const errA = (a: number): Result<never, TagA | TagB> => Err<TagA | TagB>({ _tag: "A", a });
 const errB = (b: string): Result<never, TagA | TagB> => Err<TagA | TagB>({ _tag: "B", b });
 
-describe("Result.mapErrCases (ts-pattern matcher)", () => {
+describe("Result.mapErrCases (matcher)", () => {
   it("dispatches a tagged error to its matching branch", () => {
     const r = errA(7).mapErrCases((matcher) =>
       matcher.with(tag("A"), (e) => `a:${e.a}`).with(tag("B"), (e) => `b:${e.b}`),
@@ -326,7 +326,7 @@ describe("Result.mapErrCases (ts-pattern matcher)", () => {
   });
 });
 
-describe("Result.flatMapErrCases (ts-pattern matcher)", () => {
+describe("Result.flatMapErrCases (matcher)", () => {
   it("recovers an Err into an Ok", () => {
     expect(
       Err("e")
@@ -379,7 +379,7 @@ describe("Result.flatMapErrCases (ts-pattern matcher)", () => {
   });
 });
 
-describe("Result.recoverErrCases (ts-pattern matcher)", () => {
+describe("Result.recoverErrCases (matcher)", () => {
   it("turns an Err into an Ok", () => {
     expect(
       Err("e")
@@ -432,7 +432,7 @@ describe("Result.recoverErrCases (ts-pattern matcher)", () => {
   });
 });
 
-describe("Result.tapErrCases (ts-pattern matcher, exhaustive)", () => {
+describe("Result.tapErrCases (matcher, exhaustive)", () => {
   it("runs the side effect on Err and returns the same error", () => {
     const seen: string[] = [];
     const r = Err("e").tapErrCases((matcher) => matcher.with(P._, (s) => seen.push(s)));
@@ -465,7 +465,7 @@ describe("Result.tapErrCases (ts-pattern matcher, exhaustive)", () => {
   });
 });
 
-describe("Result.flatTapErrCases (ts-pattern matcher, exhaustive)", () => {
+describe("Result.flatTapErrCases (matcher, exhaustive)", () => {
   it("runs the failable effect on Err and keeps the original error on success", () => {
     const seen: string[] = [];
     const r = Err("e").flatTapErrCases((matcher) =>

--- a/packages/core/src/tagged.spec.ts
+++ b/packages/core/src/tagged.spec.ts
@@ -126,7 +126,7 @@ describe("TaggedError", () => {
 });
 
 // The per-tag exhaustive fold that `matchTags` used to provide is now `match`
-// with its `errCases` handler driven by the ts-pattern error matcher and `tag(t)`.
+// with its `errCases` handler driven by the error matcher and `tag(t)`.
 describe("match — per-tag error matching", () => {
   const fold = (r: Result<number, ApiError>): string =>
     r.match({

--- a/packages/core/src/tagged.ts
+++ b/packages/core/src/tagged.ts
@@ -1,5 +1,5 @@
 // The TaggedError convention (à la Effect's `Data.TaggedError`) and the
-// `tag(t)` ts-pattern pattern for matching a tagged error union.
+// `tag(t)` matcher pattern for matching a tagged error union.
 
 type Props = Record<string, unknown>;
 
@@ -148,7 +148,7 @@ export function TaggedError<Tag extends string>(
 }
 
 /**
- * A `ts-pattern` pattern matching any value whose `_tag` equals `value` — a
+ * A matcher pattern matching any value whose `_tag` equals `value` — a
  * {@link TaggedError}, or any discriminated member. Equivalent to the object
  * pattern `{ _tag: value }`, but reads better inside an error-matching
  * combinator and narrows to the matching variant, payload included.

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -411,21 +411,55 @@ type _foldedObjects = Expect<
   Equal<typeof foldedObjects, { ok: number } | { bug: boolean } | { err: "TagA" | "TagB" }>
 >;
 
-// Generic-E limitation (documented in the exhaustive-error-matching guide): inside
-// a helper whose error type is still a type parameter, ts-pattern cannot prove any
-// builder exhaustive — not even `.with(P._, …)` — so `match`/`…Cases` do not
-// compile there. Generic boundary helpers use the narrowing guards instead. If a
-// future ts-pattern makes the generic case provable, this @ts-expect-error flips
-// and the guide note can be revisited.
+// Generic-E catch-all (issue #145, fixed by the built-in matcher): the catch-all
+// `.with` arm is a STATE TRANSITION to `Remaining = never` (an overload keyed on
+// the statically-universal `P._` type), not a lazily-deferred `Exclude` — so a
+// catch-all-terminated builder is provably exhaustive even when `E` is an
+// unresolved type parameter, and a generic boundary helper can use `match`.
 function _genericMatch<T, E>(result: Result<T, E>): void {
   result.match({
     ok: () => undefined,
-    // @ts-expect-error - P._ is not provably exhaustive over an unresolved E
     errCases: (matcher) => matcher.with(P._, () => undefined),
     defect: () => undefined,
   });
 }
-// The guard-based form compiles for any E — the sanctioned generic boundary shape.
+void _genericMatch;
+// The issue #145 repro verbatim: a generic boundary helper (bounded E, catch-all
+// terminated) folding an AsyncResult — must compile.
+class _AppFailure extends Error {}
+async function _resultToPromise<T, E extends _AppFailure = never>(
+  ar: AsyncResult<T, E>,
+): Promise<T> {
+  const result = await ar;
+  return result.match({
+    ok: (value) => value,
+    errCases: (matcher) =>
+      matcher.with(P._, (error) => {
+        throw error;
+      }),
+    defect: (cause) => {
+      throw cause;
+    },
+  });
+}
+void _resultToPromise;
+// A generic catch-all in a combinator position re-emits the error unchanged.
+function _genericReemit<T, E>(r: Result<T, E>): Result<T, E> {
+  return r.mapErrCases((matcher) => matcher.with(P._, (e) => e));
+}
+void _genericReemit;
+// …but tag arms alone still cannot prove exhaustiveness over an unresolved E —
+// only the statically-universal catch-all can.
+function _genericMatchTags<T, E>(result: Result<T, E>): void {
+  result.match({
+    ok: () => undefined,
+    // @ts-expect-error - tag arms are not provably exhaustive over an unresolved E
+    errCases: (matcher) => matcher.with(tag("X"), () => undefined),
+    defect: () => undefined,
+  });
+}
+void _genericMatchTags;
+// The guard-based form also works for any E — the pre-#145-fix boundary shape.
 function _genericGuards<T, E>(result: Result<T, E>): T {
   if (result.isErr()) throw result.error;
   if (result.isDefect()) throw result.cause;
@@ -622,7 +656,7 @@ new WithMsg({ ticketId: "t1" });
   type _Widens = Expect<Equal<typeof widened, number | null>>;
 }
 
-// --- error triage: mapErrCases/flatMapErrCases/recoverErrCases take a ts-pattern matcher and
+// --- error triage: mapErrCases/flatMapErrCases/recoverErrCases take a matcher and
 // --- call `.exhaustive()` for you; the callback returns the un-terminated builder
 
 {
@@ -731,7 +765,7 @@ new WithMsg({ ticketId: "t1" });
 }
 
 // --- error matching works on ANY discriminant, and is always exhaustive -------
-// ts-pattern matches by structure, so a non-`_tag` union (untagged, or the
+// The matcher matches by structure, so a non-`_tag` union (untagged, or the
 // `code`-discriminated orpc shape) is handled the same way — and the builder is
 // exhaustive-by-construction (a missing case makes `.exhaustive()` uncallable).
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,8 +1,7 @@
 // unthrown — public type surface. Pure types, no runtime.
 
-import type { match } from "ts-pattern";
-
 import type { Defect } from "./defect.js";
+import type { match } from "./matcher.js";
 
 /**
  * Flatten an intersection into a single object literal so accumulated `bind` /
@@ -43,14 +42,14 @@ export type NotThenable<R> = [R] extends [PromiseLike<unknown>]
   : unknown;
 
 /**
- * The ts-pattern match builder over an error union `E`, as produced by
+ * The built-in match builder over an error union `E`, as produced by
  * `match(error)`. This is what an error combinator's callback receives — chain
  * `.with(pattern, handler)` on it; the combinator itself calls `.exhaustive()`,
  * so the callback returns the **un-terminated** builder.
  *
  * @remarks
- * Named via `ReturnType<typeof match<E>>` so the internal ts-pattern `Match`
- * type (not part of ts-pattern's public exports) never has to be imported.
+ * Named via `ReturnType<typeof match<E>>` (i.e. `Matcher<E, E, never>`),
+ * keeping this alias stable however the builder evolves.
  *
  * @typeParam E - the error union being matched.
  * @category Types
@@ -59,8 +58,8 @@ export type ErrMatcher<E> = ReturnType<typeof match<E>>;
 
 /**
  * The shape an error-combinator callback must return: an **exhaustive**
- * ts-pattern builder. `exhaustive` is required to be *callable* — on a builder
- * that hasn't covered every case ts-pattern types it as a `NonExhaustiveError`
+ * match builder. `exhaustive` is required to be *callable* — on a builder
+ * that hasn't covered every case the matcher types it as a branded diagnostic
  * (not a function), so a non-exhaustive chain fails to satisfy this and errors
  * at the call site. `run` carries the output type.
  *
@@ -269,7 +268,7 @@ export type ResultMethods<out T, out E> = {
   ): Result<T, E | E2>;
 
   /**
-   * Transform the modeled error by **matching it exhaustively** with ts-pattern.
+   * Transform the modeled error by **matching it exhaustively**.
    *
    * @remarks
    * The callback receives `match(error)` (an {@link ErrMatcher}) and the
@@ -283,7 +282,7 @@ export type ResultMethods<out T, out E> = {
    * pass through. A branch that throws also becomes a `Defect`.
    *
    * `.with(P._, …)` is the deliberate uniform/catch-all (it makes the match
-   * exhaustive). Match on anything ts-pattern supports — `_tag`, `code`,
+   * exhaustive). Match on anything the matcher supports — `_tag`, `code`,
    * structural shape, guards, or grouped patterns `.with(a, b, handler)`.
    *
    * @typeParam M - the exhaustive builder the callback returns.
@@ -657,7 +656,7 @@ export type FailureView<E, T = never> = ErrView<E, T> | DefectView<T, E>;
  *   never appears in `E`; it is the library's third, out-of-band channel.
  *
  * Because it is a real union, you can match it natively (a `switch` on `tag`, or
- * `ts-pattern`'s `match(...).with({ tag: "Ok" }, …).exhaustive()`), *and* it
+ * the built-in `match(...).with({ tag: "Ok" }, …).exhaustive()`), *and* it
  * carries the full method surface ({@link ResultMethods}) for fluent chaining.
  * Either way, the payload (`value`/`error`/`cause`) is only reachable after you
  * narrow — so "check before you access" still holds.

--- a/packages/core/typedoc.json
+++ b/packages/core/typedoc.json
@@ -24,6 +24,8 @@
     "ResultRecord",
     "AsyncResultRecord",
     "ExhaustiveMatch",
-    "MatchOut"
+    "MatchOut",
+    "NonExhaustive",
+    "MatchedOf"
   ]
 }

--- a/packages/orpc/src/server.ts
+++ b/packages/orpc/src/server.ts
@@ -91,7 +91,7 @@ export function handlerResult<
     const result = await handler(opts, input);
     // Branch via the guards rather than `match`: this library code is generic in
     // the error type `TError`, and `match`'s exhaustive `errCases` matcher cannot be
-    // proven exhaustive by ts-pattern over an unresolved type parameter. The
+    // proven exhaustive by tag arms over an unresolved type parameter. The
     // concrete triage (`.mapErrCases((matcher) => …)`) still happens at the endpoint.
     if (result.isOk()) return result.value;
     if (result.isErr()) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,9 +81,6 @@ catalogs:
     prisma:
       specifier: 7.8.0
       version: 7.8.0
-    ts-pattern:
-      specifier: 5.9.0
-      version: 5.9.0
     tsdown:
       specifier: 0.22.12
       version: 0.22.12
@@ -242,9 +239,6 @@ importers:
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.10(vitest@4.1.10)
-      ts-pattern:
-        specifier: 'catalog:'
-        version: 5.9.0
       tsdown:
         specifier: 'catalog:'
         version: 0.22.12(oxc-resolver@11.21.3)(tsx@4.23.1)(typescript@6.0.3)
@@ -3738,9 +3732,6 @@ packages:
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
-  ts-pattern@5.9.0:
-    resolution: {integrity: sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==}
-
   tsdown@0.22.12:
     resolution: {integrity: sha512-IzGRfGwSsufXJWOcQ0tmECKMG/dbxhUwDOySTS7JE1AM8pkB9+bpcTPs8bTxxSNrSvGocSczrBlOh97tZObq9Q==}
     engines: {node: ^22.18.0 || >=24.11.0}
@@ -6929,8 +6920,6 @@ snapshots:
   tree-kill@1.2.2: {}
 
   trim-lines@3.0.1: {}
-
-  ts-pattern@5.9.0: {}
 
   tsdown@0.22.12(oxc-resolver@11.21.3)(tsx@4.23.1)(typescript@6.0.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,7 +34,6 @@ catalog:
   oxfmt: 0.59.0
   oxlint: 1.74.0
   prisma: 7.8.0
-  ts-pattern: 5.9.0
   tsdown: 0.22.12
   tsx: 4.23.1
   turbo: 2.10.5


### PR DESCRIPTION
Replaces the `ts-pattern` peer dependency with unthrown's **own built-in matcher** — same call-site shape (`.with(pattern, …patterns, handler)`, `tag(t)`, `P`), owned type machinery, **zero runtime dependencies**.

### Why
- **The guarantee becomes ours.** Exhaustiveness is unthrown's central promise, and it was computed by a third-party library whose semantics vary within the peer range (ts-pattern changed optional-discriminant exhaustiveness in a *minor*, 5.8). The built-in matcher computes it with plain `Exclude` over a tracked `Remaining` parameter — shallow, fast, stable.
- **Closes #145 by construction.** The catch-all arm is a *state transition* to `Remaining = never` (an overload keyed on the statically-universal `P._` type — no deferred `Exclude`), so `.with(P._, …)` is provably exhaustive even over an **unresolved generic `E`**. The reopened repro (`resultToActivityPromise`) is now a positive type-d test. Tag arms alone remain correctly unprovable over generic `E`.
- **Readable diagnostics.** A non-exhaustive builder's `.exhaustive` is a branded object naming the unhandled cases — no five-layer conditional dumps.
- **No install friction.** The peer (added in beta.5) is gone; `pnpm add unthrown` is the whole story.

### Scope
- `matcher.ts`: runtime (~70 lines) + types. Patterns: literals, (nested) object discriminants (`{ _tag }`, `{ code }`), `P._`/`P.any`, `P.instanceOf`, `P.when`, `P.union`, `P.string`, `P.number`, grouped arms. Deliberately dropped: deep structural inversion, `P.select`, array patterns.
- Exports: `match`, `P`, `NonExhaustiveError` (+ `Matcher`/`PatternMatcher`/`UniversalPattern` types). `tag()` unchanged (it always returned a plain `{ _tag }` object).
- Docs: CLAUDE.md thesis/invariants/status, READMEs + install pages, upgrade guide + MIGRATION.md, and the exhaustive-error-matching guide's generic-helpers section flipped from "limitation" to "the catch-all works".

### Validation
The **entire pre-existing suite passes unchanged** against the new engine — 263 runtime tests + the full type-d suite (narrowing, grouped patterns, `code`-discriminated and untagged unions, forced exhaustiveness, defect-branch subtraction, the `out E` variance regression guard, async-branch rejection) — plus `matcher.spec.ts` (10 engine tests; coverage above thresholds) and new generic-`E` type-d probes. Full gate green: format, lint, typecheck, knip, test, build, typedoc warning-free. Bundle: +~1 kB gzip while deleting the entire ts-pattern install.

### Breaking edges (in the changeset)
- Real-ts-pattern patterns are no longer accepted by unthrown matchers (import `P`/`match`/`tag` from `"unthrown"`); keep `ts-pattern` only if your own code uses it for unrelated matching.
- Rogue unmatched values throw unthrown's own `NonExhaustiveError`.

Closes #145