### PR TITLE
chore: apply the pre-v5-stable audit punch list

### DIFF
--- a/.changeset/drop-dead-sourcemaps.md
+++ b/.changeset/drop-dead-sourcemaps.md
@@ -1,0 +1,16 @@
+---
+"unthrown": patch
+"@unthrown/vitest": patch
+"@unthrown/effect": patch
+"@unthrown/neverthrow": patch
+"@unthrown/boxed": patch
+"@unthrown/standard-schema": patch
+"@unthrown/oxlint": patch
+"@unthrown/prisma": patch
+"@unthrown/orpc": patch
+---
+
+Stop shipping sourcemaps and declaration maps: `files: ["dist"]` excludes
+`src/`, so the published maps were dead-ends (silently broken go-to-definition
+and stack mapping). Each package now sets `declarationMap: false`; consumers
+land on the fully TSDoc'd `.d.ts` instead, and tarballs shrink.

--- a/.changeset/fix-stale-match-examples.md
+++ b/.changeset/fix-stale-match-examples.md
@@ -1,0 +1,9 @@
+---
+"@unthrown/effect": patch
+"@unthrown/prisma": patch
+"@unthrown/standard-schema": patch
+---
+
+Update stale v4 `match({ ok, err, defect })` doc examples to the v5
+`{ ok, errCases, defect }` shape (including `fromSchemaAsync`'s `@example`,
+which renders into the API reference).

--- a/.changeset/oxlint-peer-floor.md
+++ b/.changeset/oxlint-peer-floor.md
@@ -1,0 +1,7 @@
+---
+"@unthrown/oxlint": patch
+---
+
+Raise the `oxlint` peerDependency floor from `^1.69.0` to `^1.74.0`, matching
+the `@oxlint/plugins` runtime the rules are built against — a host older than
+the plugin runtime was never a supported combination.

--- a/.changeset/standard-schema-spec-range.md
+++ b/.changeset/standard-schema-spec-range.md
@@ -1,0 +1,7 @@
+---
+"@unthrown/standard-schema": patch
+---
+
+Publish the `@standard-schema/spec` dependency as `^1.1.0` instead of an exact
+pin, so it can dedupe with a consumer's own copy of the (types-only) spec
+package.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,6 +384,9 @@ Defect>`); flatMapErrCases: `OkOf`/`ErrOf` — plus `AsyncOkOf`/`AsyncErrOf` on 
   matcher, and matching a whole `Result` (`match(r).with({ tag: "Ok" }, …)`),
   first-class in one import — the former `@unthrown/pattern` package and the
   former `ts-pattern` re-exports, now one owned module.
+- errors: `GetError` (from `core.ts`) is also a public export — the defensive
+  wrong-variant error `get`/`getErr` throw, reachable only through a cast or a
+  raw-JS caller (see the type-gated extractor invariant).
 - guards: methods `isOk`/`isErr`/`isDefect` **and** standalone
   `isOk`/`isErr`/`isDefect` both narrow (to `OkView`/`ErrView`/`DefectView`) — the
   methods are `this is …` type predicates, so `if (r.isErr()) r.error` compiles.
@@ -399,6 +402,10 @@ Defect>`); flatMapErrCases: `OkOf`/`ErrOf` — plus `AsyncOkOf`/`AsyncErrOf` on 
   union a `tapFailure` callback receives (error-type-first, like `ErrView`).
   `ErrMatcher<E>` — the built-in match builder over the error
   (`ReturnType<typeof match<E>>`, i.e. `Matcher<E, E, never>`).
+  `OkOf<R>` / `ErrOf<R>` / `AsyncOkOf<R>` / `AsyncErrOf<R>` — public
+  derive-a-type utilities extracting a `Result`/`AsyncResult`'s channels from a
+  function's return type (also the machinery behind `flatMapErrCases`'s
+  outgoing types).
   The supporting `ExhaustiveMatch`/`MatchOut`/`MatchErrOut` are exported for the
   d.ts but not re-exported from `index.ts`. `ExhaustiveMatch<O>` requires
   `.exhaustive` to be _callable_ (the builder types it as the branded
@@ -408,7 +415,9 @@ Defect>`); flatMapErrCases: `OkOf`/`ErrOf` — plus `AsyncOkOf`/`AsyncErrOf` on 
   never combined with the class `E` in a covariant return — the historical
   ts-pattern `Match` invariance forced that rule (and `flatTapErrCases`'s plain
   `E2` inference); the built-in `Matcher` is kinder but the discipline is kept,
-  guarded by the `combine` inference regression test.
+  guarded by the `combine` inference regression guard — a compile-guard helper
+  in `aggregate.spec.ts` (its `r.get()` only compiles while `E` infers `never`)
+  plus the variance widen-guards in `types.test-d.ts`.
 - constructors: `Ok` (a no-arg overload — `Ok()` — constructs a `void` success,
   `Result<void, never>`, sparing `Ok(undefined)`; `OkAsync()` mirrors it),
   `Err` (there is **no** `Defect` constructor — a defect-state
@@ -473,9 +482,10 @@ Defect>`); flatMapErrCases: `OkOf`/`ErrOf` — plus `AsyncOkOf`/`AsyncErrOf` on 
   documented on the separate `*Methods` types, which the `Result` / `AsyncResult`
   aliases and the `OkView`/`ErrView`/`DefectView` variants link to. The async
   method docs link back to their sync `ResultMethods` counterpart and state the
