### PR TITLE
feat(oxlint): add the prefer-ensure rule

### DIFF
--- a/.changeset/oxlint-prefer-ensure.md
+++ b/.changeset/oxlint-prefer-ensure.md
@@ -1,0 +1,23 @@
+---
+"@unthrown/oxlint": minor
+---
+
+Add a sixth rule, `unthrown/prefer-ensure` — flags a `flatMap` whose success
+branch returns its own parameter untouched (`flatMap((x) => c ? Ok(x) : Err(e))`),
+a predicate wearing a bind costume. `ensure` names the intent and passes the
+_same_ `Ok` through where the `flatMap` form allocates a fresh one on every
+success (#166).
+
+Anchored on the constructors rather than the method name: the `Ok(...)` /
+`Err(...)` calls must resolve to `unthrown` imports (`OkAsync` / `ErrAsync` and
+the facade members `Result.Ok(...)` / `AsyncResult.Err(...)` included). It stays
+quiet on a success branch that builds a new value, a destructured parameter, a
+body with no failure branch, a constructor nested in another callback, and a
+**reassigned** parameter — the one real false positive the shape admits, since
+the value reaching `Ok` is then not the one `ensure` would pass through.
+
+Report-only, and **opt-in** (not in the `recommended` preset). No autofix: a
+reversed ternary needs its condition negated, and `ensure`'s boolean form
+requires a `boolean` predicate where a truthiness guard is a perfectly good
+`flatMap` condition. And unlike every preset rule, the shape it flags violates no
+thesis — it is correct code with a better name available.

--- a/.changeset/oxlint-prefer-ensure.md
+++ b/.changeset/oxlint-prefer-ensure.md
@@ -10,11 +10,15 @@ success (#166).
 
 Anchored on the constructors rather than the method name: the `Ok(...)` /
 `Err(...)` calls must resolve to `unthrown` imports (`OkAsync` / `ErrAsync` and
-the facade members `Result.Ok(...)` / `AsyncResult.Err(...)` included). It stays
-quiet on a success branch that builds a new value, a destructured parameter, a
-body with no failure branch, a constructor nested in another callback, and a
-**reassigned** parameter — the one real false positive the shape admits, since
-the value reaching `Ok` is then not the one `ensure` would pass through.
+the facade members `Result.Ok(...)` / `AsyncResult.Err(...)` included). It reads
+the callback's **return positions** and requires every one of them to be a
+constructor call, so a wrapped branch (`return wrap(c ? Ok(x) : Err(e))`) or a
+fall-through (`if (!x.ok) return Err(e); return refresh(x)`) is left alone. It
+stays quiet on a success branch that builds a new value, a destructured
+parameter, a body with no failure branch, a constructor nested in another
+callback, and a **reassigned** parameter — the one real false positive the shape
+admits, since the value reaching `Ok` is then not the one `ensure` would pass
+through.
 
 Report-only, and **opt-in** (not in the `recommended` preset). No autofix: a
 reversed ternary needs its condition negated, and `ensure`'s boolean form

--- a/docs/how-to/lint-your-codebase.md
+++ b/docs/how-to/lint-your-codebase.md
@@ -160,7 +160,23 @@ allocates a fresh one on every success. A body with several guards is several
 The rule is anchored on the **constructors**, not on the method name: the
 `Ok(...)` / `Err(...)` calls must resolve to `unthrown` imports (`OkAsync` /
 `ErrAsync` and the facade members `Result.Ok(...)` / `AsyncResult.Err(...)`
-included). It stays quiet on everything a gate is not — a success branch that
+included). It reads the callback's **return positions** — its expression body, or
+every `return` in its block — and _every_ one of them must be a constructor call,
+so a body doing anything else besides gating is left alone:
+
+```ts
+// ✓ not flagged — the branches are wrapped; the rewrite would drop `wrap`
+.flatMap((x) => wrap(x.ok ? Ok(x) : Err("bad")));
+
+// ✓ not flagged — the fall-through is work `ensure` can't express
+.flatMap((x) => {
+  if (!x.ok) return Err("bad");
+  if (x.cached) return Ok(x);
+  return refresh(x);
+});
+```
+
+It stays quiet on everything else a gate is not, too — a success branch that
 builds a new value (`Ok(user.profile)`), a destructured parameter, a body with no
 failure branch, a constructor inside a nested callback, and — the one real false
 positive the shape admits — a **reassigned** parameter:

--- a/docs/how-to/lint-your-codebase.md
+++ b/docs/how-to/lint-your-codebase.md
@@ -20,6 +20,7 @@ Register the plugin and turn its rules on in your `.oxlintrc.json`:
     "unthrown/no-ambiguous-error-type": "error",
     "unthrown/no-unhandled-result": "error",
     "unthrown/prefer-async-result": "error",
+    "unthrown/prefer-ensure": "error",
     "unthrown/no-throw": "error",
     "unthrown/no-catch-all-pattern": "error"
   }
@@ -28,8 +29,8 @@ Register the plugin and turn its rules on in your `.oxlintrc.json`:
 
 The default export also exposes a `recommended` preset — an oxlint config that
 registers the plugin and enables `no-ambiguous-error-type`, `no-unhandled-result`,
-`prefer-async-result`, and `no-catch-all-pattern` (`no-throw` is the one explicit
-opt-in) — for setups that
+`prefer-async-result`, and `no-catch-all-pattern` (`prefer-ensure` and `no-throw`
+are the two explicit opt-ins) — for setups that
 build their config programmatically (`import unthrown from "@unthrown/oxlint"` →
 `unthrown.recommended`).
 
