### PR TITLE
feat(core)!: move the tag pattern onto the P namespace as P.tag

### DIFF
--- a/.changeset/built-in-matcher.md
+++ b/.changeset/built-in-matcher.md
@@ -2,13 +2,14 @@
 "unthrown": major
 ---
 
-**The exhaustive matcher is now built-in — the `ts-pattern` peer dependency is
-removed.** `match`, `P`, and the new `NonExhaustiveError` are unthrown's own
-(`Matcher` / `PatternMatcher` / `UniversalPattern` types included), keeping the
-exact call-site shape: `.with(pattern, …patterns, handler)`, `P.tag(t)`, grouped
-patterns, and `P._` / `P.any` / `P.instanceOf` / `P.when` / `P.union` /
-`P.string` / `P.number`. Most code needs **no changes** beyond deleting
-`ts-pattern` from your dependencies (if you only added it for unthrown).
+**The exhaustive matcher is now built-in — core carries no `ts-pattern`
+dependency, plain or peer.** `match`, `P`, and the new `NonExhaustiveError` are
+unthrown's own (`Matcher` / `PatternMatcher` / `UniversalPattern` types
+included), keeping the exact call-site shape:
+`.with(pattern, …patterns, handler)`, `P.tag(t)`, grouped patterns, and `P._` /
+`P.any` / `P.instanceOf` / `P.when` / `P.union` / `P.string` / `P.number`. Most
+code needs **no changes** beyond deleting `ts-pattern` from your dependencies
+(if you only added it for unthrown).
 
 Why: exhaustiveness is unthrown's central promise, and delegating it to a peer
 meant the guarantee could vary with whichever ts-pattern version a consumer

--- a/.changeset/built-in-matcher.md
+++ b/.changeset/built-in-matcher.md
@@ -5,7 +5,7 @@
 **The exhaustive matcher is now built-in — the `ts-pattern` peer dependency is
 removed.** `match`, `P`, and the new `NonExhaustiveError` are unthrown's own
 (`Matcher` / `PatternMatcher` / `UniversalPattern` types included), keeping the
-exact call-site shape: `.with(pattern, …patterns, handler)`, `tag(t)`, grouped
+exact call-site shape: `.with(pattern, …patterns, handler)`, `P.tag(t)`, grouped
 patterns, and `P._` / `P.any` / `P.instanceOf` / `P.when` / `P.union` /
 `P.string` / `P.number`. Most code needs **no changes** beyond deleting
 `ts-pattern` from your dependencies (if you only added it for unthrown).
@@ -27,9 +27,9 @@ unprovable over a generic `E`.
 Breaking edges:
 
 - Patterns built by the real `ts-pattern` library are no longer accepted by
-  unthrown's matchers (and unthrown's `P` is not ts-pattern's). Import `match`
-  / `P` / `tag` from `"unthrown"` at unthrown call sites; keep `ts-pattern`
-  for unrelated matching if your own code uses it.
+  unthrown's matchers (and unthrown's `P` is not ts-pattern's). Import `match` /
+  `P` from `"unthrown"` at unthrown call sites; keep `ts-pattern` for unrelated
+  matching if your own code uses it.
 - Deliberately unsupported patterns: deep structural inversion, `P.select`,
   array patterns, and the other ts-pattern-only `P.*` members. The supported
   vocabulary is the error channel's: literals, (nested) object discriminants

--- a/.changeset/exhaustive-error-matcher.md
+++ b/.changeset/exhaustive-error-matcher.md
@@ -10,7 +10,7 @@ ts-pattern match builder over the error (`match(error)`) plus the injected
 calls `.exhaustive()` for you:
 
 ```ts
-import { P, tag } from "unthrown";
+import { P } from "unthrown";
 
 // before
 result.mapErr((error) => {
@@ -21,8 +21,8 @@ result.mapErr((error) => {
 // after — exhaustive; the type checker forces every case to be handled
 result.mapErrCases((matcher, defect) =>
   matcher
-    .with(tag("RecordNotFound"), () => new NotFoundException(id))
-    .with(tag("DriverError"), (e) => defect(e.cause)),
+    .with(P.tag("RecordNotFound"), () => new NotFoundException(id))
+    .with(P.tag("DriverError"), (e) => defect(e.cause)),
 );
 ```
 
@@ -35,7 +35,7 @@ no `.exhaustive()` to forget and no `.otherwise()` to smuggle in a fallback.
 
 - **Match on anything ts-pattern supports** — `_tag`, a `code`-discriminated
   union (the oRPC shape), structural shapes, guards, and grouped patterns
-  (`.with(a, b, handler)` — one strategy for several cases). `tag("X")` is sugar
+  (`.with(a, b, handler)` — one strategy for several cases). `P.tag("X")` is sugar
   for the `{ _tag: "X" }` pattern.
 - **Name the cases; group the ones that share a handler** — `.with(a, b, handler)`
   writes the handler once and still spells every case out, which is what keeps a
@@ -43,18 +43,18 @@ no `.exhaustive()` to forget and no `.otherwise()` to smuggle in a fallback.
   (principally a helper generic in `E`, where no arm list can prove coverage),
   not as a drop-in for the old single callback.
 - Each branch receives the narrowed variant **and the injected `defect` helper**
-  (`.with(tag("X"), (e) => defect(e.cause))`); its `Defect` arm is subtracted
+  (`.with(P.tag("X"), (e) => defect(e.cause))`); its `Defect` arm is subtracted
   from the outgoing `E` (`Exclude<O, Defect>`, the boundary inference). A
   throwing branch also becomes a `Defect` (the safety net).
 - **Observers match exhaustively too** (`tapErrCases`/`flatTapErrCases`, with the
   same named arms); the error is observed and flows through unchanged.
 
 **Core now depends on `ts-pattern`** (a small, types-heavy, dual-copy-safe
-library), and re-exports `match` and `P`, plus `tag` — so the matcher, and
-matching a whole `Result` (`match(r).with(P.Ok(), …)`), are first-class in one
-import. **The `@unthrown/pattern` package is removed** — its `tag` helper moved
-into core; the `P.Ok`/`P.Err`/`P.Defect` sugar is dropped (match the union
-structurally instead).
+library), and re-exports `match` and `P` — so the matcher, and matching a whole
+`Result` (`match(r).with(P.Ok(), …)`), are first-class in one import. **The
+`@unthrown/pattern` package is removed** — its `tag` helper is now core's
+`P.tag(t)` pattern constructor; the `P.Ok`/`P.Err`/`P.Defect` sugar is dropped
+(match the union structurally instead).
 
 **`match` now matches the error channel exhaustively too, and `matchTags` is
 removed.** `match`'s error handler no longer takes a blanket `(error) => R`
@@ -63,11 +63,11 @@ builder (no `defect` helper: `match` folds to a value, with no `Defect` output
 channel). It is also **renamed `err` → `errCases`** to match the combinators and
 to make the change loud (a leftover 4.x `err:` handler is now an
 excess-property compile error). This subsumes the old `matchTags` fold — a per-tag fold over a tagged
-union is now `match` with the matcher and `tag(t)`, and it generalises to any
+union is now `match` with the matcher and `P.tag(t)`, and it generalises to any
 discriminant, not only `_tag`:
 
 ```ts
-import { P, tag } from "unthrown";
+import { P } from "unthrown";
 
 // before
 matchTags(result, {
@@ -82,16 +82,18 @@ result.match({
   ok: (n) => `got ${n}`,
   defect: (cause) => `bug: ${String(cause)}`,
   errCases: (matcher) =>
-    matcher.with(tag("NotFound"), () => "404").with(tag("Forbidden"), (e) => `403 for ${e.user}`),
+    matcher
+      .with(P.tag("NotFound"), () => "404")
+      .with(P.tag("Forbidden"), (e) => `403 for ${e.user}`),
 });
 ```
 
 Name every case here too, grouping the ones that share a handler; `.with(P._, …)`
 stays an escape hatch, not the shape to reach for first. `matchTags` and its