-  async delta. The `docs/guide/choosing-a-combinator.md` guide remains the "by
-  intent" selection cheat-sheet — one table covering both — and links to these API
-  sections. The core `typedoc.json` sets an explicit `categoryOrder` (`Facade`,
+  async delta. The `docs/reference/combinators.md` page (the docs site follows
+  the Diátaxis layout — `tutorial/`, `how-to/`, `reference/`, `explanation/`)
+  remains the "by intent" selection cheat-sheet — one table covering both — and
+  links to these API sections. The core `typedoc.json` sets an explicit `categoryOrder` (`Facade`,
   `Types`, `Methods`, `Constructors`, … then `Aggregate`, `Errors`) so the core
   surface leads the API reference instead of the default alphabetical order.
 - tagged errors: `TaggedError(tag, options?)` (the error-class factory; optional
@@ -488,7 +498,9 @@ Defect>`); flatMapErrCases: `OkOf`/`ErrOf` — plus `AsyncOkOf`/`AsyncErrOf` on 
   for use in the error matchers, in `match`'s `errCases` handler, and in
   `match(result)`) — it sits with the other pattern constructors, not with
   `TaggedError`; see the
-  `TaggedError` convention in Thesis #4. **There is no `matchTags`** — a per-tag
+  `TaggedError` convention in Thesis #4. The supporting types
+  `TaggedErrorConstructor` / `TaggedErrorInstance` are exported too — they type
+  an `extends TaggedError(…)` site from the outside. **There is no `matchTags`** — a per-tag
   exhaustive fold over a tagged error union is `result.match({ ok, defect, errCases:
 (matcher) => matcher.with(P.tag("…"), …) })`, which generalises beyond `_tag` to
   any discriminant.
@@ -628,7 +640,10 @@ AsyncResult<infer T, …>` — structural inference over the whole method surfac
   `NonExhaustiveError`); it replaced the former `ts-pattern` peer so the
   exhaustiveness guarantee can never vary with a consumer-resolved third-party
   version, and nothing needs installing alongside `unthrown`)
