### PR TITLE
chore: exit prerelease mode for the v5 stable release

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "@unthrown/boxed": "4.3.0",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -653,7 +653,7 @@ AsyncResult<infer T, …>` — structural inference over the whole method surfac
   `Result` via `fromSchema` / `fromSchemaAsync`, with the validation issues as
   the modeled `E`)
 - `packages/oxlint` → `@unthrown/oxlint` (an oxlint **JS plugin**, peerDep
-  `oxlint`, dep `@oxlint/plugins`; ships **five rules**: `no-ambiguous-error-type`
+  `oxlint`, dep `@oxlint/plugins`; ships **six rules**: `no-ambiguous-error-type`
   — enforces Thesis #1 against `unknown`/`any`/`Error`/`{}` **and the primitive
   keywords** (`void` included) in `E`, both in a `Result`/`AsyncResult` type
   **annotation** and in the matcher's `returnType<R>()` **pin** — the latter only
@@ -681,9 +681,22 @@ AsyncResult<infer T, …>` — structural inference over the whole method surfac
   sanctioned catch-all), and the sites that must keep the wildcard — a helper
   generic in `E`, or an `E` that is a single type rather than a union of
   cases — carry a targeted `oxlint-disable` with a reason); and
-  `no-throw` (**the one opt-in**, not in the preset — reports every `throw`
+  `no-throw` (**opt-in**, not in the preset — reports every `throw`
   statement, pointing at `Err`/`getOrThrow`/`fromSafeThrowable`; this is the
-  `no-throw` rule the `getOrThrow` rationale references).
+  `no-throw` rule the `getOrThrow` rationale references); and `prefer-ensure`
+  (**the other opt-in**, report-only with **no autofix** — flags a `flatMap`
+  whose success branch returns its own parameter untouched
+  (`flatMap((x) => c ? Ok(x) : Err(e))`), a predicate wearing a bind costume:
+  `ensure` names that intent and passes the _same_ `Ok` through where the
+  `flatMap` form allocates a fresh one. Anchored on the constructors rather
+  than the method name — the `Ok(...)` / `Err(...)` calls must resolve to
+  `unthrown` imports (`OkAsync` / `ErrAsync` and the facade members included) —
+  and it requires **every** return position of the callback to be a constructor
+  call, so a wrapped branch or a fall-through is left alone; a **reassigned**
+  parameter is the one false positive the shape admits. No autofix because a
+  reversed ternary needs its condition negated and `ensure`'s boolean form
+  requires a `boolean` predicate. Unlike every preset rule, the shape it flags
+  violates no thesis — it is correct code with a better name available).
   Purely syntactic AST rules that
   resolve bindings via scope analysis keyed by the **imported** name (renamed
   and namespace imports resolve; alias indirection like `type E = unknown` is a


### PR DESCRIPTION
Ends the v5 beta line. Flips `.changeset/pre.json` to `mode: "exit"` so the
next `changeset version` on main consumes the 30 accumulated changesets into
**stable** versions instead of a beta.13 bump.

Dry run of `pre exit` + `version` (in a throwaway clone, working tree untouched):

| package | from | to |
| --- | --- | --- |
| `unthrown`, `@unthrown/{vitest,effect,neverthrow,boxed,oxlint,standard-schema}` | `5.0.0-beta.12` | **`5.0.0`** |
| `@unthrown/orpc` | `0.1.1-beta.2` | **`0.1.1`** |
| `@unthrown/prisma` | `0.1.1-beta.2` | **`0.1.1`** |

The fixed group bumps major from the `initialVersions` base of `4.3.0`; `orpc`
and `prisma` stay outside it, tracking their upstreams' cadence. After the run
`.changeset/` holds only `README.md` and `config.json`.

Also folds in a spec sync: `CLAUDE.md` still said the oxlint plugin ships **five**
rules and that `no-throw` was **the one** opt-in — `prefer-ensure` (#167) made it
six and two. The docs site already covers the rule; only the spec file was stale.

## After this merges

CI green on main → the Release workflow opens the `chore: release packages` PR
with the versions above → merging *that* publishes to npm, pushes the tags, and
redeploys the docs. Once `changeset version` deletes `pre.json`, main is the
stable line again and the site drops the `/beta/` path.

Worth watching on this one: `deploy-docs.yml` documents that its chained
`workflow_run` on Release is not guaranteed to fire, and this is the first real
release since that note. `workflow_dispatch` is the manual fallback.

## Verification

`pnpm format --check`, `pnpm lint`, `pnpm typecheck`, `pnpm knip`, `pnpm test`,
`pnpm build` — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)