-`TagHandlers` type are gone; `TaggedError` and `tag` are unchanged. **Library
-code generic in the error type `E`** (which ts-pattern can't prove exhaustive
-over an unresolved type parameter) should fold with the `isOk` / `isErr` /
-`isDefect` guards instead of `match`.
+`TagHandlers` type are gone; `TaggedError` is unchanged. **Library code generic
+in the error type `E`** (which ts-pattern can't prove exhaustive over an
+unresolved type parameter) should fold with the `isOk` / `isErr` / `isDefect`
+guards instead of `match`.
 
 **Also breaking:** the deprecated error-channel aliases `orElse` and `recover`
 are removed; the extractor aliases (`unwrap`, `unwrapErr`, `unwrapOr`,

--- a/.changeset/exhaustive-error-matcher.md
+++ b/.changeset/exhaustive-error-matcher.md
@@ -2,10 +2,10 @@
 "unthrown": major
 ---
 
-**The error channel is now matched exhaustively with ts-pattern** (Thesis #5).
+**The error channel is now matched exhaustively** (Thesis #5).
 The error combinators — `mapErrCases`, `flatMapErrCases`, `recoverErrCases`, `tapErrCases`,
 `flatTapErrCases` — no longer take a plain callback. Their callback receives a
-ts-pattern match builder over the error (`match(error)`) plus the injected
+match builder over the error (`match(error)`) plus the injected
 `defect` helper, and **returns the un-terminated builder** — the combinator
 calls `.exhaustive()` for you:
 
@@ -33,7 +33,7 @@ compile error at every consuming site** until each new case is handled. Because
 the combinator runs `.exhaustive()`, a missing case does not compile — there is
 no `.exhaustive()` to forget and no `.otherwise()` to smuggle in a fallback.
 
-- **Match on anything ts-pattern supports** — `_tag`, a `code`-discriminated
+- **Match on any discriminant** — `_tag`, a `code`-discriminated
   union (the oRPC shape), structural shapes, guards, and grouped patterns
   (`.with(a, b, handler)` — one strategy for several cases). `P.tag("X")` is sugar
   for the `{ _tag: "X" }` pattern.
@@ -49,16 +49,17 @@ no `.exhaustive()` to forget and no `.otherwise()` to smuggle in a fallback.
 - **Observers match exhaustively too** (`tapErrCases`/`flatTapErrCases`, with the
   same named arms); the error is observed and flows through unchanged.
 
-**Core now depends on `ts-pattern`** (a small, types-heavy, dual-copy-safe
-library), and re-exports `match` and `P` — so the matcher, and matching a whole
-`Result` (`match(r).with(P.Ok(), …)`), are first-class in one import. **The
-`@unthrown/pattern` package is removed** — its `tag` helper is now core's
-`P.tag(t)` pattern constructor; the `P.Ok`/`P.Err`/`P.Defect` sugar is dropped
-(match the union structurally instead).
+**The matcher is built into core**, which keeps **zero runtime dependencies**:
+`match`, `P`, and `NonExhaustiveError` are unthrown's own exports — so the
+matcher, and matching a whole `Result` (`match(r).with({ tag: "Ok" }, …)`), are
+first-class in one import. **The `@unthrown/pattern` package is removed** — its
+`match` / `P` are core's now, and its `tag` helper is the `P.tag(t)` pattern
+constructor; the `P.Ok`/`P.Err`/`P.Defect` sugar is dropped (match the union
+structurally instead).
 
 **`match` now matches the error channel exhaustively too, and `matchTags` is
 removed.** `match`'s error handler no longer takes a blanket `(error) => R`
-callback — it receives the same ts-pattern matcher and returns the un-terminated
+callback — it receives the same exhaustive matcher and returns the un-terminated
 builder (no `defect` helper: `match` folds to a value, with no `Defect` output
 channel). It is also **renamed `err` → `errCases`** to match the combinators and
 to make the change loud (a leftover 4.x `err:` handler is now an
@@ -91,11 +92,13 @@ result.match({
 Name every case here too, grouping the ones that share a handler; `.with(P._, …)`
 stays an escape hatch, not the shape to reach for first. `matchTags` and its
 `TagHandlers` type are gone; `TaggedError` is unchanged. **Library code generic
-in the error type `E`** (which ts-pattern can't prove exhaustive over an
-unresolved type parameter) should fold with the `isOk` / `isErr` / `isDefect`
-guards instead of `match`.
+in the error type `E`** can still fold with the `isOk` / `isErr` / `isDefect`
+guards — the simplest shape when no per-case branching is needed — but `match`
+works there too, terminated by the `.with(P._, …)` catch-all: it is the one arm
+provable against an unresolved type parameter.
 
 **Also breaking:** the deprecated error-channel aliases `orElse` and `recover`
-are removed; the extractor aliases (`unwrap`, `unwrapErr`, `unwrapOr`,
-`unwrapOrElse`) remain. `AsyncOkOf` / `AsyncErrOf` now infer through the
-awaitable channel only (same results for ordinary `AsyncResult` types).
+are removed, as are the extractor aliases `unwrap` / `unwrapErr` / `unwrapOr` /
+`unwrapOrElse` (see the extractor entry). `AsyncOkOf` / `AsyncErrOf` now infer
+through the awaitable channel only (same results for ordinary `AsyncResult`
+types).

--- a/.changeset/oxlint-catch-all-recommended.md
+++ b/.changeset/oxlint-catch-all-recommended.md
@@ -23,8 +23,8 @@ exhaustive by construction, so the compiler tells you when the list is complete:
 ```ts
 result.mapErrCases((matcher) =>
   matcher
-    .with(tag("NotFound"), () => new ApiError({ status: 404 }))
-    .with(tag("Conflict"), tag("DriverError"), (e) => new ApiError({ status: 500, error: e })),
+    .with(P.tag("NotFound"), () => new ApiError({ status: 404 }))
+    .with(P.tag("Conflict"), P.tag("DriverError"), (e) => new ApiError({ status: 500, error: e })),
 );
 ```
 

--- a/.changeset/oxlint-four-rules.md
+++ b/.changeset/oxlint-four-rules.md
@@ -2,7 +2,7 @@
 "@unthrown/oxlint": minor
 ---
 
-**Two new rules, and sharper resolution in the existing two.**
+**Two new rules, and sharper resolution in the two carried over from 4.x.**
 
 - New `no-unhandled-result` (in the recommended preset): flags a bare
   statement dropping a `Result` — a call to an unthrown-imported producer, a
@@ -13,7 +13,7 @@
 - New `no-throw` (opt-in, not in the preset): reports every `throw` statement,
   pointing at `Err(...)`, `getOrThrow()`, and `fromSafeThrowable` — the rule
   the `getOrThrow` design has always referenced.
-- Both existing rules now resolve bindings by the **imported** name:
+- Both 4.x rules now resolve bindings by the **imported** name:
   `import { Result as R }` is caught, `import { Ok as Result }` no longer
   false-positives, and namespace-qualified `U.Result<…>` is flagged.
 - `no-ambiguous-error-type` also flags `void` in `E`, and a false negative

--- a/.changeset/oxlint-no-catch-all-pattern.md
+++ b/.changeset/oxlint-no-catch-all-pattern.md
@@ -4,8 +4,8 @@
 
 **New rule `unthrown/no-catch-all-pattern`.** Bans the matcher catch-all `P._`
 (and its alias `P.any`) wherever `P` is imported from `unthrown` or `ts-pattern`,
-so every error case must be enumerated by name (`.with(tag("A"), tag("B"), …,
-handler)`, grouping cases that share a handler).
+so every error case must be enumerated by name (`.with(P.tag("A"), P.tag("B"),
+…, handler)`, grouping cases that share a handler).
 
 Resolves `P` by its imported name via scope analysis (a rename still fires; a
 decoy does not); a namespace import (`ns.P._`) is a documented limit. It is part

--- a/.changeset/oxlint-p-tag-message.md
+++ b/.changeset/oxlint-p-tag-message.md
@@ -1,0 +1,9 @@
+---
+"@unthrown/oxlint": patch
+---
+
+Update `no-catch-all-pattern`'s diagnostic and documentation to spell the
+recommended form as `.with(P.tag("A"), P.tag("B"), …, handler)`, following
+core's move of the `tag` pattern constructor onto the `P` namespace. No rule
+behaviour, name, or option changed — only the guidance text a developer reads
+when the rule fires.

--- a/.changeset/p-tag-pattern.md
+++ b/.changeset/p-tag-pattern.md
@@ -1,0 +1,33 @@
+---
+"unthrown": major
+---
+
+**`tag(t)` moves onto the pattern namespace as `P.tag(t)`; the standalone
+`tag` export is removed.** `tag` is a pattern constructor, and every other one
+already lives on `P` (`P._` / `P.any` / `P.instanceOf` / `P.when` / `P.union` /
+`P.string` / `P.number`) — having exactly one of them sitting loose in the root
+export was the odd one out. There is no alias: one concept, one name.
+
+The type and the runtime behaviour are unchanged — it still produces the
+`{ _tag: t }` object pattern, still narrows to the matching variant with its
+payload, and still works in grouped patterns and inside `P.union`.
+
+Migration is mechanical: drop `tag` from the import (keeping or adding `P`) and
+prefix the call sites.
+
+```diff
+- import { tag } from "unthrown";
++ import { P } from "unthrown";
+
+  result.mapErrCases((matcher) =>
+    matcher
+-     .with(tag("NotFound"), () => new ApiError({ status: 404 }))
+-     .with(tag("Conflict"), tag("DriverError"), (e) => defect(e.cause)),
++     .with(P.tag("NotFound"), () => new ApiError({ status: 404 }))
++     .with(P.tag("Conflict"), P.tag("DriverError"), (e) => defect(e.cause)),
+  );
+```
+
+`TaggedError` (and the `TaggedErrorConstructor` / `TaggedErrorInstance` types)
+are untouched and still exported from the root — only the matcher pattern
+moved.

--- a/.changeset/p-tag-pattern.md
+++ b/.changeset/p-tag-pattern.md
@@ -13,7 +13,9 @@ The type and the runtime behaviour are unchanged — it still produces the
 payload, and still works in grouped patterns and inside `P.union`.
 
 Migration is mechanical: drop `tag` from the import (keeping or adding `P`) and
-prefix the call sites.
+prefix the call sites. (The `- import { tag } from "unthrown"` line below is the
+v5-beta spelling; coming from 4.x the import was `@unthrown/pattern`, which is
+gone — see the v5 upgrade guide.)
 
 ```diff
 - import { tag } from "unthrown";

--- a/.changeset/rename-err-combinators-cases.md
+++ b/.changeset/rename-err-combinators-cases.md
@@ -16,7 +16,7 @@ Migration is a rename at every call site:
 
 ```diff
 - result.mapErr((m) => m.with(tag("NotFound"), wrap))
-+ result.mapErrCases((m) => m.with(tag("NotFound"), wrap))
++ result.mapErrCases((m) => m.with(P.tag("NotFound"), wrap))
 ```
 
 **`match`'s error handler is renamed the same way — `err` → `errCases`** — for
@@ -31,7 +31,7 @@ the key turns that into an excess-property compile error.
   result.match({
     ok: (value) => value,
 -   err: (matcher) => matcher.with(tag("NotFound"), wrap),
-+   errCases: (matcher) => matcher.with(tag("NotFound"), wrap),
++   errCases: (matcher) => matcher.with(P.tag("NotFound"), wrap),
     defect: (cause) => report(cause),
   })
 ```

--- a/.changeset/rename-err-combinators-cases.md
+++ b/.changeset/rename-err-combinators-cases.md
@@ -6,13 +6,16 @@
 `flatMapErr`, `recoverErr`, `tapErr`, and `flatTapErr` become `mapErrCases`,
 `flatMapErrCases`, `recoverErrCases`, `tapErrCases`, and `flatTapErrCases`.
 
-Each takes a ts-pattern matcher over the error's _cases_, not the error value —
+Each takes an exhaustive matcher over the error's _cases_, not the error value —
 so the suffix names that protocol and keeps it distinct from the value-taking
 success surface (`map` / `tap`). A bare `mapErr((e) => …)` would promise a
 functor-style callback the combinators never accept; there is deliberately no
 such variant.
 
-Migration is a rename at every call site:
+Migration is a rename at every call site. (The `-` lines here and below are the
+pre-rename v5-beta spelling, matcher callback included; coming from 4.x, `mapErr`
+and `match`'s `err` took a plain `(error) => …` callback — see the
+exhaustive-matcher entry for that step.)
 
 ```diff
 - result.mapErr((m) => m.with(tag("NotFound"), wrap))
@@ -20,7 +23,7 @@ Migration is a rename at every call site:
 ```
 
 **`match`'s error handler is renamed the same way — `err` → `errCases`** — for
-the same reason: it takes the exhaustive ts-pattern matcher, not a plain
+the same reason: it takes the same exhaustive matcher, not a plain
 `(error) => …` callback. This also makes the change **loud** where it would
 otherwise be silent: a leftover 4.x `err: (error) => …` handler still compiled
 under the matcher constraint (a throwing handler returns `never`, which

--- a/.changeset/ts-pattern-peer-dependency.md
+++ b/.changeset/ts-pattern-peer-dependency.md
@@ -2,16 +2,20 @@
 "unthrown": major
 ---
 
-**`ts-pattern` is now a `peerDependency` (`^5`), not a plain dependency.** Core
-re-exports `match` / `P` and its error matchers speak ts-pattern's builder type.
-When ts-pattern was a nested, exact-pinned dependency, a consumer
-who already used ts-pattern at another version ended up with two copies whose
-declarations don't unify — feeding a `P.union(...)` built by one copy into an
-unthrown matcher failed five layers deep in a conditional type.
+**Core takes no `ts-pattern` dependency — neither a plain one nor a peer.** An
+early v5 beta shipped it nested and exact-pinned, and that copy's declarations
+did not unify with a consumer's own: feeding a `P.union(...)` built by one copy
+into an unthrown matcher failed five layers deep in a conditional type. Making
+it a peer settled the duplication, but at the price of an install obligation on
+every consumer — and it left unthrown's central guarantee, exhaustiveness, at
+the mercy of whichever version the consumer resolved.
 
-Declaring it as a peer guarantees a single copy the consumer owns, so
-`import { P } from "ts-pattern"` composes with unthrown's matchers as expected.
+The matcher is built into core instead, so neither problem remains: `match` /
+`P` / `NonExhaustiveError` come from `"unthrown"` itself, there is only ever one
+copy of the builder type, and nothing has to be installed alongside the package
+(see the built-in matcher entry).
 
-**Action required:** add `ts-pattern` (`^5`) to your own dependencies if you
-don't already depend on it. Most package managers surface this as a missing-peer
-warning on install.
+**Action required:** none on a fresh v5 install. If you added `ts-pattern` only
+for unthrown's sake, drop it; keep it if your own code matches with it, and
+import `P` from `"unthrown"` at unthrown call sites — the two `P`s are not
+interchangeable.

--- a/.changeset/ts-pattern-peer-dependency.md
+++ b/.changeset/ts-pattern-peer-dependency.md
@@ -3,8 +3,8 @@
 ---
 
 **`ts-pattern` is now a `peerDependency` (`^5`), not a plain dependency.** Core
-re-exports `match` / `P` / `tag` and its error matchers speak ts-pattern's
-builder type. When ts-pattern was a nested, exact-pinned dependency, a consumer
+re-exports `match` / `P` and its error matchers speak ts-pattern's builder type.
+When ts-pattern was a nested, exact-pinned dependency, a consumer
 who already used ts-pattern at another version ended up with two copies whose
 declarations don't unify — feeding a `P.union(...)` built by one copy into an
 unthrown matcher failed five layers deep in a conditional type.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ was planned).
    values cannot be silently dropped. The matcher matches by structure, so this
    works on any discriminant (`_tag`, `code`, guards, grouped patterns), not
    only `TaggedError`. **Every case is named** — that is the default position,
-   and cases sharing a handler are grouped (`.with(tag("A"), tag("B"), h)`)
+   and cases sharing a handler are grouped (`.with(P.tag("A"), P.tag("B"), h)`)
    rather than collapsed into a wildcard. `P._` is an **escape hatch**, not the
    sanctioned way to handle the channel: it makes any match exhaustive, so it
    absorbs unnamed every case `E` grows later — precisely the blanket-handling
@@ -89,7 +89,7 @@ was planned).
    `oxlint-disable` with a reason. Each branch
    receives the narrowed variant and the **injected `defect` helper** — the
    same injection `qualify` gets (Thesis #3), the sanctioned deliberate
-   `Err`→`Defect` form (`.with(tag("DriverError"), (e) => defect(e.cause))`);
+   `Err`→`Defect` form (`.with(P.tag("DriverError"), (e) => defect(e.cause))`);
    the outgoing type is the builder's output **with the `Defect` arm
    subtracted** (`Exclude<O, Defect>`, exactly the boundary inference), so a
    defect branch — or a throwing one, the safety net — contributes nothing.
@@ -116,14 +116,14 @@ was planned).
    plain value, with no `Defect` output channel; the separate `defect` case
    handles a `Result` that already carries one. (This subsumes the former
    `matchTags` fold — per-tag folding at the edge is now `match` with the
-   matcher and `tag(t)`, and it works on any discriminant, not only `_tag`.) The
-   value-surrendering extractors (`getOr` / `getOrElse` / `getOrNull` /
+   matcher and `P.tag(t)`, and it works on any discriminant, not only `_tag`.)
+   The value-surrendering extractors (`getOr` / `getOrElse` / `getOrNull` /
    `getOrUndefined`) stay exempt — the value is being surrendered anyway. **The
    matcher is built-in** (`matcher.ts` — it replaced the former `ts-pattern`
    peer, keeping its call-site shape): a purpose-built, shallow matcher whose
    exhaustiveness is plain `Exclude` over a tracked `Remaining` parameter, with
-   `match`, `P` (`_`/`any`, `instanceOf`, `when`, `union`, `string`, `number`),
-   `returnType<R>()` (declare the output type once — every branch is checked
+   `match`, `P` (`_`/`any`, `tag`, `instanceOf`, `when`, `union`, `string`,
+   `number`), `returnType<R>()` (declare the output type once — every branch is checked
    against it, and the match evaluates to `R` instead of the union of the branch
    returns; callable before any arm has produced an output and only once — in
    practice directly after `match(…)`, though an arm returning `never` closes
@@ -377,10 +377,11 @@ Defect>`); flatMapErrCases: `OkOf`/`ErrOf` — plus `AsyncOkOf`/`AsyncErrOf` on 
 - matcher exports: `match`, `P`, and `NonExhaustiveError` come from the
   built-in `matcher.ts` (plus the types `Matcher`/`PatternMatcher`/
   `UniversalPattern`; the builder also carries `returnType<R>()`, which pins
-  the output type — see Thesis #5), and `tag(t)` (the `{ _tag: t }` pattern,
-  narrowing to
-  the variant + payload) lives in `tagged.ts`. These make the error matcher,
-  and matching a whole `Result` (`match(r).with({ tag: "Ok" }, …)`),
+  the output type — see Thesis #5). Every pattern constructor lives on `P`,
+  `P.tag(t)` (the `{ _tag: t }` pattern, narrowing to the variant + payload)
+  included — it is a pattern like `P.instanceOf` or `P.when`, so it is spelled
+  like one; there is **no** standalone `tag` export. These make the error
+  matcher, and matching a whole `Result` (`match(r).with({ tag: "Ok" }, …)`),
   first-class in one import — the former `@unthrown/pattern` package and the
   former `ts-pattern` re-exports, now one owned module.
 - guards: methods `isOk`/`isErr`/`isDefect` **and** standalone
@@ -483,11 +484,13 @@ Defect>`); flatMapErrCases: `OkOf`/`ErrOf` — plus `AsyncOkOf`/`AsyncErrOf` on 
   name; the payload reserves `name`, `message`, **and** `stack` via `?: never`
   (`cause` stays allowed — see Thesis #4), so the
   message is set per subclass with `override message = "…"`, never as a payload
-  field) and `tag(t)` (the `{ _tag: t }` matcher pattern, for use in the
-  error matchers, in `match`'s `errCases` handler, and in `match(result)`); see the
+  field). The matching half is `P.tag(t)` (the `{ _tag: t }` matcher pattern,
+  for use in the error matchers, in `match`'s `errCases` handler, and in
+  `match(result)`) — it sits with the other pattern constructors, not with
+  `TaggedError`; see the
   `TaggedError` convention in Thesis #4. **There is no `matchTags`** — a per-tag
   exhaustive fold over a tagged error union is `result.match({ ok, defect, errCases:
-(matcher) => matcher.with(tag("…"), …) })`, which generalises beyond `_tag` to
+(matcher) => matcher.with(P.tag("…"), …) })`, which generalises beyond `_tag` to
   any discriminant.
 
 Deliberately **excluded** for now: **generator** do-notation (`gen`/`yield*`
@@ -613,8 +616,9 @@ AsyncResult<infer T, …>` — structural inference over the whole method surfac
   `constructors.ts` (`Ok`/`Err` + guards), `do.ts` (the `Do()` do-notation entry
   — the `bind`/`let` steps themselves live on the method surface in `core.ts`),
   `interop.ts` (`from*`/`qualify`/`all`), `facade.ts` (the `Result` object),
-  `tagged.ts` (`TaggedError`/`tag`), `matcher.ts` (the built-in matcher —
-  `match`/`P`/`NonExhaustiveError` + the `Matcher` types), and `index.ts` (the
+  `tagged.ts` (`TaggedError`), `matcher.ts` (the built-in matcher —
+  `match`/`P` (`P.tag` included)/`NonExhaustiveError` + the `Matcher` types),
+  and `index.ts` (the
   curated public re-exports — the one place the API is decided).
 
 ## Monorepo layout
@@ -782,9 +786,10 @@ channel?**
    changesets `release.yml`.)
 2. ✅ **`packages/core/src/tagged.ts`** — Done. `TaggedError(tag)` factory
    (extends `Error`, `_tag`, no-arg constructor when payload is empty via the
-   `keyof A extends never ? void : A` trick) and `tag(t)` (the `{ _tag: t }`
-   matcher pattern). A per-tag exhaustive fold is `match`'s `errCases` handler
-   with the matcher (`matcher.with(tag("…"), …)`), not a dedicated
+   `keyof A extends never ? void : A` trick). Its matching half is the
+   `P.tag(t)` pattern (`{ _tag: t }`), which lives with the other pattern
+   constructors. A per-tag exhaustive fold is `match`'s `errCases` handler
+   with the matcher (`matcher.with(P.tag("…"), …)`), not a dedicated
    `matchTags` — that former helper was folded into `match` when the matcher
    became the error-channel convention.
 3. ✅ **`packages/vitest`** — Done. Custom matchers `toBeOk`, `toBeOkWith`,
@@ -801,8 +806,9 @@ channel?**
    matchers — the abandoned assertion is reported exactly once, correctly
    attributed, and can never late-fire as an unhandled rejection.
 4. ✅ **The built-in matcher** — Done. `matcher.ts` powers the exhaustive error
-   matchers (Thesis #5), exporting `match`/`P`/`NonExhaustiveError`, plus
-   `tag(t)` (the `{ _tag: t }` pattern). Because `Result` is a discriminated
+   matchers (Thesis #5), exporting `match`/`P`/`NonExhaustiveError` — `P`
+   carrying every pattern constructor, `P.tag(t)` (the `{ _tag: t }` pattern)
+   included. Because `Result` is a discriminated
    union (Thesis #1), `match(result).with({ tag: "Ok" }, …)` also matches a
    whole `Result` natively. (History: the standalone `@unthrown/pattern`
    package was folded into core when a `ts-pattern` dependency was taken in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,10 +48,9 @@ before proposing a change. In particular:
 
 - **oxlint rules are binding:** no `interface` (use `type`), no `any` (use
   `unknown`). Genuine exceptions carry a targeted `oxlint-disable` with a reason.
-- **Core has zero runtime dependencies** (the exhaustive error matcher is
-  built in — `packages/core/src/matcher.ts`, exported as `match` / `P` /
-  `NonExhaustiveError`). Add none — never pull `vitest` or any interop peer
-  into core.
+- **Core has exactly one runtime dependency, `ts-pattern`** (it powers the
+  exhaustive error matchers and is re-exported as `match`/`P`). Add no others —
+  never pull `vitest` or any interop peer into core.
 - **One name per concept.** Resist convenience aliases.
 - Public API carries full **TSDoc**; `pnpm --filter <pkg> build:docs` must stay
   warning-free.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,9 +48,10 @@ before proposing a change. In particular:
 
 - **oxlint rules are binding:** no `interface` (use `type`), no `any` (use
   `unknown`). Genuine exceptions carry a targeted `oxlint-disable` with a reason.
-- **Core has exactly one runtime dependency, `ts-pattern`** (it powers the
-  exhaustive error matchers and is re-exported as `match`/`P`). Add no others —
-  never pull `vitest` or any interop peer into core.
+- **Core has zero runtime dependencies** (the exhaustive error matcher is
+  built in — `packages/core/src/matcher.ts`, exported as `match` / `P` /
+  `NonExhaustiveError`). Add none — never pull `vitest` or any interop peer
+  into core.
 - **One name per concept.** Resist convenience aliases.
 - Public API carries full **TSDoc**; `pnpm --filter <pkg> build:docs` must stay
   warning-free.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -17,13 +17,15 @@ The headline breaking surface, so you have it up front:
 - **Removed 4.x aliases:** `unwrap` / `unwrapErr` / `unwrapOr` / `unwrapOrElse`
   (use `get` / `getErr` / `getOr` / `getOrElse`), `orElse` / `recover` (use
   `flatMapErrCases` / `recoverErrCases`), and `matchTags` / the `TagHandlers` type
-  (use `match({ …, errCases: (m) => m.with(tag("…"), …) })`).
+  (use `match({ …, errCases: (m) => m.with(P.tag("…"), …) })`).
 - **Renamed export:** `UnwrapError` → `GetError`.
 - **`getOrThrow()`** is now gated to a non-empty error channel; on a
   `Result<T, never>` use `get()`.
 - **The matcher is built-in** — nothing to install alongside `unthrown`. (The
   early v5 betas took `ts-pattern` as a peer; the built-in matcher replaced it,
-  keeping the same `.with(…)` / `tag` / `P` call-site shape.)
-- **`@unthrown/pattern` was absorbed into core** — import `match` / `P` / `tag`
-  from `unthrown`.
-- **New:** `ensure`, `DoAsync`, and the `match` / `P` / `tag` re-exports.
+  keeping the same `.with(…)` / `P` call-site shape.)
+- **`@unthrown/pattern` was absorbed into core** — import `match` / `P` from
+  `unthrown`.
+- **Renamed:** the standalone `tag("…")` pattern helper is now **`P.tag("…")`**,
+  alongside every other pattern constructor. The old export is removed.
+- **New:** `ensure`, `DoAsync`, and the `match` / `P` re-exports.

--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ pnpm add unthrown
 ```
 
 No peer dependencies — the exhaustive error matcher is built-in and exported as
-`match` / `P` / `tag`.
+`match` / `P`.
 
 ## Quick Example
 
 ```ts
-import { fromPromise, tag, TaggedError } from "unthrown";
+import { fromPromise, P, TaggedError } from "unthrown";
 
 // Our modeled domain failure:
 class NotFound extends TaggedError("NotFound") {}
@@ -73,7 +73,7 @@ const status = await user.match({
   ok: () => 200,
   // `errCases` receives the exhaustive matcher — name every case of E; adding
   // one to E is a compile error here until you handle it:
-  errCases: (matcher) => matcher.with(tag("NotFound"), () => 404),
+  errCases: (matcher) => matcher.with(P.tag("NotFound"), () => 404),
   defect: (cause) => {
     logger.error(cause); // everything unexpected
     return 500;

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -9,8 +9,8 @@ This reference is generated from the source with
   constructors (`Ok`, `Err` — a `Defect` has no constructor; it arises only at
   boundaries), guards, boundary interop (`fromNullable`, `fromThrowable`,
   `fromSafeThrowable`, `fromPromise`, `fromSafePromise`), aggregation (`all` /
-  `allFromDict`), the tagged-error utilities (`TaggedError`, `tag`), and the
-  built-in `match` / `P` that drive the exhaustive error matcher.
+  `allFromDict`), the tagged-error factory (`TaggedError`), and the built-in
+  `match` / `P` (`P.tag` included) that drive the exhaustive error matcher.
 - [**@unthrown/vitest**](./vitest/) — custom Vitest matchers (`toBeOk`,
   `toBeOkWith`, `toBeErr`, `toBeErrWith`, `toBeErrTagged`, `toBeDefect`).
 - [**@unthrown/effect**](./effect/) — bijective `Result ↔ Exit` bridges

--- a/docs/explanation/exhaustive-error-matching.md
+++ b/docs/explanation/exhaustive-error-matching.md
@@ -38,8 +38,8 @@ error, and you **return the un-terminated builder**. The combinator calls
 db.reading.tryFindUniqueOrThrow({ where: { id } }).mapErrCases(
   (matcher, defect) =>
     matcher
-      .with(tag("RecordNotFound"), () => new ReadingNotFoundException(id))
-      .with(tag("DriverError"), (e) => defect(e.cause)), // deliberate defect — the tag leaves E
+      .with(P.tag("RecordNotFound"), () => new ReadingNotFoundException(id))
+      .with(P.tag("DriverError"), (e) => defect(e.cause)), // deliberate defect — the tag leaves E
 );
 ```
 
@@ -77,7 +77,7 @@ through unchanged is a real decision with a real spelling:
 
 - to _observe_ and pass through, use `tapErrCases` (an observer);
 - to _re-emit_ cases unchanged, name them — grouped in one arm if they share the
-  treatment: `.with(tag("NotFound"), tag("Forbidden"), (e) => e)`.
+  treatment: `.with(P.tag("NotFound"), P.tag("Forbidden"), (e) => e)`.
 
 Grouped patterns are the honest form of "several cases, one strategy": the
 handler is written once, but every case is still spelled out, so enriching `E`
@@ -139,7 +139,8 @@ matcher exists to eliminate.
 ```ts
 result.match({
   ok: (v) => v,
-  errCases: (matcher) => matcher.with(tag("NotFound"), () => 404).with(tag("Forbidden"), () => 403),
+  errCases: (matcher) =>
+    matcher.with(P.tag("NotFound"), () => 404).with(P.tag("Forbidden"), () => 403),
   defect: (cause) => 500,
 });
 ```
@@ -190,7 +191,7 @@ input. There is no way to widen this hole from user code.
 // ❌ Still won't compile — and shouldn't: tag arms can never be shown to cover
 // an unresolved E. Only the catch-all (or a concrete union) can.
 function partial<T, E>(result: Result<T, E>) {
-  return result.mapErrCases((matcher) => matcher.with(tag("NotFound"), () => 404));
+  return result.mapErrCases((matcher) => matcher.with(P.tag("NotFound"), () => 404));
 }
 ```
 
@@ -258,8 +259,8 @@ result.mapErrCases(
   (matcher, defect) =>
     matcher
       .returnType<ApiError>()
-      .with(tag("RecordNotFound"), () => new ApiError({ status: 404 }))
-      .with(tag("DriverError"), (e) => defect(e.cause)), // still fine
+      .with(P.tag("RecordNotFound"), () => new ApiError({ status: 404 }))
+      .with(P.tag("DriverError"), (e) => defect(e.cause)), // still fine
 );
 ```
 

--- a/docs/explanation/the-defect-channel.md
+++ b/docs/explanation/the-defect-channel.md
@@ -67,7 +67,7 @@ throws `NonExhaustiveError` at runtime, which becomes a `Defect`. There is no
 "no-op" on the error channel — every branch of the union must be handled, which
 is the whole point (see [Exhaustive error matching](./exhaustive-error-matching)).
 To genuinely pass the error through unchanged, use an observer (`tapErrCases`) —
-or re-emit each case by name (`.with(tag("NotFound"), (e) => e)…`).
+or re-emit each case by name (`.with(P.tag("NotFound"), (e) => e)…`).
 :::
 
 ## `recoverErrCases` clears the error channel, not the runtime

--- a/docs/explanation/why-unthrown.md
+++ b/docs/explanation/why-unthrown.md
@@ -37,8 +37,8 @@ getUser(id)
     // every case in E is named — add a third and this stops compiling
     errCases: (matcher) =>
       matcher
-        .with(tag("NotFound"), () => showMessage("not found"))
-        .with(tag("Timeout"), () => showMessage("timed out")),
+        .with(P.tag("NotFound"), () => showMessage("not found"))
+        .with(P.tag("Timeout"), () => showMessage("timed out")),
     defect: report500,
   });
 ```

--- a/docs/how-to/handle-results-at-the-edge.md
+++ b/docs/how-to/handle-results-at-the-edge.md
@@ -24,7 +24,7 @@ modeled statuses are mapped in a `flatMap` (a `throw` there, like an unexpected
 status or malformed JSON, becomes a `Defect`):
 
 ```ts
-import { fromPromise, Err, tag } from "unthrown";
+import { fromPromise, Err, P } from "unthrown";
 
 const loadProfile = (id: string) =>
   // A network error (a rejected fetch) is unexpected → defect.
@@ -41,8 +41,8 @@ async function handler(id: string): Promise<HttpResponse> {
     ok: (profile) => ({ status: 200, body: profile }),
     errCases: (matcher) =>
       matcher
-        .with(tag("NotFound"), (e) => ({ status: 404, body: e }))
-        .with(tag("Forbidden"), (e) => ({ status: 403, body: e })),
+        .with(P.tag("NotFound"), (e) => ({ status: 404, body: e }))
+        .with(P.tag("Forbidden"), (e) => ({ status: 403, body: e })),
     defect: (cause) => {
       logger.error(cause); // a real bug — log it, don't leak it
       return { status: 500, body: "Internal Error" };
@@ -71,7 +71,7 @@ own `AsyncResult`, and `match`'s matcher folds every tag to a status code:
 import { Hono } from "hono";
 import { z } from "zod";
 import { fromSchema } from "@unthrown/standard-schema";
-import { P, tag, TaggedError, type AsyncResult } from "unthrown";
+import { P, TaggedError, type AsyncResult } from "unthrown";
 
 class InvalidId extends TaggedError("InvalidId") {}
 
@@ -96,8 +96,8 @@ app.get("/users/:id", (c) => {
     ok: (u) => c.json(u, 200),
     errCases: (matcher) =>
       matcher
-        .with(tag("InvalidId"), () => c.json({ error: "invalid id" }, 400))
-        .with(tag("NotFound"), (e) => c.json({ error: `no user ${e.id}` }, 404)),
+        .with(P.tag("InvalidId"), () => c.json({ error: "invalid id" }, 400))
+        .with(P.tag("NotFound"), (e) => c.json({ error: `no user ${e.id}` }, 404)),
     defect: (cause) => {
       logger.error(cause);
       return c.json({ error: "Internal Error" }, 500);

--- a/docs/how-to/interoperate-with-libraries.md
+++ b/docs/how-to/interoperate-with-libraries.md
@@ -39,7 +39,7 @@ Effect is the exception: it _does_ have a defect channel (`Cause.die`), so
 `Result ↔ Exit` round-trips losslessly.
 
 ```ts
-import { Ok, Err, tag, TaggedError } from "unthrown";
+import { Ok, Err, P, TaggedError } from "unthrown";
 import { toExit, fromEffect } from "@unthrown/effect";
 import { Effect } from "effect";
 
@@ -58,7 +58,7 @@ declare const loadUser: Effect.Effect<User, NotFound | Timeout>;
 await fromEffect(loadUser).match({
   ok: (user) => user.name,
   errCases: (matcher) =>
-    matcher.with(tag("NotFound"), () => "missing").with(tag("Timeout"), () => "timed out"),
+    matcher.with(P.tag("NotFound"), () => "missing").with(P.tag("Timeout"), () => "timed out"),
   defect: String,
 });
 ```

--- a/docs/how-to/lint-your-codebase.md
+++ b/docs/how-to/lint-your-codebase.md
@@ -68,12 +68,12 @@ pin — but **only where the pin declares the error channel**, which is inside a
 
 ```ts
 // result: Result<User, NotFound>
-result.mapErrCases((m) => m.returnType<unknown>().with(tag("NotFound"), (e) => e)); // ✗ flagged — this is E
-result.mapErrCases((m) => m.returnType<ApiError>().with(tag("NotFound"), () => new ApiError())); // ✓
+result.mapErrCases((m) => m.returnType<unknown>().with(P.tag("NotFound"), (e) => e)); // ✗ flagged — this is E
+result.mapErrCases((m) => m.returnType<ApiError>().with(P.tag("NotFound"), () => new ApiError())); // ✓
 
-result.recoverErrCases((m) => m.returnType<unknown>().with(tag("NotFound"), (e) => e)); // ✓ — the SUCCESS type
-result.tapErrCases((m) => m.returnType<void>().with(tag("NotFound"), log)); // ✓ — discarded
-result.match({ ok, defect, errCases: (m) => m.returnType<unknown>().with(tag("NotFound"), id) }); // ✓ — a folded value
+result.recoverErrCases((m) => m.returnType<unknown>().with(P.tag("NotFound"), (e) => e)); // ✓ — the SUCCESS type
+result.tapErrCases((m) => m.returnType<void>().with(P.tag("NotFound"), log)); // ✓ — discarded
+result.match({ ok, defect, errCases: (m) => m.returnType<unknown>().with(P.tag("NotFound"), id) }); // ✓ — a folded value
 ```
 
 `flatMapErrCases` / `flatTapErrCases` need no separate check: their builder output
@@ -165,7 +165,7 @@ compiling as `E` grows and silently absorbs each new case.
 ```ts
 result.mapErrCases((m) => m.with(P._, (e) => e)); // ✗ — the catch-all
 // ✓ — enumerate every case; group cases that share a handler
-result.mapErrCases((m) => m.with(tag("NotFound"), tag("Forbidden"), (e) => e));
+result.mapErrCases((m) => m.with(P.tag("NotFound"), P.tag("Forbidden"), (e) => e));
 ```
 
 Because a matched builder must still be exhaustive, removing `P._` makes the

--- a/docs/how-to/migrate-from-neverthrow.md
+++ b/docs/how-to/migrate-from-neverthrow.md
@@ -29,7 +29,7 @@ Most rows are a rename. `andThen` → `flatMap` is unthrown's
 rule. The one behavioral change to know up front: `mapErrCases` (and the other error
 combinators) take an **exhaustive matcher** rather than a plain callback. Port a
 `mapErr(f)` by **naming each case** the old callback silently absorbed —
-`.mapErrCases((matcher) => matcher.with(tag("NotFound"), f).with(tag("Conflict"), f))`
+`.mapErrCases((matcher) => matcher.with(P.tag("NotFound"), f).with(P.tag("Conflict"), f))`
 — and let the compiler tell you when you have missed one. That enumeration is
 the migration's actual payoff; the reasoning is in
 [Exhaustive error matching](../explanation/exhaustive-error-matching). The rest
@@ -63,7 +63,7 @@ app.get("/users/:id", async (req, res) => {
 
 ```ts
 // unthrown — the same bug becomes a Defect inside the pipeline; no try/catch
-import { tag } from "unthrown";
+import { P } from "unthrown";
 
 // getUser: (id: string) => AsyncResult<User, NotFound | Forbidden>
 app.get("/users/:id", async (req, res) => {
@@ -72,8 +72,8 @@ app.get("/users/:id", async (req, res) => {
     ok: (view) => res.status(200).json(view),
     errCases: (matcher) =>
       matcher
-        .with(tag("NotFound"), () => res.status(404).json({ error: "not found" }))
-        .with(tag("Forbidden"), () => res.status(403).json({ error: "forbidden" })),
+        .with(P.tag("NotFound"), () => res.status(404).json({ error: "not found" }))
+        .with(P.tag("Forbidden"), () => res.status(403).json({ error: "forbidden" })),
     defect: (cause) => {
       console.error(cause); // everything the pipeline caught lands here
       res.status(500).json({ error: "internal error" });

--- a/docs/how-to/model-errors.md
+++ b/docs/how-to/model-errors.md
@@ -82,11 +82,11 @@ e.name; // "RetryableError"          — clean stack-trace label
 
 To fold a `Result` whose error is a tagged union straight to a value, use
 `match`. Its `ok` and `defect` handlers are plain callbacks; its **`errCases` handler
-receives the matcher** — add one branch per tag with `tag(t)` and
+receives the matcher** — add one branch per tag with `P.tag(t)` and
 **return the un-terminated builder** (`match` calls `.exhaustive()` for you):
 
 ```ts
-import { tag } from "unthrown";
+import { P } from "unthrown";
 
 const status = authorize(id).match({
   ok: () => 200,
@@ -96,8 +96,8 @@ const status = authorize(id).match({
   },
   errCases: (matcher) =>
     matcher
-      .with(tag("NotFound"), () => 404)
-      .with(tag("Forbidden"), (e) => {
+      .with(P.tag("NotFound"), () => 404)
+      .with(P.tag("Forbidden"), (e) => {
         audit(e.user); // narrowed to Forbidden — `user` is available
         return 403;
       }),

--- a/docs/how-to/sequence-dependent-steps.md
+++ b/docs/how-to/sequence-dependent-steps.md
@@ -37,7 +37,7 @@ normal surface, so you can mix in `map`, `flatMap`, `match`, and the rest freely
 and a thrown callback still becomes a `Defect`:
 
 ```ts
-import { Do, Ok, Err, tag, TaggedError } from "unthrown";
+import { Do, Ok, Err, P, TaggedError } from "unthrown";
 
 class TooSmall extends TaggedError("TooSmall") {}
 declare const input: number;
@@ -47,7 +47,7 @@ Do()
   .let("doubled", ({ n }) => n * 2)
   .match({
     ok: ({ n, doubled }) => `${n} → ${doubled}`,
-    errCases: (matcher) => matcher.with(tag("TooSmall"), () => "too small"),
+    errCases: (matcher) => matcher.with(P.tag("TooSmall"), () => "too small"),
     defect: (cause) => `bug: ${String(cause)}`,
   });
 ```
@@ -59,7 +59,7 @@ To sequence asynchronous steps, lift the chain with `toAsync()` (or start from
 (never a raw `Promise` — see [Qualify a boundary](./qualify-a-boundary)):
 
 ```ts
-import { Do, fromPromise, tag, TaggedError } from "unthrown";
+import { Do, fromPromise, P, TaggedError } from "unthrown";
 
 class UserNotFound extends TaggedError("UserNotFound") {}
 declare class MissingRowError extends Error {}
@@ -75,7 +75,7 @@ const profile = await Do()
   .let("count", ({ posts }) => posts.length)
   .match({
     ok: (s) => s,
-    errCases: (matcher) => matcher.with(tag("UserNotFound"), () => null),
+    errCases: (matcher) => matcher.with(P.tag("UserNotFound"), () => null),
     defect: () => null,
   });
 ```

--- a/docs/how-to/upgrade-to-v5.md
+++ b/docs/how-to/upgrade-to-v5.md
@@ -48,9 +48,12 @@ matcher over the error's _cases_, not a plain `(error) => …` callback.
 The old names no longer exist, so the compiler flags each site:
 
 ```diff
-- result.mapErr((m) => m.with(P.tag("NotFound"), wrap))
+- result.mapErr((m) => m.with(tag("NotFound"), wrap))
 + result.mapErrCases((m) => m.with(P.tag("NotFound"), wrap))
 ```
+
+The arm moved too — `tag(…)` is now `P.tag(…)`, a separate change covered in
+[§7](#_7-tag-moved-onto-p).
 
 Same for `flatMapErr` → `flatMapErrCases`, `recoverErr` → `recoverErrCases`,
 `tapErr` → `tapErrCases`, `flatTapErr` → `flatTapErrCases`. See

--- a/docs/how-to/upgrade-to-v5.md
+++ b/docs/how-to/upgrade-to-v5.md
@@ -13,19 +13,20 @@
 | **Renamed export**     | `UnwrapError`                                                    | `GetError`                                                                                |
 | **Removed** (aliases)  | `unwrap` / `unwrapErr` / `unwrapOr` / `unwrapOrElse`             | `get` / `getErr` / `getOr` / `getOrElse`                                                  |
 | **Removed** (aliases)  | `orElse` / `recover`                                             | `flatMapErrCases` / `recoverErrCases`                                                     |
-| **Removed**            | `matchTags` / the `TagHandlers` type                             | `match({ …, errCases: (m) => m.with(tag("…"), …) })`                                      |
+| **Removed**            | `matchTags` / the `TagHandlers` type                             | `match({ …, errCases: (m) => m.with(P.tag("…"), …) })`                                    |
+| **Renamed** (loud)     | the standalone `tag("…")` export                                 | `P.tag("…")` — it lives in the pattern namespace with every other constructor             |
 | **Changed, same name** | `getOrThrow()` on any `Result`                                   | gated to a **non-empty** error channel (use `get()` otherwise)                            |
 | **Packaging**          | `ts-pattern` bundled as a dependency                             | the matcher is **built-in** — no dependency at all                                        |
 | **Packaging**          | `@unthrown/pattern` (`match` / `P` / `tag`)                      | absorbed into core — import them from `unthrown`                                          |
-| **New**                | —                                                                | `ensure`, `DoAsync`, and the built-in `match` / `P` / `tag` / `NonExhaustiveError`        |
+| **New**                | —                                                                | `ensure`, `DoAsync`, and the built-in `match` / `P` / `NonExhaustiveError`                |
 
 Everything except the two rows below is a compile error at the old call site, so
 `pnpm typecheck` is your migration to-do list.
 
 ## 1. Nothing to install — the matcher is built-in
 
-unthrown's exhaustive matcher is its own module (same `.with(…)` / `tag` / `P`
-call-site shape ts-pattern users know), exported as `match` / `P` / `tag` /
+unthrown's exhaustive matcher is its own module (same `.with(…)` / `P`
+call-site shape ts-pattern users know), exported as `match` / `P` /
 `NonExhaustiveError`. There is **no dependency to install** alongside
 `unthrown` — and no version of any third-party library can change what
 "exhaustive" means.
@@ -37,7 +38,7 @@ imports it directly for other matching.)
 
 One boundary to know: patterns built by the real `ts-pattern` library are
 **not** accepted by unthrown's matchers (and vice versa). Import `P` / `match`
-/ `tag` from `"unthrown"` at unthrown call sites; keep `ts-pattern` for your
+from `"unthrown"` at unthrown call sites; keep `ts-pattern` for your
 own unrelated matching if you use it.
 
 ## 2. Rename the error-channel combinators
@@ -47,8 +48,8 @@ matcher over the error's _cases_, not a plain `(error) => …` callback.
 The old names no longer exist, so the compiler flags each site:
 
 ```diff
-- result.mapErr((m) => m.with(tag("NotFound"), wrap))
-+ result.mapErrCases((m) => m.with(tag("NotFound"), wrap))
+- result.mapErr((m) => m.with(P.tag("NotFound"), wrap))
++ result.mapErrCases((m) => m.with(P.tag("NotFound"), wrap))
 ```
 
 Same for `flatMapErr` → `flatMapErrCases`, `recoverErr` → `recoverErrCases`,
@@ -92,15 +93,15 @@ extractor — over re-throwing inside a match arm.
 
 The `@deprecated` aliases from the 4.x line are gone (one concept, one name):
 
-| Removed        | Use                                                  |
-| -------------- | ---------------------------------------------------- |
-| `unwrap`       | `get`                                                |
-| `unwrapErr`    | `getErr`                                             |
-| `unwrapOr`     | `getOr`                                              |
-| `unwrapOrElse` | `getOrElse`                                          |
-| `orElse`       | `flatMapErrCases`                                    |
-| `recover`      | `recoverErrCases`                                    |
-| `matchTags`    | `match({ …, errCases: (m) => m.with(tag("…"), …) })` |
+| Removed        | Use                                                    |
+| -------------- | ------------------------------------------------------ |
+| `unwrap`       | `get`                                                  |
+| `unwrapErr`    | `getErr`                                               |
+| `unwrapOr`     | `getOr`                                                |
+| `unwrapOrElse` | `getOrElse`                                            |
+| `orElse`       | `flatMapErrCases`                                      |
+| `recover`      | `recoverErrCases`                                      |
+| `matchTags`    | `match({ …, errCases: (m) => m.with(P.tag("…"), …) })` |
 
 `UnwrapError` (the throw type of `get`/`getErr`) is renamed **`GetError`**.
 
@@ -115,18 +116,42 @@ The `@deprecated` aliases from the 4.x line are gone (one concept, one name):
 
 ## 6. `@unthrown/pattern` is gone
 
-`match`, `P`, and `tag` are now exported by `unthrown` itself. Drop the
-`@unthrown/pattern` dependency and re-point the imports:
+`match` and `P` are now exported by `unthrown` itself, and the package's `tag`
+helper is now `P.tag` (see the next section). Drop the `@unthrown/pattern`
+dependency and re-point the imports:
 
 ```diff
 - import { match, P, tag } from "@unthrown/pattern";
-+ import { match, P, tag } from "unthrown";
++ import { match, P } from "unthrown";
 ```
+
+## 7. `tag` moved onto `P`
+
+`tag(t)` builds the `{ _tag: t }` pattern — it is a pattern constructor, so it
+now lives in the pattern namespace beside `P._`, `P.instanceOf`, `P.when` and
+the rest. The standalone export is **removed**, not deprecated: one concept,
+one spelling.
+
+```diff
+- import { tag } from "unthrown";
++ import { P } from "unthrown";
+
+  result.mapErrCases((matcher) =>
+    matcher
+-     .with(tag("NotFound"), () => 404)
+-     .with(tag("Conflict"), () => 409),
++     .with(P.tag("NotFound"), () => 404)
++     .with(P.tag("Conflict"), () => 409),
+  );
+```
+
+The missing `tag` export is a compile error at every import site, and each call
+site follows from it. Nothing about the pattern's behaviour changed.
 
 ## What you gained
 
 - **`ensure`** — validate or refine a success in place (`Result<T, E | E2>`, or a
   type-guard narrowing `T`).
 - **`DoAsync()`** — the pre-lifted async twin of `Do()`.
-- **`match` / `P` / `tag`** as first-class re-exports, so the error matcher is one
+- **`match` / `P`** as first-class re-exports, so the error matcher is one
   import.

--- a/docs/how-to/use-with-orpc.md
+++ b/docs/how-to/use-with-orpc.md
@@ -152,7 +152,7 @@ The error channel is the raw inferable `ORPCError` union, discriminated by `code
 already ships a discriminated error type, and one concept should have one name.
 Branch on `code` — in `match`'s `errCases` matcher (as above), a `switch`, or a
 standalone `match`. Because these are plain `ORPCError`s rather than
-`TaggedError`s, `tag(...)` doesn't apply — match on the `code` field instead.
+`TaggedError`s, `P.tag(...)` doesn't apply — match on the `code` field instead.
 
 Anything non-inferable — a network failure, an undeclared throw collapsed to
 `INTERNAL_SERVER_ERROR`, a malformed response — is a `Defect`: it flows past your

--- a/docs/how-to/use-with-orpc.md
+++ b/docs/how-to/use-with-orpc.md
@@ -39,7 +39,7 @@ your service layer keeps speaking `Result`, and the endpoint stops needing to
 unwrap it into throws:
 
 ```ts
-import { tag } from "unthrown";
+import { P } from "unthrown";
 import { handlerResult } from "@unthrown/orpc/server";
 import { os } from "@orpc/server";
 import * as z from "zod";
@@ -54,9 +54,9 @@ const find = os
       repo.findPlanet(input.id).mapErrCases(
         (matcher, defect) =>
           matcher
-            .with(tag("NotFound"), () => errors.NOT_FOUND()) // modeled → typed for the client
-            .with(tag("Conflict"), () => errors.CONFLICT())
-            .with(tag("DriverError"), (e) => defect(e.cause)), // infrastructure → defect
+            .with(P.tag("NotFound"), () => errors.NOT_FOUND()) // modeled → typed for the client
+            .with(P.tag("Conflict"), () => errors.CONFLICT())
+            .with(P.tag("DriverError"), (e) => defect(e.cause)), // infrastructure → defect
       ),
     ),
   );
@@ -98,7 +98,7 @@ If you prefer a builder method over wrapping, opt into the extension — one
 side-effectful import:
 
 ```ts
-import { tag } from "unthrown";
+import { P } from "unthrown";
 import "@unthrown/orpc/extensions/result";
 
 const find = os
@@ -107,9 +107,9 @@ const find = os
   .result(({ input, errors }) =>
     repo.findPlanet(input.id).mapErrCases((matcher, defect) =>
       matcher
-        .with(tag("NotFound"), () => errors.NOT_FOUND())
-        .with(tag("Conflict"), () => errors.CONFLICT())
-        .with(tag("DriverError"), (e) => defect(e.cause)),
+        .with(P.tag("NotFound"), () => errors.NOT_FOUND())
+        .with(P.tag("Conflict"), () => errors.CONFLICT())
+        .with(P.tag("DriverError"), (e) => defect(e.cause)),
     ),
   );
 ```
@@ -184,7 +184,7 @@ Both halves compose into one error vocabulary across layers — a
 browser consumes it, all in `Result`:
 
 ```ts
-import { tag } from "unthrown";
+import { P } from "unthrown";
 
 // server — the one mapErrCases is the whole edge, and it is exhaustive: a new P-code
 // in the union becomes a compile error here, never a silent 500.
@@ -197,10 +197,10 @@ const createUser = os
         .tryCreate({ data: input })
         .mapErrCases((matcher) =>
           matcher
-            .with(tag("UniqueConstraintViolation"), () => errors.EMAIL_TAKEN())
+            .with(P.tag("UniqueConstraintViolation"), () => errors.EMAIL_TAKEN())
             .with(
-              tag("ForeignKeyViolation"),
-              tag("DriverError"),
+              P.tag("ForeignKeyViolation"),
+              P.tag("DriverError"),
               (e) => new ORPCError("INTERNAL_SERVER_ERROR", { cause: e }),
             ),
         ),

--- a/docs/how-to/use-with-prisma.md
+++ b/docs/how-to/use-with-prisma.md
@@ -68,7 +68,7 @@ with the matcher gives you an exhaustive fold — the compiler lists
 exactly the cases the operation can hit:
 
 ```ts
-import { tag } from "unthrown";
+import { P } from "unthrown";
 
 const created = await db.user.tryCreate({ data: { email, name } });
 
@@ -76,9 +76,11 @@ return created.match({
   ok: (user) => resp.created(user),
   errCases: (matcher) =>
     matcher
-      .with(tag("UniqueConstraintViolation"), (e) => resp.conflict(`taken: ${e.fields.join(", ")}`))
-      .with(tag("ForeignKeyViolation"), () => resp.badRequest("unknown reference"))
-      .with(tag("DriverError"), (e) => resp.serverError(e)),
+      .with(P.tag("UniqueConstraintViolation"), (e) =>
+        resp.conflict(`taken: ${e.fields.join(", ")}`),
+      )
+      .with(P.tag("ForeignKeyViolation"), () => resp.badRequest("unknown reference"))
+      .with(P.tag("DriverError"), (e) => resp.serverError(e)),
   defect: (cause) => resp.serverError(cause),
 });
 // No RecordNotFound arm — a create can't raise it, and the type knows.
@@ -90,10 +92,10 @@ lights the call site up:
 
 ```ts
 matcher
-  .with(tag("UniqueConstraintViolation"), tag("ForeignKeyViolation"), () =>
+  .with(P.tag("UniqueConstraintViolation"), P.tag("ForeignKeyViolation"), () =>
     resp.badRequest("bad write"),
   )
-  .with(tag("DriverError"), (e) => resp.serverError(e));
+  .with(P.tag("DriverError"), (e) => resp.serverError(e));
 ```
 
 ## Transactions
@@ -130,7 +132,7 @@ const moved = db.$tryTransaction((tx) =>
 cursor API — same option names, same `[results, meta]` shape:
 
 ```ts
-import { tag } from "unthrown";
+import { P } from "unthrown";
 
 const page = await db.user
   .tryPaginate({ where: { active: true }, orderBy: { id: "asc" } })
@@ -139,7 +141,7 @@ const page = await db.user
 
 page.match({
   ok: ([users, meta]) => json({ users, nextCursor: meta.endCursor, hasMore: meta.hasNextPage }),
-  errCases: (matcher) => matcher.with(tag("DriverError"), (e) => serverError(e)),
+  errCases: (matcher) => matcher.with(P.tag("DriverError"), (e) => serverError(e)),
   defect: serverError,
 });
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ features:
 ## At a glance
 
 ```ts
-import { Ok, Err, fromPromise, tag, TaggedError, type Result } from "unthrown";
+import { Ok, Err, fromPromise, P, TaggedError, type Result } from "unthrown";
 
 class NotFound extends TaggedError("NotFound") {}
 
@@ -58,7 +58,7 @@ const profile = fromPromise(db.loadProfile(id), (cause, defect) =>
 // Handle every channel once, at the edge — no surrounding try/catch.
 const status = await profile.match({
   ok: () => 200,
-  errCases: (matcher) => matcher.with(tag("NotFound"), () => 404), // every case, named
+  errCases: (matcher) => matcher.with(P.tag("NotFound"), () => 404), // every case, named
   defect: () => 500,
 });
 ```

--- a/docs/reference/combinators.md
+++ b/docs/reference/combinators.md
@@ -83,13 +83,13 @@ you **return the un-terminated builder** — the combinator calls `.exhaustive()
 for you:
 
 ```ts
-import { P, tag } from "unthrown";
+import { P } from "unthrown";
 
 db.reading.tryFindUniqueOrThrow({ where: { id } }).mapErrCases(
   (matcher, defect) =>
     matcher
-      .with(tag("RecordNotFound"), () => new ReadingNotFoundException(id))
-      .with(tag("DriverError"), (e) => defect(e.cause)), // deliberate defect — the tag leaves E
+      .with(P.tag("RecordNotFound"), () => new ReadingNotFoundException(id))
+      .with(P.tag("DriverError"), (e) => defect(e.cause)), // deliberate defect — the tag leaves E
 );
 ```
 
@@ -100,7 +100,7 @@ forget, and no `.otherwise()` to slip in a fallback. The rationale is in
 - **Match on anything, not just `_tag`.** The matcher matches by structure, so a
   `code`-discriminated union (the oRPC shape), a plain string, a guard
   (`.with({ code: "NOT_FOUND", id: "special" }, …)`), or grouped patterns
-  (`.with(a, b, handler)` — one strategy for several cases) all work. `tag("X")`
+  (`.with(a, b, handler)` — one strategy for several cases) all work. `P.tag("X")`
   is sugar for the `{ _tag: "X" }` pattern, narrowing to the variant and its
   payload.
 - **The outgoing `E` is the union of the branch returns.** A branch receives the
@@ -134,7 +134,7 @@ forget, and no `.otherwise()` to slip in a fallback. The rationale is in
   only type-checks when `E` is `never` and otherwise fails to compile (see
   [The Defect Channel](../explanation/the-defect-channel#no-identity-on-the-error-channel)).
   To pass the error through, observe it with `tapErrCases`, or re-emit each case
-  by name (`.with(tag("NotFound"), (e) => e)…`).
+  by name (`.with(P.tag("NotFound"), (e) => e)…`).
 - **Observers match exhaustively too.** `tapErrCases` and `flatTapErrCases` take the same
   builder; the error is observed and then flows through unchanged. Their branch
   returns are ignored (`tapErrCases`) or thread only a
@@ -154,13 +154,13 @@ When several cases deserve the same handling — logging is the classic case —
 the day `E` grows the call site still lights up:
 
 ```ts
-import { tag } from "unthrown";
+import { P } from "unthrown";
 
 // loadUser: (id: string) => Result<User, NotFound | Forbidden | DriverError>
 
 // log whatever the error is, then let it flow through unchanged
 loadUser(id).tapErrCases((matcher) =>
-  matcher.with(tag("NotFound"), tag("Forbidden"), tag("DriverError"), (e) => logger.error(e)),
+  matcher.with(P.tag("NotFound"), P.tag("Forbidden"), P.tag("DriverError"), (e) => logger.error(e)),
 );
 ```
 
@@ -173,22 +173,22 @@ the edge — and mixes freely with per-case arms:
 // one case handled specially, the rest sharing a strategy
 result.tapErrCases((matcher) =>
   matcher
-    .with(tag("RateLimited"), (e) => metrics.rateLimit(e.retryAfter))
-    .with(tag("NotFound"), tag("Forbidden"), (e) => logger.error(e)),
+    .with(P.tag("RateLimited"), (e) => metrics.rateLimit(e.retryAfter))
+    .with(P.tag("NotFound"), P.tag("Forbidden"), (e) => logger.error(e)),
 );
 
 result.recoverErrCases((matcher) =>
   matcher
-    .with(tag("RateLimited"), (e) => e.retryAfter)
-    .with(tag("NotFound"), tag("Forbidden"), () => fallback),
+    .with(P.tag("RateLimited"), (e) => e.retryAfter)
+    .with(P.tag("NotFound"), P.tag("Forbidden"), () => fallback),
 );
 
 result.match({
   ok: (v) => v,
   errCases: (matcher) =>
     matcher
-      .with(tag("RateLimited"), (e) => `retry in ${e.retryAfter}`)
-      .with(tag("NotFound"), tag("Forbidden"), (e) => `failed: ${e}`),
+      .with(P.tag("RateLimited"), (e) => `retry in ${e.retryAfter}`)
+      .with(P.tag("NotFound"), P.tag("Forbidden"), (e) => `failed: ${e}`),
   defect: (c) => `bug: ${c}`,
 });
 ```
@@ -238,7 +238,8 @@ const status = await findUser(id) // Result<User, NotFound>  (sync)
   .match({
     ok: (n) => n,
     // the boundary widened E, so both cases are named here
-    errCases: (matcher) => matcher.with(tag("NotFound"), () => 0).with(tag("LoadFailed"), () => -2),
+    errCases: (matcher) =>
+      matcher.with(P.tag("NotFound"), () => 0).with(P.tag("LoadFailed"), () => -2),
     defect: () => -1,
   }); // await collapses it
 ```

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -55,9 +55,9 @@ handed to every error combinator's callback. You return it un-terminated; the
 combinator runs `.exhaustive()`, so a missing case does not compile. See
 [Exhaustive error matching](../explanation/exhaustive-error-matching).
 
-**`P` / `tag(t)`**
-: `P` is unthrown's pattern namespace (`P._`, `P.instanceOf`, `P.when`, `P.union`, `P.string`, `P.number`).
-`tag(t)` is sugar for the `{ _tag: t }` pattern, narrowing to a tagged variant
+**`P` / `P.tag(t)`**
+: `P` is unthrown's pattern namespace (`P._`, `P.tag`, `P.instanceOf`, `P.when`, `P.union`, `P.string`, `P.number`).
+`P.tag(t)` is sugar for the `{ _tag: t }` pattern, narrowing to a tagged variant
 and its payload — the everyday way to write an arm. `P._` is the universal
 catch-all; it makes any match exhaustive, so it is reserved for the two cases
 enumeration cannot express — a helper generic in `E`, or an `E` that is a single

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -27,7 +27,7 @@ yarn add unthrown
 
 `unthrown` is ESM-first, ships dual CJS/ESM builds with full types, and has
 **zero runtime dependencies** — the exhaustive error matcher is built-in
-(exported as `match` / `P` / `tag`). Use it with TypeScript in `strict` mode.
+(exported as `match` / `P`). Use it with TypeScript in `strict` mode.
 
 ## Step 2 — Return a failure instead of throwing
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -11,10 +11,10 @@ pnpm add unthrown
 ```
 
 No peer dependencies — the exhaustive error matcher is built-in and exported as
-`match` / `P` / `tag`.
+`match` / `P`.
 
 ```ts
-import { fromPromise, tag, TaggedError } from "unthrown";
+import { fromPromise, P, TaggedError } from "unthrown";
 
 class NotFound extends TaggedError("NotFound") {} // our modeled domain failure
 class NotFoundError extends Error {} // what `fetchUser` rejects with on a 404
@@ -26,7 +26,7 @@ const user = fromPromise(fetchUser(id), (cause, defect) =>
 const status = await user.match({
   ok: () => 200,
   // `errCases` takes the exhaustive matcher — every case of E named:
-  errCases: (matcher) => matcher.with(tag("NotFound"), () => 404),
+  errCases: (matcher) => matcher.with(P.tag("NotFound"), () => 404),
   defect: () => 500,
 });
 ```
@@ -36,7 +36,7 @@ const status = await user.match({
   observable only via `match` / `recoverDefect`.
 - **Qualification at every boundary** — `fromPromise` / `fromThrowable` force you
   to triage each failure into a modeled error or a defect.
-- **Tagged errors** — `TaggedError(tag)` + `tag(t)`, folded exhaustively through
+- **Tagged errors** — `TaggedError(tag)` + `P.tag(t)`, folded exhaustively through
   `match`'s built-in error matcher.
 - **Zero runtime dependencies** (the matcher is built-in), ESM-first, dual
   CJS/ESM.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,10 +1,10 @@
 // The built-in matcher powers the error-matching combinators
 // (`mapErrCases`/`flatMapErrCases`/…): `match` starts a match (over an error or
 // any discriminated value, a `Result` included), `P` carries the pattern
-// helpers (`P.instanceOf`, `P.when`, `P.union`, `P.string`, `P.number`, plus
-// the wildcard escape hatch `P._` — name your cases instead wherever `E` is
-// concrete), and `NonExhaustiveError` is what a rogue unmatched value throws at
-// the `match` edge.
+// helpers (`P.tag`, `P.instanceOf`, `P.when`, `P.union`, `P.string`,
+// `P.number`, plus the wildcard escape hatch `P._` — name your cases instead
+// wherever `E` is concrete), and `NonExhaustiveError` is what a rogue unmatched
+// value throws at the `match` edge.
 export { match, NonExhaustiveError, P } from "./matcher.js";
 export type { Matcher, PatternMatcher, UniversalPattern } from "./matcher.js";
 
@@ -23,7 +23,7 @@ export {
   fromSafeThrowable,
   fromThrowable,
 } from "./interop.js";
-export { tag, TaggedError } from "./tagged.js";
+export { TaggedError } from "./tagged.js";
 
 export type { TaggedErrorConstructor, TaggedErrorInstance } from "./tagged.js";
 export type {

--- a/packages/core/src/matcher.spec.ts
+++ b/packages/core/src/matcher.spec.ts
@@ -210,6 +210,19 @@ describe("the built-in matcher engine", () => {
     ).toBe(1);
   });
 
+  it("freezes the P namespace — its members cannot be swapped out", () => {
+    // `P` is part of the exhaustiveness machinery (the catch-all's phantom
+    // universality above all), so a member swapped out from under every call
+    // site would silently change what "exhaustive" means at runtime.
+    expect(Object.isFrozen(P)).toBe(true);
+    expect(Object.isFrozen(P._)).toBe(true);
+    expect(Object.isFrozen(P.string)).toBe(true);
+    expect(() => {
+      (P as unknown as { string: unknown }).string = P.number;
+    }).toThrow(TypeError);
+    expect(P.string).not.toBe(P.number);
+  });
+
   it("still throws NonExhaustiveError under a pin when no arm matches", () => {
     // A rogue value that slipped past the types: pinning must not swallow the
     // non-exhaustive throw (the combinators' throw-to-defect net relies on it).

--- a/packages/core/src/matcher.spec.ts
+++ b/packages/core/src/matcher.spec.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 
 import { match, NonExhaustiveError, P } from "./matcher.js";
-import { tag } from "./tagged.js";
 
 describe("the built-in matcher engine", () => {
   it("matches a primitive literal (Object.is semantics)", () => {
@@ -47,12 +46,12 @@ describe("the built-in matcher engine", () => {
     ).toBe("prim");
   });
 
-  it("matches tag() patterns and grouped patterns with one handler", () => {
+  it("matches P.tag() patterns and grouped patterns with one handler", () => {
     type E = { _tag: "A"; a: number } | { _tag: "B" } | { _tag: "C" };
     const run = (e: E) =>
       match(e)
-        .with(tag("A"), (a) => `a:${a.a}`)
-        .with(tag("B"), tag("C"), (bc) => `bc:${bc._tag}`)
+        .with(P.tag("A"), (a) => `a:${a.a}`)
+        .with(P.tag("B"), P.tag("C"), (bc) => `bc:${bc._tag}`)
         .run();
     expect(run({ _tag: "A", a: 1 })).toBe("a:1");
     expect(run({ _tag: "B" })).toBe("bc:B");
@@ -115,8 +114,8 @@ describe("the built-in matcher engine", () => {
     type E = { _tag: "A" } | { _tag: "B" } | { _tag: "C" };
     const run = (e: E) =>
       match(e)
-        .with(P.union(tag("A"), tag("B")), (ab) => `ab:${ab._tag}`)
-        .with(tag("C"), () => "c")
+        .with(P.union(P.tag("A"), P.tag("B")), (ab) => `ab:${ab._tag}`)
+        .with(P.tag("C"), () => "c")
         .run();
     expect(run({ _tag: "A" })).toBe("ab:A");
     expect(run({ _tag: "B" })).toBe("ab:B");
@@ -189,8 +188,8 @@ describe("the built-in matcher engine", () => {
   it("arms after a match are inert (builder short-circuits)", () => {
     let sideEffect = 0;
     const out = match({ _tag: "A" } as { _tag: "A" } | { _tag: "B" })
-      .with(tag("A"), () => "a")
-      .with(tag("B"), () => {
+      .with(P.tag("A"), () => "a")
+      .with(P.tag("B"), () => {
         sideEffect += 1;
         return "b";
       })

--- a/packages/core/src/matcher.ts
+++ b/packages/core/src/matcher.ts
@@ -17,8 +17,9 @@
 //
 // Supported patterns (the vocabulary the error channel actually uses):
 // primitive literals, shallow(-ly nested) object literals (`{ _tag: "X" }`,
-// `{ code: "X" }` — `tag(t)` produces the former), and the `P.*` matchers
-// (`_`/`any`, `instanceOf`, `when`, `union`, `string`, `number`). Deliberately
+// `{ code: "X" }` — `P.tag(t)` produces the former), and the `P.*` matchers
+// (`_`/`any`, `tag`, `instanceOf`, `when`, `union`, `string`, `number`).
+// Deliberately
 // NOT supported: deep structural inversion, selections, array/variadic
 // patterns — that is the complexity (and instability) being left behind.
 
@@ -166,7 +167,7 @@ export type Matcher<E, Remaining, O, Declared = Unset> = {
   ): Matcher<E, never, O | O2, Declared>;
   /**
    * Add an arm: one or more patterns sharing a single handler (grouped
-   * patterns — `matcher.with(tag("A"), tag("B"), handler)`). The handler
+   * patterns — `matcher.with(P.tag("A"), P.tag("B"), handler)`). The handler
    * receives the input narrowed to what the patterns match (computed against
    * `Remaining`, so cases already handled by earlier arms are excluded); the
    * matched cases are subtracted from `Remaining`.
@@ -268,7 +269,7 @@ function isPlainObject(x: object): x is Record<string, unknown> {
 /**
  * Runtime test: does `pattern` match `value`? A branded `P.*` pattern applies
  * its predicate; a **plain-object** pattern (an object literal, e.g. the
- * `{ _tag }` produced by `tag()`) matches when every key matches recursively
+ * `{ _tag }` produced by `P.tag()`) matches when every key matches recursively
  * (extra keys on the value are ignored — matching is structural); anything
  * else — primitives, but also class instances, arrays, and foreign pattern
  * objects (e.g. a real ts-pattern matcher, whose keys are symbols) — is
@@ -389,6 +390,10 @@ const universal = pattern<unknown>(() => true) as UniversalPattern;
  *   `no-catch-all-pattern` (in its `recommended` preset) flags every other use;
  *   keep the deliberate ones behind a targeted `oxlint-disable` saying which of
  *   the two it is.
+ * - `P.tag(t)` — the `{ _tag: t }` object pattern, matching any value whose
+ *   `_tag` equals `t` (a `TaggedError`, or any `_tag`-discriminated member) and
+ *   narrowing to that variant, payload included. The workhorse of the error
+ *   channel: `matcher.with(P.tag("NotFound"), () => …)`.
  * - `P.instanceOf(Cls)` — an `instanceof` check, narrowing to the class
  *   instance type (for union members that are not tagged, e.g. a third-party
  *   error class).
@@ -401,6 +406,25 @@ const universal = pattern<unknown>(() => true) as UniversalPattern;
 export const P = Object.freeze({
   _: universal,
   any: universal,
+  /**
+   * A matcher pattern matching any value whose `_tag` equals `value` — a
+   * `TaggedError`, or any `_tag`-discriminated member. Equivalent to the object
+   * pattern `{ _tag: value }`, but reads better inside an error-matching
+   * combinator and narrows to the matching variant, payload included.
+   *
+   * @typeParam Tag - the string literal tag to match.
+   * @param value - the `_tag` to match.
+   *
+   * @example
+   * ```ts
+   * result.mapErrCases((matcher) =>
+   *   matcher
+   *     .with(P.tag("NotFound"), () => new NotFoundException())
+   *     .with(P.tag("Conflict"), (e) => new ConflictException(e.key)),
+   * );
+   * ```
+   */
+  tag: <const Tag extends string>(value: Tag): { _tag: Tag } => ({ _tag: value }),
   instanceOf: <C extends abstract new (...args: never[]) => unknown>(
     cls: C,
   ): PatternMatcher<InstanceType<C>> => pattern((value) => value instanceof cls),

--- a/packages/core/src/matcher.ts
+++ b/packages/core/src/matcher.ts
@@ -19,9 +19,9 @@
 // primitive literals, shallow(-ly nested) object literals (`{ _tag: "X" }`,
 // `{ code: "X" }` — `P.tag(t)` produces the former), and the `P.*` matchers
 // (`_`/`any`, `tag`, `instanceOf`, `when`, `union`, `string`, `number`).
-// Deliberately
-// NOT supported: deep structural inversion, selections, array/variadic
-// patterns — that is the complexity (and instability) being left behind.
+// Deliberately NOT supported: deep structural inversion, selections,
+// array/variadic patterns — that is the complexity (and instability) being
+// left behind.
 
 import type { Defect } from "./defect.js";
 
@@ -390,10 +390,13 @@ const universal = pattern<unknown>(() => true) as UniversalPattern;
  *   `no-catch-all-pattern` (in its `recommended` preset) flags every other use;
  *   keep the deliberate ones behind a targeted `oxlint-disable` saying which of
  *   the two it is.
- * - `P.tag(t)` — the `{ _tag: t }` object pattern, matching any value whose
- *   `_tag` equals `t` (a `TaggedError`, or any `_tag`-discriminated member) and
- *   narrowing to that variant, payload included. The workhorse of the error
- *   channel: `matcher.with(P.tag("NotFound"), () => …)`.
+ * - `P.tag<const Tag extends string>(value: Tag): { _tag: Tag }` — the
+ *   `{ _tag: t }` object pattern, matching any value whose `_tag` equals `t` (a
+ *   `TaggedError`, or any `_tag`-discriminated member) and narrowing the
+ *   branch's parameter to that variant, payload included. The workhorse of the
+ *   error channel: `matcher.with(P.tag("NotFound"), (e) => …)`. It composes like
+ *   any other pattern — in a grouped arm
+ *   (`.with(P.tag("A"), P.tag("B"), handler)`) and inside `P.union`.
  * - `P.instanceOf(Cls)` — an `instanceof` check, narrowing to the class
  *   instance type (for union members that are not tagged, e.g. a third-party
  *   error class).
@@ -406,24 +409,6 @@ const universal = pattern<unknown>(() => true) as UniversalPattern;
 export const P = Object.freeze({
   _: universal,
   any: universal,
-  /**
-   * A matcher pattern matching any value whose `_tag` equals `value` — a
-   * `TaggedError`, or any `_tag`-discriminated member. Equivalent to the object
-   * pattern `{ _tag: value }`, but reads better inside an error-matching
-   * combinator and narrows to the matching variant, payload included.
-   *
-   * @typeParam Tag - the string literal tag to match.
-   * @param value - the `_tag` to match.
-   *
-   * @example
-   * ```ts
-   * result.mapErrCases((matcher) =>
-   *   matcher
-   *     .with(P.tag("NotFound"), () => new NotFoundException())
-   *     .with(P.tag("Conflict"), (e) => new ConflictException(e.key)),
-   * );
-   * ```
-   */
   tag: <const Tag extends string>(value: Tag): { _tag: Tag } => ({ _tag: value }),
   instanceOf: <C extends abstract new (...args: never[]) => unknown>(
     cls: C,

--- a/packages/core/src/result.spec.ts
+++ b/packages/core/src/result.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { Err, Ok, P, type Result, tag } from "./index.js";
+import { Err, Ok, P, type Result } from "./index.js";
 
 const boom = new Error("boom");
 const defectOf = (cause: unknown): Result<number, never> =>
@@ -254,7 +254,7 @@ const errB = (b: string): Result<never, TagA | TagB> => Err<TagA | TagB>({ _tag:
 describe("Result.mapErrCases (matcher)", () => {
   it("dispatches a tagged error to its matching branch", () => {
     const r = errA(7).mapErrCases((matcher) =>
-      matcher.with(tag("A"), (e) => `a:${e.a}`).with(tag("B"), (e) => `b:${e.b}`),
+      matcher.with(P.tag("A"), (e) => `a:${e.a}`).with(P.tag("B"), (e) => `b:${e.b}`),
     );
     expect(r.getErr()).toBe("a:7");
   });
@@ -269,7 +269,7 @@ describe("Result.mapErrCases (matcher)", () => {
 
   it("shares one strategy across grouped patterns", () => {
     const build = (r: Result<never, TagA | TagB>) =>
-      r.mapErrCases((matcher) => matcher.with(tag("A"), tag("B"), () => "grouped" as const));
+      r.mapErrCases((matcher) => matcher.with(P.tag("A"), P.tag("B"), () => "grouped" as const));
     expect(build(errA(7)).getErr()).toBe("grouped");
     expect(build(errB("x")).getErr()).toBe("grouped");
   });
@@ -281,12 +281,12 @@ describe("Result.mapErrCases (matcher)", () => {
 
   it("a branch returning the injected defect(cause) becomes a Defect carrying that cause", () => {
     const ok = errA(7).mapErrCases((matcher, defect) =>
-      matcher.with(tag("A"), (e) => e.a).with(tag("B"), (_e) => defect(boom)),
+      matcher.with(P.tag("A"), (e) => e.a).with(P.tag("B"), (_e) => defect(boom)),
     );
     expect(ok.isDefect()).toBe(false); // an A error takes the mapped branch
 
     const d = errB("x").mapErrCases((matcher, defect) =>
-      matcher.with(tag("A"), (e) => e.a).with(tag("B"), (_e) => defect(boom)),
+      matcher.with(P.tag("A"), (e) => e.a).with(P.tag("B"), (_e) => defect(boom)),
     );
     expect(d.isDefect()).toBe(true);
     if (d.isDefect()) expect(d.cause).toBe(boom);
@@ -294,7 +294,7 @@ describe("Result.mapErrCases (matcher)", () => {
 
   it("throws NonExhaustiveError → Defect when a value slips past the types", () => {
     const smuggled = Err({ _tag: "C" }) as unknown as Result<never, TagA>;
-    const r = smuggled.mapErrCases((matcher) => matcher.with(tag("A"), (e) => e.a));
+    const r = smuggled.mapErrCases((matcher) => matcher.with(P.tag("A"), (e) => e.a));
     expect(r.isDefect()).toBe(true);
   });
 
@@ -338,7 +338,7 @@ describe("Result.flatMapErrCases (matcher)", () => {
   it("dispatches per tag — one branch recovers, another re-emits", () => {
     const build = (r: Result<never, TagA | TagB>) =>
       r.flatMapErrCases((matcher) =>
-        matcher.with(tag("A"), (e) => Ok(e.a)).with(tag("B"), (e) => Err(e)),
+        matcher.with(P.tag("A"), (e) => Ok(e.a)).with(P.tag("B"), (e) => Err(e)),
       );
     expect(build(errA(7)).getOr(-1)).toBe(7);
     const reEmitted = build(errB("x"));
@@ -391,7 +391,9 @@ describe("Result.recoverErrCases (matcher)", () => {
   it("dispatches per tag and unions the recovered values", () => {
     expect(
       errA(7)
-        .recoverErrCases((matcher) => matcher.with(tag("A"), (e) => e.a).with(tag("B"), (e) => e.b))
+        .recoverErrCases((matcher) =>
+          matcher.with(P.tag("A"), (e) => e.a).with(P.tag("B"), (e) => e.b),
+        )
         .get(),
     ).toBe(7);
   });
@@ -443,7 +445,7 @@ describe("Result.tapErrCases (matcher, exhaustive)", () => {
   it("runs only the matching branch; the error still passes through unchanged", () => {
     const seenA: number[] = [];
     const observed = errA(7).tapErrCases((matcher) =>
-      matcher.with(tag("A"), (e) => seenA.push(e.a)).with(tag("B"), () => undefined),
+      matcher.with(P.tag("A"), (e) => seenA.push(e.a)).with(P.tag("B"), () => undefined),
     );
     expect(seenA).toEqual([7]);
     expect(observed.isErr() && observed.error).toEqual({ _tag: "A", a: 7 });
@@ -524,7 +526,7 @@ describe("a rogue value past the types: NonExhaustiveError → Defect in EVERY e
   it("flatMapErrCases routes the unmatched rogue value to a Defect", () => {
     expect(
       smuggled()
-        .flatMapErrCases((matcher) => matcher.with(tag("A"), (e) => Ok(e.a)))
+        .flatMapErrCases((matcher) => matcher.with(P.tag("A"), (e) => Ok(e.a)))
         .isDefect(),
     ).toBe(true);
   });
@@ -532,7 +534,7 @@ describe("a rogue value past the types: NonExhaustiveError → Defect in EVERY e
   it("recoverErrCases routes the unmatched rogue value to a Defect", () => {
     expect(
       smuggled()
-        .recoverErrCases((matcher) => matcher.with(tag("A"), (e) => e.a))
+        .recoverErrCases((matcher) => matcher.with(P.tag("A"), (e) => e.a))
         .isDefect(),
     ).toBe(true);
   });
@@ -540,7 +542,7 @@ describe("a rogue value past the types: NonExhaustiveError → Defect in EVERY e
   it("tapErrCases routes the unmatched rogue value to a Defect", () => {
     expect(
       smuggled()
-        .tapErrCases((matcher) => matcher.with(tag("A"), () => undefined))
+        .tapErrCases((matcher) => matcher.with(P.tag("A"), () => undefined))
         .isDefect(),
     ).toBe(true);
   });
@@ -548,7 +550,7 @@ describe("a rogue value past the types: NonExhaustiveError → Defect in EVERY e
   it("flatTapErrCases routes the unmatched rogue value to a Defect", () => {
     expect(
       smuggled()
-        .flatTapErrCases((matcher) => matcher.with(tag("A"), () => Ok(1)))
+        .flatTapErrCases((matcher) => matcher.with(P.tag("A"), () => Ok(1)))
         .isDefect(),
     ).toBe(true);
   });

--- a/packages/core/src/tagged.spec.ts
+++ b/packages/core/src/tagged.spec.ts
@@ -7,7 +7,6 @@ import {
   Ok,
   P,
   type Result,
-  tag,
   TaggedError,
 } from "./index.js";
 
@@ -119,14 +118,14 @@ describe("TaggedError", () => {
     const out = (Err(new Retryable()) as Result<number, Retryable>).match({
       ok: (n) => `ok:${n}`,
       defect: () => "defect",
-      errCases: (matcher) => matcher.with(tag("@my-lib/Retryable"), (e) => `retry:${e.name}`),
+      errCases: (matcher) => matcher.with(P.tag("@my-lib/Retryable"), (e) => `retry:${e.name}`),
     });
     expect(out).toBe("retry:Retryable");
   });
 });
 
 // The per-tag exhaustive fold that `matchTags` used to provide is now `match`
-// with its `errCases` handler driven by the error matcher and `tag(t)`.
+// with its `errCases` handler driven by the error matcher and `P.tag(t)`.
 describe("match — per-tag error matching", () => {
   const fold = (r: Result<number, ApiError>): string =>
     r.match({
@@ -134,9 +133,9 @@ describe("match — per-tag error matching", () => {
       defect: (cause) => `defect:${String(cause)}`,
       errCases: (matcher) =>
         matcher
-          .with(tag("NotFound"), () => "not-found")
-          .with(tag("Forbidden"), (e) => `forbidden:${e.user}`)
-          .with(tag("HttpError"), (e) => `http:${e.status}`),
+          .with(P.tag("NotFound"), () => "not-found")
+          .with(P.tag("Forbidden"), (e) => `forbidden:${e.user}`)
+          .with(P.tag("HttpError"), (e) => `http:${e.status}`),
     });
 
   it("dispatches Ok to the ok handler", () => {
@@ -170,9 +169,9 @@ describe("match — per-tag error matching", () => {
       defect: () => "defect",
       errCases: (matcher) =>
         matcher
-          .with(tag("NotFound"), () => "nf")
-          .with(tag("Forbidden"), () => "fb")
-          .with(tag("HttpError"), () => "he"),
+          .with(P.tag("NotFound"), () => "nf")
+          .with(P.tag("Forbidden"), () => "fb")
+          .with(P.tag("HttpError"), () => "he"),
     });
     expect(out).toBe("ok:1");
   });
@@ -195,7 +194,7 @@ describe("match — per-tag error matching", () => {
       (Err(rogue) as Result<number, Known>).match({
         ok: () => "ok",
         defect: () => "defect",
-        errCases: (matcher) => matcher.with(tag("Known"), () => "known"),
+        errCases: (matcher) => matcher.with(P.tag("Known"), () => "known"),
       }),
     ).toThrow();
   });

--- a/packages/core/src/tagged.ts
+++ b/packages/core/src/tagged.ts
@@ -1,5 +1,6 @@
-// The TaggedError convention (à la Effect's `Data.TaggedError`) and the
-// `tag(t)` matcher pattern for matching a tagged error union.
+// The TaggedError convention (à la Effect's `Data.TaggedError`). The matcher
+// pattern that matches a tagged error union lives with the other pattern
+// constructors, as `P.tag(t)` in `matcher.ts`.
 
 type Props = Record<string, unknown>;
 
@@ -65,8 +66,8 @@ export type TaggedErrorConstructor<Tag extends string> = {
  * so a payload `cause` (e.g. a wrapped driver error) is a legitimate,
  * *narrowing* structured field.
  *
- * `_tag` is the discriminant matched by {@link tag} in the error combinators
- * (`result.mapErrCases((matcher) => matcher.with(tag("NotFound"), …))`) and in
+ * `_tag` is the discriminant matched by `P.tag` in the error combinators
+ * (`result.mapErrCases((matcher) => matcher.with(P.tag("NotFound"), …))`) and in
  * `match`; `Error.name` is the human-facing label in stack traces and logs. By
  * default they coincide, but
  * they can be **decoupled** with `options.name` — so a tag can be namespaced for
@@ -145,28 +146,4 @@ export function TaggedError<Tag extends string>(
   }
 
   return TaggedErrorBase as unknown as TaggedErrorConstructor<Tag>;
-}
-
-/**
- * A matcher pattern matching any value whose `_tag` equals `value` — a
- * {@link TaggedError}, or any discriminated member. Equivalent to the object
- * pattern `{ _tag: value }`, but reads better inside an error-matching
- * combinator and narrows to the matching variant, payload included.
- *
- * @typeParam Tag - the string literal tag to match.
- * @param value - the `_tag` to match.
- *
- * @category Tagged errors
- *
- * @example
- * ```ts
- * result.mapErrCases((matcher) =>
- *   matcher
- *     .with(tag("NotFound"), () => new NotFoundException())
- *     .with(tag("Conflict"), (e) => new ConflictException(e.key)),
- * );
- * ```
- */
-export function tag<const Tag extends string>(value: Tag): { _tag: Tag } {
-  return { _tag: value };
 }

--- a/packages/core/src/tagged.ts
+++ b/packages/core/src/tagged.ts
@@ -66,10 +66,14 @@ export type TaggedErrorConstructor<Tag extends string> = {
  * so a payload `cause` (e.g. a wrapped driver error) is a legitimate,
  * *narrowing* structured field.
  *
+ * The matching half of the convention is `P.tag(t)` — the pattern constructor on
+ * the `P` namespace, which builds the `{ _tag: t }` pattern this factory's `_tag`
+ * is selected by (there is no standalone `tag` export).
+ *
  * `_tag` is the discriminant matched by `P.tag` in the error combinators
  * (`result.mapErrCases((matcher) => matcher.with(P.tag("NotFound"), …))`) and in
- * `match`; `Error.name` is the human-facing label in stack traces and logs. By
- * default they coincide, but
+ * `match`'s `errCases` handler; `Error.name` is the human-facing label in stack
+ * traces and logs. By default they coincide, but
  * they can be **decoupled** with `options.name` — so a tag can be namespaced for
  * collision-safety (`"@my-lib/RetryableError"`) without that slash-prefixed
  * string leaking into `Error.name`:

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -33,7 +33,6 @@ import {
   isOk,
   isResult,
   match,
-  tag,
   P,
   Ok,
   OkAsync,
@@ -370,14 +369,14 @@ declare const tagged: Result<number, TagA | TagB>;
 tagged.match({
   ok: () => 1,
   defect: () => 2,
-  errCases: (matcher) => matcher.with(tag("TagA"), () => 3).with(tag("TagB"), () => 4),
+  errCases: (matcher) => matcher.with(P.tag("TagA"), () => 3).with(P.tag("TagB"), () => 4),
 });
 
 tagged.match({
   ok: () => 1,
   defect: () => 2,
   // @ts-expect-error - the TagB branch is missing, so the builder is not exhaustive
-  errCases: (matcher) => matcher.with(tag("TagA"), () => 3),
+  errCases: (matcher) => matcher.with(P.tag("TagA"), () => 3),
 });
 
 // The 4.x call shape — an `err` key taking the error value — no longer compiles:
@@ -402,7 +401,7 @@ const folded = tagged.match({
   ok: () => "ok" as const,
   defect: () => "defect" as const,
   errCases: (matcher) =>
-    matcher.with(tag("TagA"), () => "a" as const).with(tag("TagB"), () => "b" as const),
+    matcher.with(P.tag("TagA"), () => "a" as const).with(P.tag("TagB"), () => "b" as const),
 });
 type _folded = Expect<Equal<typeof folded, "ok" | "defect" | "a" | "b">>;
 
@@ -460,7 +459,7 @@ function _genericMatchTags<T, E>(result: Result<T, E>): void {
   result.match({
     ok: () => undefined,
     // @ts-expect-error - tag arms are not provably exhaustive over an unresolved E
-    errCases: (matcher) => matcher.with(tag("X"), () => undefined),
+    errCases: (matcher) => matcher.with(P.tag("X"), () => undefined),
     defect: () => undefined,
   });
 }
@@ -674,26 +673,26 @@ new WithMsg({ ticketId: "t1" });
   // exhaustive per-tag; the outgoing E is the union of the branch returns
   const triaged = r.mapErrCases((matcher) =>
     matcher
-      .with(tag("NotFound"), (e) => `nf:${e.id}` as const)
-      .with(tag("Conflict"), () => new Mapped()),
+      .with(P.tag("NotFound"), (e) => `nf:${e.id}` as const)
+      .with(P.tag("Conflict"), () => new Mapped()),
   );
   type _Triaged = Expect<Equal<ErrOf<typeof triaged>, `nf:${string}` | Mapped>>;
 
   // each branch receives the narrowed variant
   r.mapErrCases((matcher) =>
     matcher
-      .with(tag("NotFound"), (e) => {
+      .with(P.tag("NotFound"), (e) => {
         type _Narrowed = Expect<Equal<typeof e, NotFound>>;
         return e;
       })
-      .with(tag("Conflict"), (e) => e),
+      .with(P.tag("Conflict"), (e) => e),
   );
 
   // a throwing branch types as `never` and drops out of the outgoing union
   const thrown = r.mapErrCases((matcher) =>
     matcher
-      .with(tag("NotFound"), () => new Mapped())
-      .with(tag("Conflict"), (e) => {
+      .with(P.tag("NotFound"), () => new Mapped())
+      .with(P.tag("Conflict"), (e) => {
         throw e.key;
       }),
   );
@@ -703,7 +702,9 @@ new WithMsg({ ticketId: "t1" });
   // Defect arm is subtracted from the outgoing union (Exclude<O, Defect>, the
   // same inference as a qualify boundary)
   const defected = r.mapErrCases((matcher, defect) =>
-    matcher.with(tag("NotFound"), () => new Mapped()).with(tag("Conflict"), (e) => defect(e.key)),
+    matcher
+      .with(P.tag("NotFound"), () => new Mapped())
+      .with(P.tag("Conflict"), (e) => defect(e.key)),
   );
   type _DefectDrops = Expect<Equal<ErrOf<typeof defected>, Mapped>>;
 
@@ -723,29 +724,31 @@ new WithMsg({ ticketId: "t1" });
   // NOT exhaustive: a missing case makes `.exhaustive()` uncallable, so the
   // builder is not an ExhaustiveMatch and the call fails at the call site
   // @ts-expect-error — Conflict is unhandled
-  r.mapErrCases((matcher) => matcher.with(tag("NotFound"), (e) => e));
+  r.mapErrCases((matcher) => matcher.with(P.tag("NotFound"), (e) => e));
 
   // flatMapErrCases: channels are the unions of the branch-returned Results' channels
   const flat = r.flatMapErrCases((matcher) =>
-    matcher.with(tag("NotFound"), (e) => Ok(e.id)).with(tag("Conflict"), () => Err(new Mapped())),
+    matcher
+      .with(P.tag("NotFound"), (e) => Ok(e.id))
+      .with(P.tag("Conflict"), () => Err(new Mapped())),
   );
   type _FlatT = Expect<Equal<typeof flat, Result<number | string, Mapped>>>;
 
   // flatMapErrCases: a defect branch contributes to neither channel
   const flatDefected = r.flatMapErrCases((matcher, defect) =>
-    matcher.with(tag("NotFound"), (e) => Ok(e.id)).with(tag("Conflict"), (e) => defect(e.key)),
+    matcher.with(P.tag("NotFound"), (e) => Ok(e.id)).with(P.tag("Conflict"), (e) => defect(e.key)),
   );
   type _FlatDefected = Expect<Equal<typeof flatDefected, Result<number | string, never>>>;
 
   // recoverErrCases: recovers per tag, unioning the recovered values; E empties
   const rec = r.recoverErrCases((matcher) =>
-    matcher.with(tag("NotFound"), (e) => e.id).with(tag("Conflict"), () => 0 as const),
+    matcher.with(P.tag("NotFound"), (e) => e.id).with(P.tag("Conflict"), () => 0 as const),
   );
   type _Rec = Expect<Equal<typeof rec, Result<number | string | 0, never>>>;
 
   // recoverErrCases: a defect branch does not widen the recovered success type
   const recDefected = r.recoverErrCases((matcher, defect) =>
-    matcher.with(tag("NotFound"), (e) => e.id).with(tag("Conflict"), (e) => defect(e.key)),
+    matcher.with(P.tag("NotFound"), (e) => e.id).with(P.tag("Conflict"), (e) => defect(e.key)),
   );
   type _RecDefected = Expect<Equal<typeof recDefected, Result<number | string, never>>>;
 
@@ -764,8 +767,8 @@ new WithMsg({ ticketId: "t1" });
   const ar2 = r.toAsync();
   const aflat = ar2.flatMapErrCases((matcher) =>
     matcher
-      .with(tag("NotFound"), (e) => OkAsync(e.id))
-      .with(tag("Conflict"), () => Err(new Mapped())),
+      .with(P.tag("NotFound"), (e) => OkAsync(e.id))
+      .with(P.tag("Conflict"), () => Err(new Mapped())),
   );
   type _AFlat = Expect<Equal<typeof aflat, AsyncResult<number | string, Mapped>>>;
 }
@@ -819,8 +822,8 @@ new WithMsg({ ticketId: "t1" });
   // pinned: the fold type is the DECLARED one, not the union of branch returns
   const pinned = match(e)
     .returnType<string>()
-    .with(tag("NotFound"), (n) => n.id)
-    .with(tag("Conflict"), () => "conflict")
+    .with(P.tag("NotFound"), (n) => n.id)
+    .with(P.tag("Conflict"), () => "conflict")
     .exhaustive();
   type _Pinned = Expect<Equal<typeof pinned, string>>;
 
@@ -828,42 +831,42 @@ new WithMsg({ ticketId: "t1" });
   // (the `BranchReturn` conditional must not defer inference and collapse O2 —
   // the `fromPromise`-qualify hazard, see CLAUDE.md's internal design)
   const inferred = match(e)
-    .with(tag("NotFound"), () => 1 as const)
-    .with(tag("Conflict"), () => "x" as const)
+    .with(P.tag("NotFound"), () => 1 as const)
+    .with(P.tag("Conflict"), () => "x" as const)
     .exhaustive();
   type _Inferred = Expect<Equal<typeof inferred, 1 | "x">>;
 
   // narrowing is preserved under a pin
   match(e)
     .returnType<string>()
-    .with(tag("NotFound"), (n) => {
+    .with(P.tag("NotFound"), (n) => {
       type _Narrowed = Expect<Equal<typeof n, NotFound>>;
       return n.id;
     })
-    .with(tag("Conflict"), () => "c")
+    .with(P.tag("Conflict"), () => "c")
     .exhaustive();
 
   // a branch that violates the pin fails ON THE BRANCH, not downstream
   match(e)
     .returnType<string>()
     // @ts-expect-error — 42 is not assignable to the declared `string`
-    .with(tag("NotFound"), () => 42)
-    .with(tag("Conflict"), () => "c")
+    .with(P.tag("NotFound"), () => 42)
+    .with(P.tag("Conflict"), () => "c")
     .exhaustive();
 
   // `.returnType` is callable only before any arm has produced an output, and
   // only once — not tied to position (see `afterNever` below); here an arm has
   // already produced an output, so pinning after it is rejected
   match(e)
-    .with(tag("NotFound"), () => "a")
-    .with(tag("Conflict"), () => "c")
+    .with(P.tag("NotFound"), () => "a")
+    .with(P.tag("Conflict"), () => "c")
     // @ts-expect-error — not callable: an arm has already run
     .returnType<string>();
 
   // re-pinning is rejected by the same gate
   match(e)
     .returnType<string>()
-    .with(tag("NotFound"), () => "a")
+    .with(P.tag("NotFound"), () => "a")
     // @ts-expect-error — not callable: the builder is already pinned
     .returnType<number>();
 
@@ -878,18 +881,18 @@ new WithMsg({ ticketId: "t1" });
   // contributes nothing, so a pin after it still compiles. Sound, since a
   // `never` branch can contradict no declared type.
   const afterNever = match(e)
-    .with(tag("NotFound"), (): never => {
+    .with(P.tag("NotFound"), (): never => {
       throw new Error("always throws");
     })
     .returnType<string>()
-    .with(tag("Conflict"), () => "c")
+    .with(P.tag("Conflict"), () => "c")
     .exhaustive();
   type _AfterNever = Expect<Equal<typeof afterNever, string>>;
 
   // a missing case under a pin still makes `.exhaustive` uncallable
   const partial = match(e)
     .returnType<string>()
-    .with(tag("NotFound"), (n) => n.id);
+    .with(P.tag("NotFound"), (n) => n.id);
   // @ts-expect-error — Conflict is unhandled
   partial.exhaustive();
 
@@ -897,15 +900,15 @@ new WithMsg({ ticketId: "t1" });
   // output type — the same subtraction the unpinned path does with Exclude
   const pinnedDefect = match(e)
     .returnType<string>()
-    .with(tag("NotFound"), (n) => n.id)
-    .with(tag("Conflict"), (c) => defect(c))
+    .with(P.tag("NotFound"), (n) => n.id)
+    .with(P.tag("Conflict"), (c) => defect(c))
     .exhaustive();
   type _PinnedDefect = Expect<Equal<typeof pinnedDefect, string>>;
 
   // grouped patterns under a pin: the variadic form and P.union
   const grouped = match(e)
     .returnType<string>()
-    .with(tag("NotFound"), tag("Conflict"), (both) => {
+    .with(P.tag("NotFound"), P.tag("Conflict"), (both) => {
       type _Both = Expect<Equal<typeof both, NotFound | Conflict>>;
       return both._tag;
     })
@@ -914,7 +917,7 @@ new WithMsg({ ticketId: "t1" });
 
   const unioned = match(e)
     .returnType<string>()
-    .with(P.union(tag("NotFound"), tag("Conflict")), (both) => {
+    .with(P.union(P.tag("NotFound"), P.tag("Conflict")), (both) => {
       type _UnionNarrowed = Expect<Equal<typeof both, NotFound | Conflict>>;
       return both._tag;
     })
@@ -940,8 +943,8 @@ new WithMsg({ ticketId: "t1" });
   const pinned = r.mapErrCases((matcher) =>
     matcher
       .returnType<ApiError>()
-      .with(tag("NotFound"), () => new ApiError({ status: 404 }))
-      .with(tag("DriverError"), () => new ApiError({ status: 500 })),
+      .with(P.tag("NotFound"), () => new ApiError({ status: 404 }))
+      .with(P.tag("DriverError"), () => new ApiError({ status: 500 })),
   );
   type _Pinned = Expect<Equal<typeof pinned, Result<number, ApiError>>>;
 
@@ -950,8 +953,8 @@ new WithMsg({ ticketId: "t1" });
   const withDefect = r.mapErrCases((matcher, defect) =>
     matcher
       .returnType<ApiError>()
-      .with(tag("NotFound"), () => new ApiError({ status: 404 }))
-      .with(tag("DriverError"), (d) => defect(d.cause)),
+      .with(P.tag("NotFound"), () => new ApiError({ status: 404 }))
+      .with(P.tag("DriverError"), (d) => defect(d.cause)),
   );
   type _WithDefect = Expect<Equal<typeof withDefect, Result<number, ApiError>>>;
 
@@ -959,8 +962,8 @@ new WithMsg({ ticketId: "t1" });
   const flat = r.flatMapErrCases((matcher) =>
     matcher
       .returnType<Result<string, ApiError>>()
-      .with(tag("NotFound"), (n) => Ok(n.id))
-      .with(tag("DriverError"), () => Err(new ApiError({ status: 500 }))),
+      .with(P.tag("NotFound"), (n) => Ok(n.id))
+      .with(P.tag("DriverError"), () => Err(new ApiError({ status: 500 }))),
   );
   type _Flat = Expect<Equal<typeof flat, Result<number | string, ApiError>>>;
 
@@ -980,11 +983,11 @@ new WithMsg({ ticketId: "t1" });
   const responded = r.recoverErrCases((matcher) =>
     matcher
       .returnType<Response>()
-      .with(tag("NotFound"), () => ({
+      .with(P.tag("NotFound"), () => ({
         status: 404 as const,
         body: { code: "NOT_FOUND" as const },
       }))
-      .with(tag("DriverError"), () => ({
+      .with(P.tag("DriverError"), () => ({
         status: 409 as const,
         body: { code: "CONFLICT" as const },
       })),
@@ -996,11 +999,11 @@ new WithMsg({ ticketId: "t1" });
     matcher
       .returnType<Response>()
       // @ts-expect-error — "GONE" is not a declared body code
-      .with(tag("NotFound"), () => ({
+      .with(P.tag("NotFound"), () => ({
         status: 404 as const,
         body: { code: "GONE" as const },
       }))
-      .with(tag("DriverError"), () => ({
+      .with(P.tag("DriverError"), () => ({
         status: 409 as const,
         body: { code: "CONFLICT" as const },
       })),
@@ -1057,8 +1060,8 @@ new WithMsg({ ticketId: "t1" });
   const apinned = r.toAsync().mapErrCases((matcher) =>
     matcher
       .returnType<ApiError>()
-      .with(tag("NotFound"), () => new ApiError({ status: 404 }))
-      .with(tag("DriverError"), () => new ApiError({ status: 500 })),
+      .with(P.tag("NotFound"), () => new ApiError({ status: 404 }))
+      .with(P.tag("DriverError"), () => new ApiError({ status: 500 })),
   );
   type _APinned = Expect<Equal<typeof apinned, AsyncResult<number, ApiError>>>;
 
@@ -1066,8 +1069,8 @@ new WithMsg({ ticketId: "t1" });
   const aflat = r.toAsync().flatMapErrCases((matcher) =>
     matcher
       .returnType<Result<string, ApiError>>()
-      .with(tag("NotFound"), (n) => Ok(n.id))
-      .with(tag("DriverError"), () => Err(new ApiError({ status: 500 }))),
+      .with(P.tag("NotFound"), (n) => Ok(n.id))
+      .with(P.tag("DriverError"), () => Err(new ApiError({ status: 500 }))),
   );
   type _AFlat = Expect<Equal<typeof aflat, AsyncResult<number | string, ApiError>>>;
 

--- a/packages/effect/README.md
+++ b/packages/effect/README.md
@@ -16,7 +16,7 @@ failure (`Cause.fail` ↔ `Err`) from an unexpected one (`Cause.die` ↔ `Defect
 So `Result ↔ Exit` is a genuine **bijection**.
 
 ```ts
-import { Ok, Err, tag, TaggedError } from "unthrown";
+import { Ok, Err, P, TaggedError } from "unthrown";
 import { toExit, fromEffect, toEither } from "@unthrown/effect";
 import { Effect } from "effect";
 
@@ -32,7 +32,7 @@ const load = (id: string): Effect.Effect<string, NotFound> =>
 await fromEffect(load("1")).match({
   ok: (value) => value,
   // the error channel, matched exhaustively — every case named
-  errCases: (matcher) => matcher.with(tag("NotFound"), () => "missing"),
+  errCases: (matcher) => matcher.with(P.tag("NotFound"), () => "missing"),
   defect: String,
 });
 ```

--- a/packages/orpc/README.md
+++ b/packages/orpc/README.md
@@ -29,7 +29,7 @@ second error concept in between.
 ## Server — `handlerResult` / `.result()`
 
 ```ts
-import { tag } from "unthrown";
+import { P } from "unthrown";
 import { handlerResult } from "@unthrown/orpc/server";
 
 const find = os
@@ -39,7 +39,7 @@ const find = os
     handlerResult(({ input, errors }) =>
       repo
         .findPlanet(input.id)
-        .mapErrCases((matcher) => matcher.with(tag("NotFound"), () => errors.NOT_FOUND())),
+        .mapErrCases((matcher) => matcher.with(P.tag("NotFound"), () => errors.NOT_FOUND())),
     ),
   );
 ```
@@ -50,7 +50,7 @@ inferable; a `Defect` rethrows its cause and stays a defect. A handler may also
 be written as `.result(...)` directly, by opting into the builder extension:
 
 ```ts
-import { tag } from "unthrown";
+import { P } from "unthrown";
 import "@unthrown/orpc/extensions/result";
 
 const find = os
@@ -59,7 +59,7 @@ const find = os
   .result(({ input, errors }) =>
     repo
       .findPlanet(input.id)
-      .mapErrCases((matcher) => matcher.with(tag("NotFound"), () => errors.NOT_FOUND())),
+      .mapErrCases((matcher) => matcher.with(P.tag("NotFound"), () => errors.NOT_FOUND())),
   );
 ```
 

--- a/packages/orpc/src/extensions/result.ts
+++ b/packages/orpc/src/extensions/result.ts
@@ -13,7 +13,7 @@
 //     .result(({ input, errors }) =>
 //       repo
 //         .findPlanet(input.id)
-//         .mapErrCases((m) => m.with(tag("NotFound"), () => errors.NOT_FOUND())),
+//         .mapErrCases((m) => m.with(P.tag("NotFound"), () => errors.NOT_FOUND())),
 //     );
 //
 // This registration is a genuine import-time side effect — the one entry

--- a/packages/orpc/src/server.ts
+++ b/packages/orpc/src/server.ts
@@ -10,7 +10,7 @@
 //   Defect     → rethrow the cause     (oRPC collapses it to INTERNAL_SERVER_ERROR)
 //
 // The handler's `Err` channel is constrained to `ORPCError`: mapping a domain
-// error into one — `mapErrCases((m) => m.with(tag("NotFound"), () => errors.NOT_FOUND({...})))`,
+// error into one — `mapErrCases((m) => m.with(P.tag("NotFound"), () => errors.NOT_FOUND({...})))`,
 // one arm per case of `E` — is the explicit triage point at the transport
 // boundary (Thesis #3).
 
@@ -66,7 +66,7 @@ export type ResultHandler<
  *
  * @example
  * ```ts
- * import { tag } from "unthrown";
+ * import { P } from "unthrown";
  * import { handlerResult } from "@unthrown/orpc/server";
  *
  * const find = os
@@ -76,7 +76,7 @@ export type ResultHandler<
  *     handlerResult(({ input, errors }) =>
  *       repo
  *         .findPlanet(input.id)
- *         .mapErrCases((matcher) => matcher.with(tag("NotFound"), () => errors.NOT_FOUND())),
+ *         .mapErrCases((matcher) => matcher.with(P.tag("NotFound"), () => errors.NOT_FOUND())),
  *     ),
  *   );
  * ```

--- a/packages/oxlint/README.md
+++ b/packages/oxlint/README.md
@@ -14,13 +14,13 @@ library's theses into automated checks.
 
 ## Rules
 
-| Rule                               | What it enforces                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `unthrown/no-ambiguous-error-type` | The `E` in `Result<T, E>` / `AsyncResult<T, E>` must name a concrete domain error — no `unknown`, `any`, `Error`, `object`, bare `{}`, `void`, or primitives. (`never` is allowed.) This is [Thesis #1](https://btravstack.github.io/unthrown/explanation/why-unthrown): `E` is only the _anticipated_ failures. Covers the matcher's `returnType<R>()` pin too, but only in `mapErrCases`, where the pin _is_ the new `E`.                 |
-| `unthrown/prefer-async-result`     | Prefer `AsyncResult<T, E>` over `Promise<Result<T, E>>` — a raw `Promise<Result>` can still reject. Autofixable — except on an `async` function's own return annotation and on a function _type_'s return position (the implementer may be `async`), where the rule reports without a fix since the rewrite would not compile.                                                                                                              |
-| `unthrown/no-unhandled-result`     | A `Result` / `AsyncResult` returned by a bare call (awaited or not) must not be dropped on the floor — it carries the error channel; dropping it silently discards failures. Bind it, return it, or eliminate it with `match` / a `get*` extractor.                                                                                                                                                                                         |
-| `unthrown/no-catch-all-pattern`    | No `P._` / `P.any` catch-all in a matcher — enumerate every error case by name (`.with(tag("A"), tag("B"), …, handler)`, grouping cases that share a handler), so a new error can't be silently absorbed. This is unthrown's default position; `P._` is an escape hatch — a helper generic in `E`, or an `E` that is a single type rather than a union — and carries a targeted `oxlint-disable`. See [below](#the-catch-all-escape-hatch). |
-| `unthrown/no-throw`                | **Opt-in** (not in `recommended`): no raw `throw` statements — errors are returned (`Err(...)`), only a true defect ever throws. `getOrThrow()` is the sanctioned extraction escape; a known-technical precondition throw lives in a plain helper wrapped once with `fromSafeThrowable`; a deliberate throw site carries a targeted `oxlint-disable`.                                                                                       |
+| Rule                               | What it enforces                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `unthrown/no-ambiguous-error-type` | The `E` in `Result<T, E>` / `AsyncResult<T, E>` must name a concrete domain error — no `unknown`, `any`, `Error`, `object`, bare `{}`, `void`, or primitives. (`never` is allowed.) This is [Thesis #1](https://btravstack.github.io/unthrown/explanation/why-unthrown): `E` is only the _anticipated_ failures. Covers the matcher's `returnType<R>()` pin too, but only in `mapErrCases`, where the pin _is_ the new `E`.                     |
+| `unthrown/prefer-async-result`     | Prefer `AsyncResult<T, E>` over `Promise<Result<T, E>>` — a raw `Promise<Result>` can still reject. Autofixable — except on an `async` function's own return annotation and on a function _type_'s return position (the implementer may be `async`), where the rule reports without a fix since the rewrite would not compile.                                                                                                                  |
+| `unthrown/no-unhandled-result`     | A `Result` / `AsyncResult` returned by a bare call (awaited or not) must not be dropped on the floor — it carries the error channel; dropping it silently discards failures. Bind it, return it, or eliminate it with `match` / a `get*` extractor.                                                                                                                                                                                             |
+| `unthrown/no-catch-all-pattern`    | No `P._` / `P.any` catch-all in a matcher — enumerate every error case by name (`.with(P.tag("A"), P.tag("B"), …, handler)`, grouping cases that share a handler), so a new error can't be silently absorbed. This is unthrown's default position; `P._` is an escape hatch — a helper generic in `E`, or an `E` that is a single type rather than a union — and carries a targeted `oxlint-disable`. See [below](#the-catch-all-escape-hatch). |
+| `unthrown/no-throw`                | **Opt-in** (not in `recommended`): no raw `throw` statements — errors are returned (`Err(...)`), only a true defect ever throws. `getOrThrow()` is the sanctioned extraction escape; a known-technical precondition throw lives in a plain helper wrapped once with `fromSafeThrowable`; a deliberate throw site carries a targeted `oxlint-disable`.                                                                                           |
 
 The rules resolve import bindings via scope analysis (through the _imported_
 name, so renamed imports resolve too), and only fire on unthrown's own
@@ -82,13 +82,13 @@ Everywhere the error union is concrete, name the cases instead — grouping the
 ones that share a handler:
 
 ```ts
-import { tag } from "unthrown";
+import { P } from "unthrown";
 
 // E is `NotFound | Conflict | DriverError` — every member gets an arm:
 result.mapErrCases((matcher) =>
   matcher
-    .with(tag("NotFound"), () => new ApiError({ status: 404 }))
-    .with(tag("Conflict"), tag("DriverError"), (e) => new ApiError({ status: 500, error: e })),
+    .with(P.tag("NotFound"), () => new ApiError({ status: 404 }))
+    .with(P.tag("Conflict"), P.tag("DriverError"), (e) => new ApiError({ status: 500, error: e })),
 );
 ```
 

--- a/packages/oxlint/src/rules/no-catch-all-pattern.test.ts
+++ b/packages/oxlint/src/rules/no-catch-all-pattern.test.ts
@@ -5,7 +5,7 @@ ruleTester.run("no-catch-all-pattern", noCatchAllPattern, {
   valid: [
     // Explicit enumeration — every case named, no wildcard.
     {
-      code: `import { P, tag } from "unthrown";\nresult.mapErrCases((m) => m.with(tag("A"), tag("B"), (e) => e));`,
+      code: `import { P } from "unthrown";\nresult.mapErrCases((m) => m.with(P.tag("A"), P.tag("B"), (e) => e));`,
     },
     // Specific `P.*` matchers are fine — only the catch-alls are banned.
     {

--- a/packages/oxlint/src/rules/no-catch-all-pattern.ts
+++ b/packages/oxlint/src/rules/no-catch-all-pattern.ts
@@ -19,7 +19,7 @@ const CATCH_ALL_PROPS: ReadonlySet<string> = new Set(["_", "any"]);
  * closes, silently absorbing any error the union grows later.
  *
  * This rule states unthrown's own default: every error case is enumerated by
- * name (`.with(tag("A"), tag("B"), …, handler)`, grouping cases that share a
+ * name (`.with(P.tag("A"), P.tag("B"), …, handler)`, grouping cases that share a
  * handler), and `P._` is an **escape hatch**, not the sanctioned way to handle
  * the error channel. Hence its place in the `recommended` preset.
  *
@@ -53,7 +53,7 @@ export const noCatchAllPattern = defineRule({
     },
     messages: {
       noCatchAll:
-        'Unexpected `P.{{prop}}` catch-all. Enumerate every error case by name — `.with(tag("A"), tag("B"), …, handler)`, grouping cases that share a handler — so a new error can\'t be silently absorbed. The catch-all is an escape hatch for what enumeration can\'t express — a helper generic in `E`, or an `E` that is a single type rather than a union — so keep it there behind a targeted `oxlint-disable` with a reason.',
+        'Unexpected `P.{{prop}}` catch-all. Enumerate every error case by name — `.with(P.tag("A"), P.tag("B"), …, handler)`, grouping cases that share a handler — so a new error can\'t be silently absorbed. The catch-all is an escape hatch for what enumeration can\'t express — a helper generic in `E`, or an `E` that is a single type rather than a union — so keep it there behind a targeted `oxlint-disable` with a reason.',
     },
   },
   createOnce: (context) => {

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -19,7 +19,7 @@ type_. Qualification happens once, inside the extension: no raw Promise ever
 reaches your code.
 
 ```ts
-import { tag } from "unthrown";
+import { P } from "unthrown";
 import { unthrownPrisma } from "@unthrown/prisma";
 import { PrismaClient } from "./generated/prisma/client.ts";
 
@@ -35,8 +35,8 @@ await db.user.tryCreate({ data }).match({
   // are grouped, so nothing is absorbed unnamed:
   errCases: (matcher) =>
     matcher
-      .with(tag("UniqueConstraintViolation"), (e) => conflict(e.fields))
-      .with(tag("ForeignKeyViolation"), tag("DriverError"), (e) => serverError(e)),
+      .with(P.tag("UniqueConstraintViolation"), (e) => conflict(e.fields))
+      .with(P.tag("ForeignKeyViolation"), P.tag("DriverError"), (e) => serverError(e)),
   defect: serverError,
 });
 ```


### PR DESCRIPTION
## What & why

`tag(t)` builds the `{ _tag: t }` matcher pattern — it is a **pattern
constructor**. But it was exported standalone from the package root, while every
other pattern constructor lives on `P` (`P._`, `P.any`, `P.instanceOf`,
`P.when`, `P.union`, `P.string`, `P.number`). It also sat in `tagged.ts` next to
`TaggedError`, which reads as though it belongs to the error-class convention
rather than to the matcher.

It becomes **`P.tag(t)`**, and the standalone export is removed.

```diff
-import { tag, TaggedError } from "unthrown";
+import { P, TaggedError } from "unthrown";

 result.mapErrCases((matcher) =>
   matcher
-    .with(tag("NotFound"), () => 404)
-    .with(tag("Conflict"), () => 409),
+    .with(P.tag("NotFound"), () => 404)
+    .with(P.tag("Conflict"), () => 409),
 );
```

### A replacement, not an alias

No deprecated `tag` export survives. That is the repo's standing rule — one
concept, one name — and `CLAUDE.md` states no deprecated aliases survive into
v5. `unthrown` is at `5.0.0-beta.8` in an active prerelease, so this is the
moment to take the break.

### Where the implementation lives

Inside `matcher.ts`'s frozen `P` literal, **not** imported from `tagged.ts`.
`matcher.ts` already owns the pattern vocabulary (`P`, `PatternMatcher`,
`MatchedOf`) and the structural `matches()` runtime that is what actually makes
a `{ _tag }` literal narrow. `P.tag` needs no knowledge of `TaggedError` — it
builds a bare `{ _tag }` literal and works on any `_tag`-discriminated union.
Importing from `tagged.ts` would point the dependency the wrong way, making the
generic matcher depend on a convention layered on top of it. `tagged.ts` is now
cleanly one concept.

### Behaviour is unchanged

`P.tag` keeps `<const Tag extends string>(value: Tag) => { _tag: Tag }` and
narrows identically, including in grouped arms and inside `P.union`. It stays
deliberately **non-universal**: unlike `P._`, tag arms are still not provably
exhaustive over an unresolved generic `E`, and the `types.test-d.ts`
`@ts-expect-error` asserting exactly that still fires — the one property a
careless port would have silently lost.

### Also in here

- **Queued changesets retro-fit.** Six unreleased entries still showed
  `import { tag }`; because pre-mode changesets are all re-emitted at exit, they
  would have described a removed API in the 5.0.0 changelog. Updated the sides
  that describe what 5.0.0 ships, left genuine "before" sides alone. Published
  `CHANGELOG.md` files are untouched — at beta.2 `tag` genuinely was standalone.
- **Dead TSDoc removed.** `P.tag` carried an 18-line doc block TypeDoc never
  rendered (it drops object-literal property docs), duplicating the namespace
  bullet that does render. Folded into the bullet, which now carries the literal
  signature.
- **`Object.isFrozen(P)` is now tested** — a pre-existing gap, closed now that
  `P` has gained a member.

## Checklist

- [x] The full gate passes locally: `pnpm format --check && pnpm lint && pnpm typecheck && pnpm knip && pnpm test && pnpm build`
- [x] Added/updated tests (and invariant guards / type-level tests if behaviour changed)
- [x] Added a changeset (`pnpm changeset`) for any user-facing change
- [x] Updated TSDoc and `CLAUDE.md` if the public surface or a design rule changed
- [x] Commits follow Conventional Commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