-- `packages/vitest` → `@unthrown/vitest` (peerDep `vitest`)
+- `packages/vitest` → `@unthrown/vitest` (peerDep `vitest`; besides the
+  `expect.extend` registration it also exports the six raw matcher functions,
+  `failOnForgottenAwait`, and the `UnthrownMatchers` type — for manual
+  `expect.extend` wiring)
 - `packages/effect` → `@unthrown/effect` (peerDep `effect`)
 - `packages/neverthrow` → `@unthrown/neverthrow` (peerDep `neverthrow`)
 - `packages/boxed` → `@unthrown/boxed` (peerDep `@bloodyowl/boxed` — Boxed's
@@ -771,6 +786,9 @@ channel?**
   never a `Defect`. Going _out_, every `to*` takes a **mandatory `onDefect:
 (cause) => E`** (forced triage, Thesis #3): a defect is never silently folded
   into `E`. There is no one-arg form.
+- The async-direction names are **deliberately asymmetric** —
+  `toNeverthrowAsync` / `toBoxedFuture` — because each names the neighbour's
+  own async type (`ResultAsync` vs `Future<Result>`). Do not uniformise them.
 - A `Defect` `Result` has no public constructor (defects arise at boundaries).
   The only place one is minted is `@unthrown/effect`'s `fromExit`, which replays
   Effect's `die` cause through the `fromThrowable` boundary — itself a genuine
@@ -823,7 +841,10 @@ configured outside the repo).
 
 ## Toolchain & conventions
 
-- **Stack:** pnpm (catalog) + turbo; build with **tsdown** (dual CJS/ESM + d.ts);
+- **Stack:** pnpm (catalog) + turbo; build with **tsdown** (dual CJS/ESM + d.ts;
+  **no sourcemaps or declaration maps** — each package tsconfig sets
+  `declarationMap: false` over the shared base, because `files: ["dist"]`
+  excludes `src/` and published maps would be dead-ends);
   lint/format with **oxlint** / **oxfmt**; **knip** for dead-code/deps; **vitest**
   (+ v8 coverage); **typedoc** (markdown) feeding **vitepress**; **changesets**
   for releases; **lefthook** + **commitlint** (conventional commits) on commit.

--- a/README.md
+++ b/README.md
@@ -86,17 +86,17 @@ defect, so the edge of your program needs a single `match` and no `try`/`catch`.
 
 ## Packages
 
-| Package                                                   | Description                                                                                         |
-| --------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| [`unthrown`](./packages/core)                             | The core `Result` / `AsyncResult`, interop, `TaggedError`, built-in exhaustive error matching.      |
-| [`@unthrown/vitest`](./packages/vitest)                   | Vitest matchers: `toBeOk`, `toBeOkWith`, `toBeErr`, `toBeErrWith`, `toBeErrTagged`, `toBeDefect`.   |
-| [`@unthrown/effect`](./packages/effect)                   | Effect interop: `Result ↔ Exit` (bijection), `Either`, `Effect`.                                    |
-| [`@unthrown/neverthrow`](./packages/neverthrow)           | neverthrow interop: `Result ↔ Result`, `AsyncResult ↔ ResultAsync`.                                 |
-| [`@unthrown/boxed`](./packages/boxed)                     | Boxed interop: `Result ↔ Result`, `AsyncResult ↔ Future<Result>`.                                   |
-| [`@unthrown/prisma`](./packages/prisma)                   | Prisma Client extension: `try*` query methods returning `AsyncResult`, per-operation errors.        |
-| [`@unthrown/orpc`](./packages/orpc)                       | oRPC (v2) bridge: `Result`-returning handlers, `AsyncResult` client, typed errors end-to-end.       |
-| [`@unthrown/standard-schema`](./packages/standard-schema) | `fromSchema` / `fromSchemaAsync`: any Standard Schema validator into a `Result`.                    |
-| [`@unthrown/oxlint`](./packages/oxlint)                   | oxlint plugin: `no-ambiguous-error-type`, `prefer-async-result`, `no-unhandled-result`, `no-throw`. |
+| Package                                                   | Description                                                                                                                 |
+| --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| [`unthrown`](./packages/core)                             | The core `Result` / `AsyncResult`, interop, `TaggedError`, built-in exhaustive error matching.                              |
+| [`@unthrown/vitest`](./packages/vitest)                   | Vitest matchers: `toBeOk`, `toBeOkWith`, `toBeErr`, `toBeErrWith`, `toBeErrTagged`, `toBeDefect`.                           |
+| [`@unthrown/effect`](./packages/effect)                   | Effect interop: `Result ↔ Exit` (bijection), `Either`, `Effect`.                                                            |
+| [`@unthrown/neverthrow`](./packages/neverthrow)           | neverthrow interop: `Result ↔ Result`, `AsyncResult ↔ ResultAsync`.                                                         |
+| [`@unthrown/boxed`](./packages/boxed)                     | Boxed interop: `Result ↔ Result`, `AsyncResult ↔ Future<Result>`.                                                           |
+| [`@unthrown/prisma`](./packages/prisma)                   | Prisma Client extension: `try*` query methods returning `AsyncResult`, per-operation errors.                                |
+| [`@unthrown/orpc`](./packages/orpc)                       | oRPC (v2) bridge: `Result`-returning handlers, `AsyncResult` client, typed errors end-to-end.                               |
+| [`@unthrown/standard-schema`](./packages/standard-schema) | `fromSchema` / `fromSchemaAsync`: any Standard Schema validator into a `Result`.                                            |
+| [`@unthrown/oxlint`](./packages/oxlint)                   | oxlint plugin: `no-ambiguous-error-type`, `no-catch-all-pattern`, `no-unhandled-result`, `prefer-async-result`, `no-throw`. |
 
 ## Contributing
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -226,7 +226,7 @@ export default defineConfig({
   },
 
   head: [
-    ["link", { rel: "icon", type: "image/svg+xml", href: "/unthrown/logo.svg" }],
+    ["link", { rel: "icon", type: "image/svg+xml", href: `${BASE}logo.svg` }],
     ["meta", { name: "author", content: "Benoit TRAVERS" }],
     ["meta", { name: "robots", content: "index, follow" }],
     ["meta", { name: "application-name", content: "unthrown" }],

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -33,6 +33,7 @@ This reference is generated from the source with
   (each an `AsyncResult` whose error channel is exactly the P-codes it can
   raise), plus `$tryTransaction` and `tryPaginate(...).withCursor(...)`.
 
-`@unthrown/oxlint` (the lint rules `no-ambiguous-error-type` and
-`prefer-async-result`) has no generated API page — it is documented in the
+`@unthrown/oxlint` (the lint rules `no-ambiguous-error-type`,
+`no-catch-all-pattern`, `no-unhandled-result`, `prefer-async-result`, and the
+opt-in `no-throw`) has no generated API page — it is documented in the
 [Linting guide](../how-to/lint-your-codebase).

--- a/docs/explanation/comparison.md
+++ b/docs/explanation/comparison.md
@@ -77,9 +77,8 @@ This isn't a clean sweep — pick the tool for the job:
 
 - **byethrow** — if you want a lightweight, pipe-idiomatic Result with **one**
   failure axis and don't need the defect distinction, it's an excellent, smaller,
-  more mature choice. It also ships niceties unthrown deliberately omits
-  (error-accumulating `collect`, lightweight `do`/`bind` notation, a Standard
-  Schema adapter, an oxlint plugin).
+  more mature choice. It also ships error-accumulating `collect`, which unthrown
+  deliberately omits.
 - **neverthrow** — the established, widely-adopted class-based option; reach for
   it if ecosystem maturity outweighs the defect channel.
 - **boxed** — if you specifically want an `Option` type and a broader functional

--- a/docs/explanation/why-unthrown.md
+++ b/docs/explanation/why-unthrown.md
@@ -31,7 +31,7 @@ function getUser(id: string): User; // throws NotFoundError? TimeoutError? TypeE
 function getUser(id: string): Result<User, NotFound | Timeout>;
 
 getUser(id)
-  .map((u) => u.emial.trim()) // typo — TypeError → Defect, NOT an Err
+  .map((u) => new URL(u.website).host) // malformed URL — TypeError → Defect, NOT an Err
   .match({
     ok: render,
     // every case in E is named — add a third and this stops compiling

--- a/docs/how-to/model-errors.md
+++ b/docs/how-to/model-errors.md
@@ -133,7 +133,7 @@ exists for what enumeration cannot express — a helper generic in `E`, or an `E
 that is a single type rather than a union — and is covered in
 [Exhaustive error matching](../explanation/exhaustive-error-matching#generic-boundary-helpers-the-catch-all-is-the-only-form-that-compiles).
 
-Unlike the error _combinators_ (`mapErrCases`, `flatMapErrCases`, …), `match`'s `err`
+Unlike the error _combinators_ (`mapErrCases`, `flatMapErrCases`, …), `match`'s `errCases`
 handler receives **no `defect` helper** — `match` is total elimination to a value,
 and a `Result` that already carries a defect is handled by the `defect:` case. To
 keep matching _inside_ the pipeline (transforming or recovering the error rather

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -88,8 +88,8 @@ when it returns another `Result`. (The full picture is in the
 ## Step 4 — Handle every outcome with `match`
 
 At the edge of your program, fold a `Result` into a single value with `match`.
-You handle three runtime channels — `ok`, `err`, and a `defect` channel for the
-_unexpected_ (you'll meet it in the next step):
+You handle three runtime channels — `ok`, `errCases`, and a `defect` channel for
+the _unexpected_ (you'll meet it in the next step):
 
 ```ts
 const message = parseAge("-3").match({

--- a/packages/boxed/tsconfig.json
+++ b/packages/boxed/tsconfig.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
+    // `files: ["dist"]` excludes `src/`, so published declaration maps would be
+    // dead-ends (broken go-to-definition); consumers get the TSDoc'd d.ts.
+    "declarationMap": false,
     // @btravstack/tsconfig@0.2.0 dropped `types: ["node"]` from the base;
     // re-declare it here for the Node globals used in source/tests.
     "types": ["node"]

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -33,7 +33,8 @@ const status = await user.match({
 
 - **Errors as values** via `Result<T, E>` / `AsyncResult<T, E>`.
 - **A separate defect channel** for the unexpected — invisible to the type,
-  observable only via `match` / `recoverDefect`.
+  observable only via `match` / `recoverDefect` and the `tapDefect` /
+  `tapFailure` observers.
 - **Qualification at every boundary** — `fromPromise` / `fromThrowable` force you
   to triage each failure into a modeled error or a defect.
 - **Tagged errors** — `TaggedError(tag)` + `P.tag(t)`, folded exhaustively through

--- a/packages/core/src/async-result.spec.ts
+++ b/packages/core/src/async-result.spec.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { type AsyncResult, Err, fromPromise, fromSafePromise, P, Ok, OkAsync } from "./index.js";
+import {
+  type AsyncResult,
+  Err,
+  fromPromise,
+  fromSafePromise,
+  NonExhaustiveError,
+  P,
+  Ok,
+  OkAsync,
+  type Result,
+} from "./index.js";
 
 const boom = new Error("boom");
 const asyncOk = <T>(v: T): AsyncResult<T, never> => Ok(v).toAsync();
@@ -343,16 +353,90 @@ describe("AsyncResult error channel", () => {
   });
 });
 
+describe("a rogue value past the types: NonExhaustiveError → Defect in EVERY async error combinator", () => {
+  // The sync probes live in result.spec.ts; the async five dispatch through the
+  // same runMatch, but the invariant claims both surfaces — so each gets its
+  // own probe, asserting the Defect's cause is the matcher's NonExhaustiveError.
+  type TagA = { _tag: "A"; a: number };
+  const smuggled = () => asyncErr({ _tag: "C" }) as unknown as AsyncResult<never, TagA>;
+
+  const expectRogueDefect = (r: Result<unknown, unknown>) => {
+    expect(r.isDefect()).toBe(true);
+    if (r.isDefect()) expect(r.cause).toBeInstanceOf(NonExhaustiveError);
+  };
+
+  // In the two OBSERVERS the throw takes the failure-observer route: the
+  // NonExhaustiveError aggregates with the observed rogue error instead of
+  // destroying it, so it sits at errors[0] of the AggregateError cause.
+  const expectRogueObserverDefect = (r: Result<unknown, unknown>) => {
+    expect(r.isDefect()).toBe(true);
+    if (r.isDefect()) {
+      expect(r.cause).toBeInstanceOf(AggregateError);
+      expect((r.cause as AggregateError).errors[0]).toBeInstanceOf(NonExhaustiveError);
+      expect((r.cause as AggregateError).errors[1]).toEqual({ _tag: "C" });
+    }
+  };
+
+  it("mapErrCases routes the unmatched rogue value to a Defect", async () => {
+    expectRogueDefect(
+      await smuggled().mapErrCases((matcher) => matcher.with(P.tag("A"), (e) => e.a)),
+    );
+  });
+
+  it("flatMapErrCases routes the unmatched rogue value to a Defect", async () => {
+    expectRogueDefect(
+      await smuggled().flatMapErrCases((matcher) => matcher.with(P.tag("A"), (e) => Ok(e.a))),
+    );
+  });
+
+  it("recoverErrCases routes the unmatched rogue value to a Defect", async () => {
+    expectRogueDefect(
+      await smuggled().recoverErrCases((matcher) => matcher.with(P.tag("A"), (e) => e.a)),
+    );
+  });
+
+  it("tapErrCases routes the unmatched rogue value to a Defect", async () => {
+    expectRogueObserverDefect(
+      await smuggled().tapErrCases((matcher) => matcher.with(P.tag("A"), () => undefined)),
+    );
+  });
+
+  it("flatTapErrCases routes the unmatched rogue value to a Defect", async () => {
+    expectRogueObserverDefect(
+      await smuggled().flatTapErrCases((matcher) => matcher.with(P.tag("A"), () => Ok(1))),
+    );
+  });
+});
+
 describe("AsyncResult Defect channel", () => {
   it("a Defect flows through the success and error combinators untouched", async () => {
     const f = vi.fn();
     expect((await asyncDefect().map(f)).isDefect()).toBe(true);
+    expect((await asyncDefect().flatMap(f)).isDefect()).toBe(true);
+    expect((await asyncDefect().tap(f)).isDefect()).toBe(true);
     expect((await asyncDefect().mapErrCases((matcher) => matcher.with(P._, f))).isDefect()).toBe(
       true,
     );
     expect(
+      (await asyncDefect().flatMapErrCases((matcher) => matcher.with(P._, f))).isDefect(),
+    ).toBe(true);
+    expect(
       (await asyncDefect().recoverErrCases((matcher) => matcher.with(P._, f))).isDefect(),
     ).toBe(true);
+    expect((await asyncDefect().tapErrCases((matcher) => matcher.with(P._, f))).isDefect()).toBe(
+      true,
+    );
+    expect(f).not.toHaveBeenCalled();
+  });
+
+  it("recoverDefect passes Ok and Err through and does not call the callback", async () => {
+    const f = vi.fn();
+    const okR = await asyncOk(1).recoverDefect(f);
+    expect(okR.isOk()).toBe(true);
+    if (okR.isOk()) expect(okR.value).toBe(1);
+    const errR = await asyncErr("e").recoverDefect(f);
+    expect(errR.isErr()).toBe(true);
+    if (errR.isErr()) expect(errR.error).toBe("e");
     expect(f).not.toHaveBeenCalled();
   });
 

--- a/packages/core/src/do.spec.ts
+++ b/packages/core/src/do.spec.ts
@@ -136,6 +136,16 @@ describe("Do / bind / let — async", () => {
     expect(fromLet.isDefect()).toBe(true);
   });
 
+  it("passes a Defect-state scope through bind and let without running the callback", async () => {
+    const later = vi.fn(() => Ok(1));
+    const fromBind = await defectOf(boom).toAsync().bind("a", later);
+    expect(fromBind.isDefect()).toBe(true);
+
+    const fromLet = await defectOf(boom).toAsync().let("a", later);
+    expect(fromLet.isDefect()).toBe(true);
+    expect(later).not.toHaveBeenCalled();
+  });
+
   it("turns an async bind/let on a non-object scope into a Defect", async () => {
     const fromBind = await Ok(5)
       .toAsync()

--- a/packages/core/src/result.spec.ts
+++ b/packages/core/src/result.spec.ts
@@ -488,6 +488,9 @@ describe("Result.flatTapErrCases (matcher, exhaustive)", () => {
   it("propagates a Defect from the effect", () => {
     const r = Err("e").flatTapErrCases((matcher) => matcher.with(P._, () => defectOf(boom)));
     expect(r.isDefect()).toBe(true);
+    // an effect that blew up on its own REPLACES the error, unaggregated: the
+    // cause is the raw thrown value, not an AggregateError (unlike an observer throw)
+    if (r.isDefect()) expect(r.cause).toBe(boom);
   });
 
   it("does not run on Ok or Defect", () => {

--- a/packages/core/src/tagged.spec.ts
+++ b/packages/core/src/tagged.spec.ts
@@ -4,6 +4,7 @@ import {
   type AsyncResult,
   Err,
   fromSafePromise,
+  NonExhaustiveError,
   Ok,
   P,
   type Result,
@@ -196,6 +197,6 @@ describe("match — per-tag error matching", () => {
         defect: () => "defect",
         errCases: (matcher) => matcher.with(P.tag("Known"), () => "known"),
       }),
-    ).toThrow();
+    ).toThrow(NonExhaustiveError);
   });
 });

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -192,6 +192,12 @@ type _flatMapped = Expect<Equal<typeof flatMapped, Result<never, "e1" | "e2">>>;
 declare const ar: AsyncResult<number, "e">;
 // @ts-expect-error - a raw Promise callback return is not assignable
 ar.flatMap((n) => Promise.resolve(Ok(n)));
+// @ts-expect-error - a raw Promise callback return is not assignable
+ar.flatTap(() => Promise.resolve(Ok(1)));
+// bind: same ban, from a Do-scope AsyncResult so the call otherwise typechecks
+declare const arDo: AsyncResult<{ a: number }, "e">;
+// @ts-expect-error - a raw Promise callback return is not assignable
+arDo.bind("x", () => Promise.resolve(Ok(1)));
 
 // REGRESSION GUARD: chaining a callback that returns a value typed as the
 // opaque `AsyncResult<U, E2>` alias (not a freshly-minted Ok/fromPromise) must
@@ -1055,6 +1061,12 @@ new WithMsg({ ticketId: "t1" });
   type _FlatObservedDefect = Expect<
     Equal<typeof flatObservedDefect, Result<number, NotFound | DriverError>>
   >;
+
+  // …and UNPINNED the marker is rejected: the builder's output must satisfy
+  // `ExhaustiveMatch<Result<…>>`, which admits no `defect(…)` marker — the
+  // `returnType` pin above is the only way to write a defect branch here.
+  // @ts-expect-error — an unpinned flatTapErrCases branch may not return the defect(…) marker
+  r.flatTapErrCases((matcher, defect) => matcher.with(P._, (e) => defect(e)));
 
   // the async surface mirrors it
   const apinned = r.toAsync().mapErrCases((matcher) =>

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
+    // `files: ["dist"]` excludes `src/`, so published declaration maps would be
+    // dead-ends (broken go-to-definition); consumers get the TSDoc'd d.ts.
+    "declarationMap": false,
     "types": ["node"]
   },
   "include": ["src/**/*"],

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -10,7 +10,7 @@
 //   import { toExit, fromEffect } from "@unthrown/effect";
 //
 //   toExit(Ok(1));                 // Exit.succeed(1)
-//   await fromEffect(Effect.succeed(1)).match({ ok, err, defect });
+//   await fromEffect(Effect.succeed(1)).match({ ok, errCases, defect });
 //
 // `Either` has only two channels, so converting a `Result` *into* an `Either`
 // forces you to triage the Defect with `onDefect` (Thesis #3): there is no

--- a/packages/effect/tsconfig.json
+++ b/packages/effect/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "@btravstack/tsconfig/base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    // `files: ["dist"]` excludes `src/`, so published declaration maps would be
+    // dead-ends (broken go-to-definition); consumers get the TSDoc'd d.ts.
+    "declarationMap": false
   },
   "include": ["src/**/*"]
 }

--- a/packages/neverthrow/tsconfig.json
+++ b/packages/neverthrow/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "@btravstack/tsconfig/base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    // `files: ["dist"]` excludes `src/`, so published declaration maps would be
+    // dead-ends (broken go-to-definition); consumers get the TSDoc'd d.ts.
+    "declarationMap": false
   },
   "include": ["src/**/*"]
 }

--- a/packages/orpc/README.md
+++ b/packages/orpc/README.md
@@ -104,4 +104,4 @@ beta) and its majors track oRPC's cadence, not the unthrown family's.
 
 ## License
 
-[MIT](./LICENSE)
+[MIT](https://github.com/btravstack/unthrown/blob/main/LICENSE) © Benoit TRAVERS

--- a/packages/orpc/tsconfig.json
+++ b/packages/orpc/tsconfig.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
+    // `files: ["dist"]` excludes `src/`, so published declaration maps would be
+    // dead-ends (broken go-to-definition); consumers get the TSDoc'd d.ts.
+    "declarationMap": false,
     // @btravstack/tsconfig@0.2.0 dropped `types: ["node"]` from the base;
     // re-declare it here for the Node globals used in source/tests.
     "types": ["node"]

--- a/packages/oxlint/package.json
+++ b/packages/oxlint/package.json
@@ -62,7 +62,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "oxlint": "^1.69.0"
+    "oxlint": "^1.74.0"
   },
   "engines": {
     "node": ">=20"

--- a/packages/oxlint/tsconfig.json
+++ b/packages/oxlint/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "@btravstack/tsconfig/base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    // `files: ["dist"]` excludes `src/`, so published declaration maps would be
+    // dead-ends (broken go-to-definition); consumers get the TSDoc'd d.ts.
+    "declarationMap": false
   },
   "include": ["src/**/*"]
 }

--- a/packages/prisma/src/index.ts
+++ b/packages/prisma/src/index.ts
@@ -10,8 +10,8 @@
 //
 //   const db = new PrismaClient({ adapter }).$extends(unthrownPrisma);
 //
-//   await db.user.tryCreate({ data }).match({ ok, err, defect });
-//   // err is UniqueConstraintViolation | ForeignKeyViolation | DriverError
+//   await db.user.tryCreate({ data }).match({ ok, errCases, defect });
+//   // errCases matches UniqueConstraintViolation | ForeignKeyViolation | DriverError
 //
 // The raw promise methods stay available on purpose: they are the escape hatch
 // for batch `$transaction([...])`, which needs unexecuted `PrismaPromise`s.

--- a/packages/prisma/tsconfig.json
+++ b/packages/prisma/tsconfig.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
+    // `files: ["dist"]` excludes `src/`, so published declaration maps would be
+    // dead-ends (broken go-to-definition); consumers get the TSDoc'd d.ts.
+    "declarationMap": false,
     // The generated test client (src/generated, gitignored) imports its own
     // files with explicit `.ts` extensions; `noEmit` in the base config makes
     // this legal.

--- a/packages/standard-schema/src/index.ts
+++ b/packages/standard-schema/src/index.ts
@@ -107,7 +107,7 @@ export function fromSchema<S extends StandardSchemaV1>(
  * ```ts
  * import { fromSchemaAsync } from "@unthrown/standard-schema";
  * const parse = fromSchemaAsync(asyncSchema);
- * (await parse(input)).match({ ok, err, defect });
+ * (await parse(input)).match({ ok, errCases, defect });
  * ```
  */
 export function fromSchemaAsync<S extends StandardSchemaV1>(

--- a/packages/standard-schema/tsconfig.json
+++ b/packages/standard-schema/tsconfig.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
+    // `files: ["dist"]` excludes `src/`, so published declaration maps would be
+    // dead-ends (broken go-to-definition); consumers get the TSDoc'd d.ts.
+    "declarationMap": false,
     // @btravstack/tsconfig@0.2.0 dropped `types: ["node"]` from the base;
     // re-declare it here for the Node globals used in source/tests.
     "types": ["node"]

--- a/packages/vitest/tsconfig.json
+++ b/packages/vitest/tsconfig.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
+    // `files: ["dist"]` excludes `src/`, so published declaration maps would be
+    // dead-ends (broken go-to-definition); consumers get the TSDoc'd d.ts.
+    "declarationMap": false,
     // @btravstack/tsconfig@0.2.0 dropped `types: ["node"]` from the base;
     // re-declare it here for the Node globals used in source/tests.
     "types": ["node"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ catalogs:
       specifier: 7.8.0
       version: 7.8.0
     '@standard-schema/spec':
-      specifier: 1.1.0
+      specifier: ^1.1.0
       version: 1.1.0
     '@types/node':
       specifier: 26.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,7 +23,10 @@ catalog:
   "@orpc/server": 2.0.0-beta.18
   "@prisma/adapter-better-sqlite3": 7.8.0
   "@prisma/client": 7.8.0
-  "@standard-schema/spec": 1.1.0
+  # Ranged, not pinned: published as a regular dependency of
+  # @unthrown/standard-schema — an exact pin would block dedupe with a
+  # consumer's own copy of the (types-only) spec package.
+  "@standard-schema/spec": ^1.1.0
   "@types/node": 26.1.1
   "@vitest/coverage-v8": 4.1.10
   better-sqlite3: 12.11.1


### PR DESCRIPTION
## Summary

A full pre-release audit (core API surface vs spec, packaging/publishing metadata, invariant & type-test coverage, satellites, docs) before exiting the v5 beta found **zero breaking-risk issues**. This PR applies the audit's non-breaking punch list so nothing forces a change after 5.0.0 ships.

### Packaging
- **Drop sourcemaps/declaration maps from every dist**: `files: ["dist"]` excludes `src/`, so the published maps were dead-ends (silently broken go-to-definition and stack mapping). Root cause: the shared `@btravstack/tsconfig` base sets `declarationMap: true`, which drove *all* map emission (including the `.mjs.map`); each package tsconfig now overrides it to `false`. Verified map-free dists after a full rebuild.
- Raise `@unthrown/oxlint`'s `oxlint` peer floor to `^1.74.0` — the `@oxlint/plugins` runtime it builds against (a floor raise post-stable would be disruptive; doing it now).
- Publish `@standard-schema/spec` as `^1.1.0` instead of an exact pin, so it can dedupe with a consumer's copy.
- Delete the stale `tools/` and `packages/pattern/` leftovers (orphaned `node_modules` husks).

### Docs
- Fix the three remaining v4 `match({ ok, err, defect })` examples — effect and prisma file headers, and `fromSchemaAsync`'s `@example`, which renders into the API reference.
- Complete the oxlint rule lists (root README and `docs/api/index.md` still described 4 and 2 of the 5 rules).
- Correct the comparison page: byethrow was credited with do-notation, a Standard Schema adapter, and an oxlint plugin as things unthrown "deliberately omits" — unthrown ships all three; only accumulation remains a genuine omission.
- Smaller drift: `err`-handler prose in two guide pages, the `u.emial` example (now `new URL(u.website)` — a genuinely type-invisible runtime bug), the core README's defect-observer list, the orpc README license footer, the favicon href now derived from `BASE`.

### Test hardening (13 new tests, core at 289 passing)
- `@ts-expect-error` guards proving a raw `Promise<Result>` cannot enter async `flatTap`/`bind` (only `flatMap` was guarded — the exact signature shape the spec documents as historically fragile).
- Unpinned `flatTapErrCases` rejects the `defect(…)` marker (claimed contract, now asserted).
- Async rogue-tag → Defect probes for all five error combinators (the observer pair correctly aggregates: `AggregateError([NonExhaustiveError, original])`).
- The async Defect pass-through matrix (`flatMap`/`tap`/`tapErrCases`/`flatMapErrCases`/`bind`/`let`, plus `recoverDefect` pass-through on Ok/Err).
- Match-edge assertion tightened to `.toThrow(NonExhaustiveError)`; `flatTapErrCases` short-circuit now asserts the unaggregated cause.

### Spec (CLAUDE.md)
- List the legitimately-public exports the spec omitted: `GetError`, `TaggedErrorConstructor`/`TaggedErrorInstance`, `OkOf`/`ErrOf`/`AsyncOkOf`/`AsyncErrOf`.
- Bless the two decide-now items: `@unthrown/vitest`'s raw matcher-function exports, and the deliberate `toNeverthrowAsync`/`toBoxedFuture` naming asymmetry (each names the neighbour's own async type).
- Fix the Diátaxis docs paths (spec still said `docs/guide/`) and the `combine`-guard location; record the no-sourcemaps build rule.

Four patch-level changesets included (`drop-dead-sourcemaps`, `oxlint-peer-floor`, `fix-stale-match-examples`, `standard-schema-spec-range`) — version math unchanged: family → 5.0.0, orpc/prisma → 0.1.1.

## Test plan
- [x] Full gate green: `pnpm format --check`, `lint`, `typecheck` (incl. `types.test-d.ts` — the new negatives are verified by `@ts-expect-error` failing the build if the line compiles), `knip`, `test` (289 passed; lines/functions 100%, branches 98.73%), `build`, typedoc warning-free, docs site builds.
- [x] `ls packages/*/dist/*.map` → no matches after full rebuild.