### PR TITLE
fix(oxlint): restore the oxlint peer floor to ^1.69.0

### DIFF
--- a/.changeset/relax-oxlint-peer-floor.md
+++ b/.changeset/relax-oxlint-peer-floor.md
@@ -1,0 +1,22 @@
+---
+"@unthrown/oxlint": patch
+---
+
+Restore the `oxlint` peerDependency floor to `^1.69.0`, undoing the `^1.74.0`
+raise shipped in `5.0.0-beta.10`. That raise was mechanical — it synced the peer
+to the `@oxlint/plugins` version the package builds against, not to a host API
+the rules actually need — and beta.10's plugin bundle is byte-identical to
+beta.9's apart from a dropped sourcemap comment.
+
+The rules only ever touch `context.report` (with `fix`), `context.sourceCode`,
+`getScope`, and `defineConfig` from `oxlint`; all five rules and the
+`prefer-async-result` autofix were re-verified against an `oxlint@1.69.0` host.
+
+The tighter range was expensive downstream: under `strictPeerDependencies` it
+failed installs outright, and satisfying it cascaded into `oxlint@1.74.0` →
+`oxlint-tsgolint@0.24.0`, dragging a lint _and_ type-check engine upgrade across
+every consuming project for a packaging-only release.
+
+The peer floor now names the oldest host the rules are verified on, decoupled
+from the `@oxlint/plugins` dependency, with a regression test guarding the
+decoupling.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -689,7 +689,15 @@ AsyncResult<infer T, …>` — structural inference over the whole method surfac
   and namespace imports resolve; alias indirection like `type E = unknown` is a
   documented limit) so they only fire on unthrown's `Result`. No TypeDoc API
   page; documented in the Linting guide.
-  Tested with oxlint's `RuleTester` from `oxlint/plugins-dev`.)
+  Tested with oxlint's `RuleTester` from `oxlint/plugins-dev`.
+  The **`oxlint` peer floor (`^1.69.0`) is deliberately decoupled from the
+  `@oxlint/plugins` dependency** — it names the oldest _host_ the rules were
+  verified to run on, not the plugin-utils version the package happens to build
+  against. Slaving the two ratchets the floor on every bot bump and drags
+  consumers through an oxlint + `oxlint-tsgolint` engine upgrade for a
+  packaging-only release (#163). Raise it only when a rule starts using a host
+  API that needs it, and name that API in the changeset; the decoupling is
+  guarded by a test in `index.test.ts`.)
 - `packages/prisma` → `@unthrown/prisma` (peerDep `@prisma/client` ^7; a Prisma
   Client **extension** — `$extends(unthrownPrisma)` adds `try*` variants of
   **all seventeen** model delegate operations alongside the raw promise ones,

--- a/packages/oxlint/package.json
+++ b/packages/oxlint/package.json
@@ -62,7 +62,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "oxlint": "^1.74.0"
+    "oxlint": "^1.69.0"
   },
   "engines": {
     "node": ">=20"

--- a/packages/oxlint/src/index.test.ts
+++ b/packages/oxlint/src/index.test.ts
@@ -1,6 +1,12 @@
+import { readFileSync } from "node:fs";
+
 import { describe, expect, it } from "vitest";
 
 import plugin from "./index.js";
+
+const manifest: { peerDependencies: Record<string, string> } = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+);
 
 describe("@unthrown/oxlint plugin", () => {
   it("exposes all five rules under the `unthrown` plugin name", () => {
@@ -42,5 +48,16 @@ describe("@unthrown/oxlint plugin", () => {
   it("keeps every preset rule pointing at a rule the plugin actually defines", () => {
     for (const name of Object.keys(plugin.recommended.rules ?? {}))
       expect(plugin.rules).toHaveProperty(name.replace(/^unthrown\//, ""));
+  });
+
+  // Regression guard for #163. The `oxlint` peer floor is the oldest *host* the
+  // rules were verified to run on — it is NOT the `@oxlint/plugins` version this
+  // package happens to build against. Slaving the two (as beta.10 did) ratchets
+  // the floor every time a bot bumps the dependency, forcing consumers through a
+  // lint + type-check engine upgrade for a packaging-only release. Raise this
+  // deliberately, only when a rule starts using a host API that needs it, and say
+  // which API in the changeset.
+  it("keeps the `oxlint` peer floor decoupled from the `@oxlint/plugins` dependency", () => {
+    expect(manifest.peerDependencies["oxlint"]).toBe("^1.69.0");
   });
 });

--- a/packages/oxlint/tsconfig.json
+++ b/packages/oxlint/tsconfig.json
@@ -5,7 +5,10 @@
     "rootDir": "./src",
     // `files: ["dist"]` excludes `src/`, so published declaration maps would be
     // dead-ends (broken go-to-definition); consumers get the TSDoc'd d.ts.
-    "declarationMap": false
+    "declarationMap": false,
+    // `node:fs` + `import.meta.url` in `index.test.ts`, which reads the manifest
+    // to guard the `oxlint` peer floor. Same setting as core's tsconfig.
+    "types": ["node"]
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
Closes #163.

## The bump was mechanical

`@unthrown/oxlint@5.0.0-beta.10` raised its `oxlint` peer from `^1.69.0` to `^1.74.0` while shipping a plugin bundle byte-identical to beta.9's (bar a dropped sourcemap comment). Tracing it back:

- `fd40735` set `^1.69.0` deliberately — *"oxlint JS plugins require >=1.69"*.
- `6c8cb55` (dependabot) took the **`@oxlint/plugins` dependency** 1.73 → 1.74.
- `92c848b` (the pre-v5-stable audit) then raised the **peer** to `^1.74.0` *"matching the `@oxlint/plugins` runtime the rules are built against"*.

So the floor got slaved to a version a bot bumps on its own cadence, not to any host API the rules need. The package README and `docs/how-to/lint-your-codebase.md` were never updated and still say ≥ 1.69 — consistent again after this revert.

## Verified against real hosts

The bundle only touches `context.report` (with `fix`), `context.sourceCode`, `getScope`, and `defineConfig` from `oxlint`. No suggestion API is used — the `suggest` hits in the source are `meta.type: "suggestion"`.

Built the plugin and ran it against real oxlint hosts, with `@oxlint/plugins` held at 1.74.0 (the realistic consumer tree, since that dependency is unchanged here):

| host | diagnostics | `prefer-async-result` autofix |
| --- | --- | --- |
| 1.69.0 | 6/6 rules fire | applies |
| 1.74.0 | 6/6 rules fire | applies |
| 1.76.0 | 6/6 rules fire | applies |

## Why the range mattered downstream

Per the issue: under `strictPeerDependencies` `^1.74.0` fails `pnpm install` outright, and satisfying it cascades into `oxlint@1.74.0` → `oxlint-tsgolint@0.24.0` — a lint **and** type-check engine upgrade across every consuming project, for a packaging-only release. A 14-day `minimumReleaseAge` also left 1.74.0 as the only version both satisfying the range and out of quarantine, effectively pinning consumers to one version.

## Changes

- `packages/oxlint/package.json` — peer `oxlint` back to `^1.69.0`.
- `packages/oxlint/src/index.test.ts` — regression guard pinning the floor, with the reasoning inline so the next mechanical bump fails CI instead of shipping.
- `packages/oxlint/tsconfig.json` — `"types": ["node"]` (mirrors core's), for the manifest read in that test.
- `CLAUDE.md` — records the rule: the peer floor names the oldest verified *host*, decoupled from the `@oxlint/plugins` dependency; raise it only when a rule starts using a host API that needs it, and name that API in the changeset.
- `.changeset/relax-oxlint-peer-floor.md` — patch changeset.

## Notes

- The `@oxlint/plugins` **dependency** stays at `^1.74.0`. It is an ordinary dependency, so it cannot fail a consumer's install, and 1.74's compat shim is exactly what was verified against a 1.69 host.
- 1.69 is not a hard API boundary — hosts down to 1.50.0 also run the plugin in a sweep. `^1.69.0` is restored rather than lowered further because it is the range the package shipped with for its whole life before beta.10: a strict de-restriction, no new support claim.

Gate green locally: `format --check`, `lint`, `typecheck`, `knip`, `test`, `build`, plus `pnpm install --frozen-lockfile` (the lockfile is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)