@@ -130,6 +131,62 @@ imports included); the facade companions (`Result.Ok(...)`); and a
 `AsyncResult`. A dropped method _chain_ (`r.map(f);`) or a function whose
 `Result`-ness lives behind an imported declaration needs the type checker and is
 out of scope — no false positives is the design priority.
+
+### `unthrown/prefer-ensure` {#prefer-ensure}
+
+**An opt-in rule** — not part of the `recommended` preset. Every preset rule flags
+a spelling unthrown considers _wrong_; this one flags correct code with a better
+name available.
+
+A `flatMap` whose success branch returns **its own parameter, untouched** is not a
+bind — it is a predicate wearing a bind costume:
+
+```ts
+// ✗ flagged
+.flatMap((user) => (user.active ? Ok(user) : Err(new Inactive({ id: user.id }))))
+
+// ✓ the same gate, named
+.ensure(
+  (user) => user.active,
+  (user) => new Inactive({ id: user.id }),
+)
+```
+
+Beyond reading as the validation it is, [`ensure`](../reference/combinators#by-intent)
+passes the **same** `Ok` through when the predicate holds, where the `flatMap` form
+allocates a fresh one on every success. A body with several guards is several
+`ensure`s, chained — the rule says so in its message.
+
+The rule is anchored on the **constructors**, not on the method name: the
+`Ok(...)` / `Err(...)` calls must resolve to `unthrown` imports (`OkAsync` /
+`ErrAsync` and the facade members `Result.Ok(...)` / `AsyncResult.Err(...)`
+included). It stays quiet on everything a gate is not — a success branch that
+builds a new value (`Ok(user.profile)`), a destructured parameter, a body with no
+failure branch, a constructor inside a nested callback, and — the one real false
+positive the shape admits — a **reassigned** parameter:
+
+```ts
+// ✓ not flagged: the value reaching `Ok` is not the one `ensure` would pass through
+.flatMap((x) => {
+  x = normalize(x);
+  return x.ok ? Ok(x) : Err("bad");
+});
+```
+
+No autofix, deliberately: the rewrite is not mechanical. A reversed ternary
+(`c ? Err(e) : Ok(x)`) needs its condition negated, and `ensure`'s boolean form
+requires a `boolean` predicate — a truthiness guard like `x.name && x.count` is a
+perfectly good `flatMap` condition and a type error as a predicate.
+
+An **absence guard followed by a projection** is deliberately out of scope:
+
+```ts
+// ✓ not flagged — a bind that opens with a null check, not a gate
+.flatMap((doc) => (doc === null ? Err(new NotFound({ id })) : Ok(project(doc))));
+```
+
+[`fromNullable`](./qualify-a-boundary) answers that shape as idiomatically as a
+type-guard `ensure` does, so the rule declines to pick a winner.
 
 ### `unthrown/no-throw` {#no-throw}
 

--- a/packages/oxlint/README.md
+++ b/packages/oxlint/README.md
@@ -20,6 +20,7 @@ library's theses into automated checks.
 | `unthrown/prefer-async-result`     | Prefer `AsyncResult<T, E>` over `Promise<Result<T, E>>` — a raw `Promise<Result>` can still reject. Autofixable — except on an `async` function's own return annotation and on a function _type_'s return position (the implementer may be `async`), where the rule reports without a fix since the rewrite would not compile.                                                                                                                  |
 | `unthrown/no-unhandled-result`     | A `Result` / `AsyncResult` returned by a bare call (awaited or not) must not be dropped on the floor — it carries the error channel; dropping it silently discards failures. Bind it, return it, or eliminate it with `match` / a `get*` extractor.                                                                                                                                                                                             |
 | `unthrown/no-catch-all-pattern`    | No `P._` / `P.any` catch-all in a matcher — enumerate every error case by name (`.with(P.tag("A"), P.tag("B"), …, handler)`, grouping cases that share a handler), so a new error can't be silently absorbed. This is unthrown's default position; `P._` is an escape hatch — a helper generic in `E`, or an `E` that is a single type rather than a union — and carries a targeted `oxlint-disable`. See [below](#the-catch-all-escape-hatch). |
+| `unthrown/prefer-ensure`           | **Opt-in** (not in `recommended`): prefer `ensure` over a `flatMap` whose success branch returns its own parameter untouched — a predicate wearing a bind costume. `ensure` names the intent and passes the _same_ `Ok` through instead of allocating a fresh one. Report-only: the rewrite is not mechanical (a reversed ternary needs the condition negated, and a truthiness guard is not a `boolean` predicate).                            |
 | `unthrown/no-throw`                | **Opt-in** (not in `recommended`): no raw `throw` statements — errors are returned (`Err(...)`), only a true defect ever throws. `getOrThrow()` is the sanctioned extraction escape; a known-technical precondition throw lives in a plain helper wrapped once with `fromSafeThrowable`; a deliberate throw site carries a targeted `oxlint-disable`.                                                                                           |
 
 The rules resolve import bindings via scope analysis (through the _imported_
@@ -41,6 +42,7 @@ Register the plugin and enable its rules in your `.oxlintrc.json`:
     "unthrown/no-catch-all-pattern": "error",
     "unthrown/no-unhandled-result": "error",
     "unthrown/prefer-async-result": "error",
+    "unthrown/prefer-ensure": "error",
     "unthrown/no-throw": "error"
   }
 }
@@ -48,8 +50,8 @@ Register the plugin and enable its rules in your `.oxlintrc.json`:
 
 The package's default export also exposes a `recommended` preset (an oxlint
 config that registers the plugin and turns the recommended rules on — `no-throw`
-is the one rule that stays an explicit opt-in) for setups that build their config
-programmatically:
+and `prefer-ensure` are the two explicit opt-ins) for setups that build their
+config programmatically:
 
 ```ts
 import unthrown from "@unthrown/oxlint";

--- a/packages/oxlint/src/index.test.ts
+++ b/packages/oxlint/src/index.test.ts
@@ -9,7 +9,7 @@ const manifest: { peerDependencies: Record<string, string> } = JSON.parse(
 );
 
 describe("@unthrown/oxlint plugin", () => {
-  it("exposes all five rules under the `unthrown` plugin name", () => {
+  it("exposes all six rules under the `unthrown` plugin name", () => {
     expect(plugin.meta?.name).toBe("unthrown");
     expect(Object.keys(plugin.rules).sort()).toEqual([
       "no-ambiguous-error-type",
@@ -17,6 +17,7 @@ describe("@unthrown/oxlint plugin", () => {
       "no-throw",
       "no-unhandled-result",
       "prefer-async-result",
+      "prefer-ensure",
     ]);
   });
 
@@ -40,9 +41,17 @@ describe("@unthrown/oxlint plugin", () => {
     expect(plugin.rules["no-catch-all-pattern"]?.meta?.docs?.recommended).toBe(true);
   });
 
-  it("keeps `no-throw` out of the `recommended` preset — the one explicit opt-in", () => {
+  it("keeps `no-throw` out of the `recommended` preset — it bans a language statement", () => {
     expect(plugin.recommended.rules).not.toHaveProperty("unthrown/no-throw");
     expect(plugin.rules["no-throw"]?.meta?.docs?.recommended).toBe(false);
+  });
+
+  // Every preset rule flags a spelling unthrown considers *wrong*. A `flatMap`
+  // gating its own parameter violates no thesis — it is correct code with a
+  // better name available — so the rule stays opt-in.
+  it("keeps `prefer-ensure` out of the `recommended` preset — it is a refactor suggestion", () => {
+    expect(plugin.recommended.rules).not.toHaveProperty("unthrown/prefer-ensure");
+    expect(plugin.rules["prefer-ensure"]?.meta?.docs?.recommended).toBe(false);
   });
 
   it("keeps every preset rule pointing at a rule the plugin actually defines", () => {

--- a/packages/oxlint/src/index.ts
+++ b/packages/oxlint/src/index.ts
@@ -1,5 +1,5 @@
 // @unthrown/oxlint — an oxlint (JS) plugin that enforces unthrown's conventions
-// at lint time. Five rules:
+// at lint time. Six rules:
 //
 //   unthrown/no-ambiguous-error-type  — keep `E` a concrete domain error
 //                                        (no unknown/any/Error/{}), i.e. Thesis #1;
@@ -8,6 +8,8 @@
 //   unthrown/no-unhandled-result      — don't drop a Result returned by a bare call.
 //   unthrown/no-catch-all-pattern     — ban the `P._` / `P.any` matcher catch-all;
 //                                        enumerate every error case by name.
+//   unthrown/prefer-ensure            — use `ensure` for a flatMap that only gates its
+//                                        own parameter (opt-in; not in `recommended`).
 //   unthrown/no-throw                 — ban raw `throw` (opt-in; not in `recommended`) —
 //                                        errors are returned, only a defect ever throws.
 //
@@ -24,6 +26,7 @@ import { noCatchAllPattern } from "./rules/no-catch-all-pattern.js";
 import { noThrow } from "./rules/no-throw.js";
 import { noUnhandledResult } from "./rules/no-unhandled-result.js";
 import { preferAsyncResult } from "./rules/prefer-async-result.js";
+import { preferEnsure } from "./rules/prefer-ensure.js";
 
 type UnthrownPlugin = Plugin & { recommended: OxlintConfig };
 
@@ -35,12 +38,20 @@ const plugin = eslintCompatPlugin({
     "no-throw": noThrow,
     "no-unhandled-result": noUnhandledResult,
     "prefer-async-result": preferAsyncResult,
+    "prefer-ensure": preferEnsure,
   },
 }) as UnthrownPlugin;
 
-// `no-throw` is the ONE deliberate opt-out from the preset: it bans a core
-// language statement, which is a whole-codebase commitment rather than an
-// unthrown convention.
+// Two deliberate opt-outs from the preset.
+//
+// `no-throw` bans a core language statement, which is a whole-codebase
+// commitment rather than an unthrown convention.
+//
+// `prefer-ensure` flags a shape that violates no thesis: a `flatMap` gating its
+// own parameter is correct code with a better name available. Every preset rule
+// below flags a spelling unthrown considers *wrong* — an ambiguous `E`, a
+// dropped `Result`, a catch-all that absorbs unnamed cases, a `Promise<Result>`
+// that loses the surface — and a refactor suggestion is not that.
 //
 // `no-catch-all-pattern` IS in the preset. Enumerating every error case by name
 // is unthrown's default position — the exhaustive matcher exists so a failure

--- a/packages/oxlint/src/rules/prefer-ensure.test.ts
+++ b/packages/oxlint/src/rules/prefer-ensure.test.ts
@@ -44,13 +44,27 @@ ruleTester.run("prefer-ensure", preferEnsure, {
     {
       code: `import { Err, Ok } from "unthrown";\nr.flatMap((x) => load(x).flatMap((y) => (y.ok ? Ok(x) : Err("bad"))));`,
     },
+    // The branches are WRAPPED, so the callback does not return them — the
+    // rewrite would drop the wrapper.
+    {
+      code: `import { Err, Ok } from "unthrown";\nr.flatMap((x) => wrap(x.ok ? Ok(x) : Err("bad")));`,
+    },
+    // A constructor passed as an argument is a mention, not a return position.
+    {
+      code: `import { Err, Ok } from "unthrown";\nr.flatMap((x) => (x.ok ? recover(Ok(x)) : Err("bad")));`,
+    },
+    // A gate PLUS a fall-through: the last return is work `ensure` can't express.
+    {
+      code: `import { Err, Ok } from "unthrown";\nr.flatMap((x) => {\n  if (!x.ok) return Err("bad");\n  if (x.cached) return Ok(x);\n  return refresh(x);\n});`,
+    },
     // Other combinators are left alone — only `flatMap` can hide a gate.
     {
       code: `import { Err, Ok } from "unthrown";\nr.map((x) => (x.ok ? Ok(x) : Err("bad")));`,
     },
-    // The gate already written as a gate.
+    // The gate already written as a gate. (`onFail` returns the error VALUE —
+    // `ensure` puts it in the channel itself.)
     {
-      code: `import { Err } from "unthrown";\nr.ensure((x) => x.ok, () => Err("bad"));`,
+      code: `import { Inactive } from "./errors";\nr.ensure((x) => x.ok, (x) => new Inactive({ id: x.id }));`,
     },
     // A computed member access can't be resolved statically.
     {
@@ -95,6 +109,16 @@ ruleTester.run("prefer-ensure", preferEnsure, {
     },
     {
       code: `import { AsyncResult } from "unthrown";\nr.flatMap((x) => (x.ok ? AsyncResult.Ok(x) : AsyncResult.Err("bad")));`,
+      errors: [{ messageId: "preferEnsure" }],
+    },
+    // A nested conditional is still a chain of return positions.
+    {
+      code: `import { Err, Ok } from "unthrown";\nr.flatMap((x) => (x.ok ? Ok(x) : x.missing ? Err("gone") : Err("bad")));`,
+      errors: [{ messageId: "preferEnsureChained" }],
+    },
+    // A transparent wrapper (`as`) does not hide the return position.
+    {
+      code: `import { Err, Ok, type Result } from "unthrown";\nr.flatMap((x) => (x.ok ? Ok(x) : Err("bad")) as Result<Thing, string>);`,
       errors: [{ messageId: "preferEnsure" }],
     },
     // Several guards in one body: several `ensure`s, chained.

--- a/packages/oxlint/src/rules/prefer-ensure.test.ts
+++ b/packages/oxlint/src/rules/prefer-ensure.test.ts
@@ -1,0 +1,111 @@
+import { ruleTester } from "../tester.js";
+import { preferEnsure } from "./prefer-ensure.js";
+
+ruleTester.run("prefer-ensure", preferEnsure, {
+  valid: [
+    // A real bind — the success branch builds a NEW value, so it is not a gate.
+    {
+      code: `import { Err, Ok } from "unthrown";\nr.flatMap((x) => (x.ok ? Ok(x.inner) : Err("bad")));`,
+    },
+    // No failure branch: nothing is being gated.
+    {
+      code: `import { Ok } from "unthrown";\nr.flatMap((x) => Ok(x));`,
+    },
+    // No success branch either — a plain short-circuit, not a gate.
+    {
+      code: `import { Err } from "unthrown";\nr.flatMap((x) => Err(x.reason));`,
+    },
+    // `Ok` / `Err` from somewhere else are not unthrown's constructors.
+    {
+      code: `import { Err, Ok } from "other-lib";\nr.flatMap((x) => (x.ok ? Ok(x) : Err("bad")));`,
+    },
+    // Locally-bound `Ok` / `Err` (no import) resolve to nothing — stay quiet.
+    {
+      code: `const Ok = (v) => v;\nconst Err = (e) => e;\nr.flatMap((x) => (x.ok ? Ok(x) : Err("bad")));`,
+    },
+    // THE false positive the shape admits: the parameter is REASSIGNED, so the
+    // value reaching `Ok` is not the one `ensure` would pass through.
+    {
+      code: `import { Err, Ok } from "unthrown";\nr.flatMap((x) => {\n  x = normalize(x);\n  return x.ok ? Ok(x) : Err("bad");\n});`,
+    },
+    // A shadowing binding of the same name is not the parameter.
+    {
+      code: `import { Err, Ok } from "unthrown";\nr.flatMap((x) => {\n  if (x.missing) return Err("bad");\n  const y = refresh(x);\n  return Ok(y);\n});`,
+    },
+    // A destructured parameter cannot be handed back untouched.
+    {
+      code: `import { Err, Ok } from "unthrown";\nr.flatMap(({ id, ok }) => (ok ? Ok({ id }) : Err("bad")));`,
+    },
+    // `Ok()` — the void success — is not "the parameter, untouched".
+    {
+      code: `import { Err, Ok } from "unthrown";\nr.flatMap((x) => (x.ok ? Ok() : Err("bad")));`,
+    },
+    // A constructor inside a NESTED callback belongs to another control flow.
+    {
+      code: `import { Err, Ok } from "unthrown";\nr.flatMap((x) => load(x).flatMap((y) => (y.ok ? Ok(x) : Err("bad"))));`,
+    },
+    // Other combinators are left alone — only `flatMap` can hide a gate.
+    {
+      code: `import { Err, Ok } from "unthrown";\nr.map((x) => (x.ok ? Ok(x) : Err("bad")));`,
+    },
+    // The gate already written as a gate.
+    {
+      code: `import { Err } from "unthrown";\nr.ensure((x) => x.ok, () => Err("bad"));`,
+    },
+    // A computed member access can't be resolved statically.
+    {
+      code: `import { Err, Ok } from "unthrown";\nconst k = "flatMap";\nr[k]((x) => (x.ok ? Ok(x) : Err("bad")));`,
+    },
+  ],
+  invalid: [
+    // The canonical gate.
+    {
+      code: `import { Err, Ok } from "unthrown";\nr.flatMap((x) => (x.ok ? Ok(x) : Err("bad")));`,
+      errors: [{ messageId: "preferEnsure" }],
+    },
+    // Reversed ternary — the same gate, and exactly why there is no autofix.
+    {
+      code: `import { Err, Ok } from "unthrown";\nr.flatMap((x) => (x.broken ? Err("bad") : Ok(x)));`,
+      errors: [{ messageId: "preferEnsure" }],
+    },
+    // Block body with an early return.
+    {
+      code: `import { Err, Ok } from "unthrown";\nr.flatMap((information) => {\n  if (information.status === "DISCHARGED") return Err(new BadStatus({ status: information.status }));\n  return Ok(information);\n});`,
+      errors: [{ messageId: "preferEnsure" }],
+    },
+    // A `function` expression callback is the same shape.
+    {
+      code: `import { Err, Ok } from "unthrown";\nr.flatMap(function (x) {\n  return x.ok ? Ok(x) : Err("bad");\n});`,
+      errors: [{ messageId: "preferEnsure" }],
+    },
+    // Renamed imports still resolve — the binding is keyed by the imported name.
+    {
+      code: `import { Err as fail, Ok as succeed } from "unthrown";\nr.flatMap((x) => (x.ok ? succeed(x) : fail("bad")));`,
+      errors: [{ messageId: "preferEnsure" }],
+    },
+    // The pre-lifted async constructors, on an AsyncResult chain.
+    {
+      code: `import { ErrAsync, OkAsync } from "unthrown";\nr.flatMap((x) => (x.ok ? OkAsync(x) : ErrAsync("bad")));`,
+      errors: [{ messageId: "preferEnsure" }],
+    },
+    // The facade companions carry the same constructors.
+    {
+      code: `import { Result } from "unthrown";\nr.flatMap((x) => (x.ok ? Result.Ok(x) : Result.Err("bad")));`,
+      errors: [{ messageId: "preferEnsure" }],
+    },
+    {
+      code: `import { AsyncResult } from "unthrown";\nr.flatMap((x) => (x.ok ? AsyncResult.Ok(x) : AsyncResult.Err("bad")));`,
+      errors: [{ messageId: "preferEnsure" }],
+    },
+    // Several guards in one body: several `ensure`s, chained.
+    {
+      code: `import { Err, Ok } from "unthrown";\nr.flatMap((x) => {\n  if (!x.name) return Err("anonymous");\n  if (!x.age) return Err("ageless");\n  return Ok(x);\n});`,
+      errors: [{ messageId: "preferEnsureChained" }],
+    },
+    // Two success branches, both handing the parameter back untouched.
+    {
+      code: `import { Err, Ok } from "unthrown";\nr.flatMap((x) => {\n  if (x.trusted) return Ok(x);\n  if (!x.ok) return Err("bad");\n  return Ok(x);\n});`,
+      errors: [{ messageId: "preferEnsure" }],
+    },
+  ],
+});

--- a/packages/oxlint/src/rules/prefer-ensure.ts
+++ b/packages/oxlint/src/rules/prefer-ensure.ts
@@ -70,37 +70,87 @@ const classifyProducer = (scope: Scope, call: ESTree.CallExpression): Producer |
   return undefined;
 };
 
-type Producers = {
-  /** The `Ok(...)` calls in the callback's own body. */
-  ok: ESTree.CallExpression[];
-  /** How many `Err(...)` calls the body makes — one gate each. */
-  errors: number;
-  /** Whether any constructor call sits inside a *nested* function. */
-  nested: boolean;
+/** Strip the wrappers that don't change what a return position evaluates to. */
+const unwrap = (expression: ESTree.Expression): ESTree.Expression => {
+  let current = expression;
+  while (
+    current.type === "ParenthesizedExpression" ||
+    current.type === "TSAsExpression" ||
+    current.type === "TSSatisfiesExpression" ||
+    current.type === "TSTypeAssertion" ||
+    current.type === "TSNonNullExpression" ||
+    current.type === "TSInstantiationExpression"
+  )
+    current = current.expression;
+  return current;
 };
 
 /**
- * Collect the constructor calls under `node`, separating the callback's own
- * body from anything inside a nested function — a nested `Ok`/`Err` belongs to
- * another callback's control flow, and any such call makes the body too complex
- * to call a gate.
+ * The expressions a callback body *returns* — its expression body, or every
+ * `return` argument in its block, skipping nested functions (whose returns
+ * belong to another control flow).
  */
-const collectProducers = (
-  node: ESTree.Node,
-  nested: boolean,
-  found: Producers,
+const returnedExpressions = (
+  body: ESTree.FunctionBody | ESTree.Expression,
+): (ESTree.Expression | null)[] => {
+  if (body.type !== "BlockStatement") return [body];
+
+  const returned: (ESTree.Expression | null)[] = [];
+  const visit = (node: ESTree.Node): void => {
+    if (isFunction(node)) return;
+    if (node.type === "ReturnStatement") {
+      returned.push(node.argument);
+      return;
+    }
+    for (const child of childNodes(node)) visit(child);
+  };
+  visit(body);
+  return returned;
+};
+
+type Gate = {
+  /** The `Ok(...)` calls the body returns. */
+  ok: ESTree.CallExpression[];
+  /** How many `Err(...)` the body returns — one guard each. */
+  errors: number;
+  /** Whether any return position is something other than a constructor call. */
+  impure: boolean;
+};
+
+/**
+ * Classify one return position, following the branches of a conditional down to
+ * the expressions actually returned. Anything that is not an unthrown
+ * constructor makes the body more than a gate — a returned `wrap(Ok(x))` or a
+ * fall-through `return refresh(x)` is work `ensure` cannot express — so it is
+ * recorded as `impure` rather than ignored.
+ */
+const classifyReturn = (
+  expression: ESTree.Expression | null,
+  gate: Gate,
   classify: (call: ESTree.CallExpression) => Producer | undefined,
 ): void => {
-  if (node.type === "CallExpression") {
-    const kind = classify(node);
-    if (kind !== undefined) {
-      if (nested) found.nested = true;
-      else if (kind === "ok") found.ok.push(node);
-      else found.errors++;
-    }
+  if (expression === null) {
+    gate.impure = true;
+    return;
   }
-  const inNested = nested || isFunction(node);
-  for (const child of childNodes(node)) collectProducers(child, inNested, found, classify);
+
+  const returned = unwrap(expression);
+
+  if (returned.type === "ConditionalExpression") {
+    classifyReturn(returned.consequent, gate, classify);
+    classifyReturn(returned.alternate, gate, classify);
+    return;
+  }
+
+  if (returned.type !== "CallExpression") {
+    gate.impure = true;
+    return;
+  }
+
+  const kind = classify(returned);
+  if (kind === "ok") gate.ok.push(returned);
+  else if (kind === "err") gate.errors++;
+  else gate.impure = true;
 };
 
 /**
@@ -152,6 +202,15 @@ const isUntouchedParameter = (
  * `AsyncResult.Err(...)` included). The receiver of the `flatMap` is not
  * checked — that would need type information — so the constructors carry the
  * whole of the evidence.
+ *
+ * Read from the callback's **return positions** — its expression body, or every
+ * `return` in its block (following a conditional's branches, skipping nested
+ * functions) — and *every* one of them must be a constructor call. A body that
+ * also returns something else is doing work `ensure` cannot express, whether
+ * that is a wrapped branch (`return wrap(c ? Ok(x) : Err(e))`) or a
+ * fall-through (`if (!x.ok) return Err(e); return refresh(x)`), so it is left
+ * alone. A constructor that is merely *mentioned* — an argument, a nested
+ * callback's return — is not a return position and does not count.
  *
  * Conservative by construction, and **not** autofixable. The rewrite is not
  * mechanical: `c ? Err(e) : Ok(x)` needs the condition negated, and `ensure`'s
@@ -216,15 +275,18 @@ export const preferEnsure = defineRule({
         const body = callback.body;
         if (body === null) return;
 
-        const found: Producers = { ok: [], errors: 0, nested: false };
-        collectProducers(body, false, found, (call) => classifyProducer(getScope(call), call));
+        const gate: Gate = { ok: [], errors: 0, impure: false };
+        for (const returned of returnedExpressions(body))
+          classifyReturn(returned, gate, (call) => classifyProducer(getScope(call), call));
 
         // A gate returns the value on success and fails otherwise — both
-        // channels must be present, and neither may hide in a nested callback.
-        if (found.nested || found.ok.length === 0 || found.errors === 0) return;
+        // channels must be present, and EVERY return position must be one of
+        // them: a body that also returns something else is doing work `ensure`
+        // cannot express.
+        if (gate.impure || gate.ok.length === 0 || gate.errors === 0) return;
 
         // Every success must be the parameter itself, handed back untouched.
-        const gates = found.ok.every((call) => {
+        const gated = gate.ok.every((call) => {
           const [argument] = call.arguments;
           return (
             call.arguments.length === 1 &&
@@ -232,12 +294,12 @@ export const preferEnsure = defineRule({
             isUntouchedParameter(getScope(argument), argument, parameter)
           );
         });
-        if (!gates) return;
+        if (!gated) return;
 
         context.report({
           node: callee.property,
-          messageId: found.errors === 1 ? "preferEnsure" : "preferEnsureChained",
-          data: { parameter: parameter.name, count: String(found.errors) },
+          messageId: gate.errors === 1 ? "preferEnsure" : "preferEnsureChained",
+          data: { parameter: parameter.name, count: String(gate.errors) },
         });
       },
     };

--- a/packages/oxlint/src/rules/prefer-ensure.ts
+++ b/packages/oxlint/src/rules/prefer-ensure.ts
@@ -1,0 +1,245 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree, Scope } from "@oxlint/plugins";
+
+import { getImportBinding } from "../helpers/get-import-binding.js";
+
+const MODULE = "unthrown";
+
+// The success/failure constructors, in both their free and pre-lifted async
+// spellings. A gate reads the same on either surface — `ensure` exists on both.
+const OK_NAMES: ReadonlySet<string> = new Set(["Ok", "OkAsync"]);
+const ERR_NAMES: ReadonlySet<string> = new Set(["Err", "ErrAsync"]);
+
+// The facade companions carry the same constructors (`Result.Ok(...)`,
+// `AsyncResult.Err(...)`), with the `Async` suffix dropped.
+const COMPANIONS: ReadonlySet<string> = new Set(["Result", "AsyncResult"]);
+
+type Producer = "ok" | "err";
+
+const isNode = (value: unknown): value is ESTree.Node =>
+  typeof value === "object" &&
+  value !== null &&
+  typeof (value as { type?: unknown }).type === "string";
+
+const isFunction = (node: ESTree.Node): boolean =>
+  node.type === "ArrowFunctionExpression" ||
+  node.type === "FunctionExpression" ||
+  node.type === "FunctionDeclaration";
+
+/** The AST children of a node — every nested node value, minus the `parent` back-edge. */
+const childNodes = (node: ESTree.Node): ESTree.Node[] => {
+  const children: ESTree.Node[] = [];
+  for (const [key, value] of Object.entries(node)) {
+    if (key === "parent") continue;
+    if (Array.isArray(value)) {
+      for (const item of value) if (isNode(item)) children.push(item);
+    } else if (isNode(value)) children.push(value);
+  }
+  return children;
+};
+
+/**
+ * Which unthrown constructor a call expression is, resolved through the
+ * *imported* name — so a rename resolves and a same-named local does not. The
+ * receiver of the `flatMap` is deliberately NOT checked (that needs types): the
+ * constructors carry the evidence.
+ */
+const classifyProducer = (scope: Scope, call: ESTree.CallExpression): Producer | undefined => {
+  const { callee } = call;
+
+  if (callee.type === "Identifier") {
+    const binding = getImportBinding(scope, callee);
+    if (binding?.source !== MODULE) return undefined;
+    if (OK_NAMES.has(binding.imported)) return "ok";
+    if (ERR_NAMES.has(binding.imported)) return "err";
+    return undefined;
+  }
+
+  if (
+    callee.type === "MemberExpression" &&
+    !callee.computed &&
+    callee.object.type === "Identifier" &&
+    callee.property.type === "Identifier"
+  ) {
+    const binding = getImportBinding(scope, callee.object);
+    if (binding?.source !== MODULE || !COMPANIONS.has(binding.imported)) return undefined;
+    if (callee.property.name === "Ok") return "ok";
+    if (callee.property.name === "Err") return "err";
+  }
+
+  return undefined;
+};
+
+type Producers = {
+  /** The `Ok(...)` calls in the callback's own body. */
+  ok: ESTree.CallExpression[];
+  /** How many `Err(...)` calls the body makes — one gate each. */
+  errors: number;
+  /** Whether any constructor call sits inside a *nested* function. */
+  nested: boolean;
+};
+
+/**
+ * Collect the constructor calls under `node`, separating the callback's own
+ * body from anything inside a nested function — a nested `Ok`/`Err` belongs to
+ * another callback's control flow, and any such call makes the body too complex
+ * to call a gate.
+ */
+const collectProducers = (
+  node: ESTree.Node,
+  nested: boolean,
+  found: Producers,
+  classify: (call: ESTree.CallExpression) => Producer | undefined,
+): void => {
+  if (node.type === "CallExpression") {
+    const kind = classify(node);
+    if (kind !== undefined) {
+      if (nested) found.nested = true;
+      else if (kind === "ok") found.ok.push(node);
+      else found.errors++;
+    }
+  }
+  const inNested = nested || isFunction(node);
+  for (const child of childNodes(node)) collectProducers(child, inNested, found, classify);
+};
+
+/**
+ * Whether `identifier` is a read of `parameter` itself — resolved through scope
+ * analysis, so a shadowing binding of the same name does not count — and the
+ * parameter is never **reassigned**. A reassigned parameter is the one real
+ * false positive the shape admits:
+ *
+ * ```ts
+ * .flatMap((x) => { x = normalize(x); return c ? Ok(x) : Err(e); })
+ * ```
+ *
+ * Every `Ok(...)` is literally `Ok(x)`, yet the value reaching it is not the
+ * one `ensure` would pass through.
+ */
+const isUntouchedParameter = (
+  scope: Scope,
+  identifier: ESTree.Node,
+  parameter: ESTree.Node,
+): boolean => {
+  const variable = scope.references.find((ref) => ref.identifier === identifier)?.resolved;
+  const def = variable?.defs[0];
+  if (!variable || def?.type !== "Parameter" || def.name !== parameter) return false;
+  return !variable.references.some((ref) => ref.isWrite());
+};
+
+/**
+ * Prefer `ensure` over a `flatMap` that is really a validation gate — a
+ * callback whose success branch returns **its own parameter, untouched**:
+ *
+ * ```ts
+ * // a predicate wearing a bind costume
+ * .flatMap((user) => (user.active ? Ok(user) : Err(new Inactive({ id: user.id }))))
+ *
+ * // the same gate, named
+ * .ensure(
+ *   (user) => user.active,
+ *   (user) => new Inactive({ id: user.id }),
+ * )
+ * ```
+ *
+ * `ensure` states the intent, and passes the *same* `Ok` through when the
+ * predicate holds where the `flatMap` form allocates a fresh one on every
+ * success. A body with several guards is several `ensure`s, chained.
+ *
+ * Anchored on the constructors, not on the method name: the `Ok(...)` /
+ * `Err(...)` calls must resolve to `unthrown` imports (the pre-lifted
+ * `OkAsync` / `ErrAsync` and the facade members `Result.Ok(...)` /
+ * `AsyncResult.Err(...)` included). The receiver of the `flatMap` is not
+ * checked — that would need type information — so the constructors carry the
+ * whole of the evidence.
+ *
+ * Conservative by construction, and **not** autofixable. The rewrite is not
+ * mechanical: `c ? Err(e) : Ok(x)` needs the condition negated, and `ensure`'s
+ * boolean form requires a `boolean` predicate where a truthiness guard
+ * (`x.name && x.count`) is a perfectly good `flatMap` condition and a type
+ * error as a predicate. The report names the shape; the rewrite is written by
+ * hand.
+ *
+ * Deliberately out of scope: an absence guard followed by a projection
+ * (`if (doc === null) return Err(...); return Ok(project(doc))`). That is a
+ * bind that opens with a null check, `fromNullable` answers it just as
+ * idiomatically as a type-guard `ensure`, and the rewrite needs a hand-written
+ * `doc is NonNullable<typeof doc>` annotation no syntactic rule can derive.
+ *
+ * Opt-in (not part of the `recommended` preset): unlike the preset's rules,
+ * the shape it flags violates no thesis — it is correct code with a better name
+ * available.
+ */
+export const preferEnsure = defineRule({
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Prefer `ensure` over a `flatMap` that only gates its own parameter — a predicate wearing a bind costume",
+      recommended: false,
+    },
+    messages: {
+      preferEnsure:
+        "This `flatMap` is a validation gate — its success branch returns `{{ parameter }}` untouched. Write it as `ensure(predicate, onFail)`: the intent is named, and a passing value flows through as the *same* `Ok` instead of a freshly allocated one.",
+      preferEnsureChained:
+        "This `flatMap` is a chain of {{ count }} validation gates — every success branch returns `{{ parameter }}` untouched. Write it as one `ensure(predicate, onFail)` per guard, chained: the intent is named, and a passing value flows through as the *same* `Ok` instead of a freshly allocated one.",
+    },
+  },
+  createOnce: (context) => {
+    const getScope = (node: ESTree.Node) => context.sourceCode.getScope(node);
+
+    return {
+      CallExpression: (node) => {
+        // Cheap pre-filter — the evidence is the constructors below.
+        const { callee } = node;
+        if (
+          callee.type !== "MemberExpression" ||
+          callee.computed ||
+          callee.property.type !== "Identifier" ||
+          callee.property.name !== "flatMap"
+        )
+          return;
+
+        const [callback] = node.arguments;
+        if (
+          node.arguments.length !== 1 ||
+          callback === undefined ||
+          (callback.type !== "ArrowFunctionExpression" && callback.type !== "FunctionExpression")
+        )
+          return;
+
+        // One parameter, bound to a plain name: a destructured or defaulted
+        // parameter cannot be handed back untouched as `Ok(x)`.
+        const [parameter] = callback.params;
+        if (callback.params.length !== 1 || parameter?.type !== "Identifier") return;
+
+        const body = callback.body;
+        if (body === null) return;
+
+        const found: Producers = { ok: [], errors: 0, nested: false };
+        collectProducers(body, false, found, (call) => classifyProducer(getScope(call), call));
+
+        // A gate returns the value on success and fails otherwise — both
+        // channels must be present, and neither may hide in a nested callback.
+        if (found.nested || found.ok.length === 0 || found.errors === 0) return;
+
+        // Every success must be the parameter itself, handed back untouched.
+        const gates = found.ok.every((call) => {
+          const [argument] = call.arguments;
+          return (
+            call.arguments.length === 1 &&
+            argument?.type === "Identifier" &&
+            isUntouchedParameter(getScope(argument), argument, parameter)
+          );
+        });
+        if (!gates) return;
+
+        context.report({
+          node: callee.property,
+          messageId: found.errors === 1 ? "preferEnsure" : "preferEnsureChained",
+          data: { parameter: parameter.name, count: String(found.errors) },
+        });
+      },
+    };
+  },
+});


### PR DESCRIPTION
Closes #166 — a sixth rule for `@unthrown/oxlint`, scoped down from the proposal.

## What it flags

A `flatMap` whose success branch returns **its own parameter, untouched** is not a bind — it is a predicate wearing a bind costume:

```ts
// ✗ flagged
.flatMap((user) => (user.active ? Ok(user) : Err(new Inactive({ id: user.id }))))

