### PR TITLE
docs: correct the stale ts-pattern claim and silence the vitest typedoc warning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,9 +48,12 @@ before proposing a change. In particular:
 
 - **oxlint rules are binding:** no `interface` (use `type`), no `any` (use
   `unknown`). Genuine exceptions carry a targeted `oxlint-disable` with a reason.
-- **Core has exactly one runtime dependency, `ts-pattern`** (it powers the
-  exhaustive error matchers and is re-exported as `match`/`P`). Add no others —
-  never pull `vitest` or any interop peer into core.
+- **Core has zero runtime dependencies** — the exhaustive error matcher is
+  built in (`packages/core/src/matcher.ts`, exporting `match`/`P`/
+  `NonExhaustiveError` as core's own). It replaced a former `ts-pattern`
+  dependency deliberately: the exhaustiveness guarantee must not vary with a
+  consumer-resolved third-party version. Add no dependencies — never pull
+  `vitest` or any interop peer into core.
 - **One name per concept.** Resist convenience aliases.
 - Public API carries full **TSDoc**; `pnpm --filter <pkg> build:docs` must stay
   warning-free.

--- a/packages/vitest/typedoc.json
+++ b/packages/vitest/typedoc.json
@@ -1,5 +1,6 @@
 {
   "extends": "@btravstack/typedoc/base.json",
   "entryPoints": ["src/index.ts"],
-  "out": "docs"
+  "out": "docs",
+  "intentionallyNotExported": ["HookContext"]
 }


### PR DESCRIPTION
## What & why

Two pieces of staleness, unrelated to any feature work.

### `CONTRIBUTING.md` documented a dependency that no longer exists

The contributor guide told newcomers:

> **Core has exactly one runtime dependency, `ts-pattern`** (it powers the
> exhaustive error matchers and is re-exported as `match`/`P`).

Every factual claim there is false. Core has **zero** runtime dependencies — the
matcher is built into `packages/core/src/matcher.ts`, and `match` / `P` /
`NonExhaustiveError` are core's own exports, not re-exports. The `ts-pattern`
dependency was removed deliberately, so the exhaustiveness guarantee cannot vary
with a consumer-resolved third-party version.

That is precisely the rule a new contributor most needs to get right, so it
being inverted is worth fixing on its own. The bullet now states the
zero-dependency rule and its reasoning, mirroring `CLAUDE.md` so the two agree.

### A TypeDoc warning in `@unthrown/vitest`

```
[warning] HookContext, defined in @unthrown/vitest/src/index.ts, is referenced
          by failOnForgottenAwait.context but not included in the documentation
```

`HookContext` is a local, non-exported type used as `failOnForgottenAwait`'s
optional parameter. Fixed with TypeDoc's `intentionallyNotExported`, the
established treatment here — `packages/core/typedoc.json` already lists
`Defect`, `MatchedOf`, `NonExhaustive`, and others for the same reason.

Deliberately **not** exported: it describes Vitest's hook context, the parameter
is structurally typed, and exporting it would grow the public surface for no
user benefit.

The repo's rule is that `build:docs` stays typedoc-warning-free, and this was
the one package violating it. Every other package with the script was checked
and is clean: core, `boxed`, `effect`, `neverthrow`, `orpc`, `prisma`,
`standard-schema`.

## No changeset

Neither change affects any package's runtime or public API — one is contributor
documentation, the other a TypeDoc config that only affects generated output.

## Checklist

- [x] The full gate passes locally: `pnpm format --check && pnpm lint && pnpm typecheck && pnpm knip && pnpm test && pnpm build`
- [ ] Added/updated tests — n/a, no behaviour change
- [ ] Added a changeset — n/a, see above
- [x] Updated TSDoc and `CLAUDE.md` if the public surface or a design rule changed — n/a; `CLAUDE.md` was already correct, `CONTRIBUTING.md` now matches it
- [x] Commits follow Conventional Commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