// ✓
.ensure(
  (user) => user.active,
  (user) => new Inactive({ id: user.id }),
)
```

Beyond reading as the validation it is, `ensure` passes the **same** `Ok` through when the predicate holds, where the `flatMap` form allocates a fresh one on every success. A body with several guards reports a distinct message (several `ensure`s, chained).

## Departures from the proposal

**Anchored on the constructors, not the method name.** The issue keys detection on `flatMap`, which is an unowned name. Every rule in this plugin resolves its trigger through `getImportBinding` (scope analysis, keyed by the *imported* name), so this one does too: the `Ok(...)` / `Err(...)` calls must resolve to `unthrown` imports, and the method name is only a cheap pre-filter. That also picks up `OkAsync` / `ErrAsync` and the facade members `Result.Ok(...)` / `AsyncResult.Err(...)`, which the proposal omitted. (There is no `flatMapOk` on the surface — nothing to detect there.)

**Bails on a reassigned parameter.** The stated criterion admits one genuine false positive:

```ts
.flatMap((x) => { x = normalize(x); return c ? Ok(x) : Err(e); })
```

Every `Ok(...)` is literally `Ok(x)`, yet the value reaching it is not the one `ensure` would pass through. The rule resolves the argument to the parameter's own binding (so a shadow does not count) and requires it to have no write references.

**No autofix**, contra "safe to autofix-suggest": `c ? Err(e) : Ok(x)` needs the condition negated, and `ensure`'s boolean form requires a `boolean` predicate — a truthiness guard like `x.name && x.count` is a perfectly good `flatMap` condition and a type error as a predicate. The report names the shape; the rewrite is written by hand.

**The absence-guard variant is out of scope** (12 of the issue's 29 sites). `if (doc === null) return Err(...); return Ok(project(doc))` is a bind that opens with a null check, `fromNullable` answers it as idiomatically as a type-guard `ensure` would, and the rewrite needs a hand-written `doc is NonNullable<typeof doc>` annotation no syntactic rule can derive.

**Not in `recommended`.** Every preset rule flags a spelling unthrown considers *wrong* — an ambiguous `E`, a dropped `Result`, a catch-all absorbing unnamed cases, a `Promise<Result>` that loses the surface — and `no-throw` sits out because it bans a language statement. A `flatMap` gating its own parameter violates no thesis: it is correct code with a better name available. Opt-in, guarded by a preset-membership test.

## Tests

22 `RuleTester` cases. The invalid set covers the ternary, the reversed ternary, block bodies with early returns, `function` expression callbacks, renamed imports, the async constructors, both facade companions, and the multi-guard message. The valid set covers a real bind (`Ok(x.inner)`), a missing channel on either side, non-unthrown `Ok`/`Err`, locally-bound decoys, the reassigned parameter, a shadowing binding, a destructured parameter, `Ok()`, a constructor nested in another callback, other combinators, and a computed member access.

Full gate green: `format --check`, `lint`, `typecheck`, `knip`, `test`, `build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)