### PR TITLE
docs: add the unthrown agent skill for skills.sh distribution

### DIFF
--- a/skills/unthrown/SKILL.md
+++ b/skills/unthrown/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: unthrown
+description: Write and review TypeScript that uses the unthrown library — errors as values via a Result type with a separate defect channel, exhaustive error matching, and qualified async boundaries. Use when the project depends on unthrown or any @unthrown/* package, when converting throw/try-catch code to errors as values, when working with Result/AsyncResult values, TaggedError, fromPromise/fromThrowable, mapErrCases-style combinators, or when testing with @unthrown/vitest or linting with @unthrown/oxlint.
+---
+
+# unthrown
+
+Errors as values for TypeScript, with a separate **defect channel** for the
+unexpected. Ordinary errors are _unthrown_ — returned as values; only a true
+defect ever throws (at extraction). Zero runtime dependencies; the exhaustive
+matcher (`match` / `P`) is built in.
+
+Full docs: https://btravstack.github.io/unthrown/
+
+## Mental model (get this right first)
+
+`Result<T, E>` is a **three-variant discriminated union**:
+
+- `{ tag: "Ok", value: T }` — success.
+- `{ tag: "Err", error: E }` — an **anticipated, modeled** failure. `E` lists
+  only failures the caller is expected to handle.
+- `{ tag: "Defect", cause: unknown }` — an **unmodeled** failure (a bug, an
+  unqualified throw). A defect **never appears in `E`** — it travels in its own
+  channel, flows through almost every combinator untouched, and is handled only
+  at the edge (`match`'s `defect` arm) or by `recoverDefect`.
+
+Three rules that follow:
+
+1. **Never type `E` as `unknown`, `any`, `Error`, or a primitive keyword.** `E`
+   is a union of concrete, nameable cases (string literals, `TaggedError`
+   classes, `code`-discriminated objects).
+2. **There is no `Option` type.** Use `T | undefined`, `Result<T, NotFound>`,
+   or `fromNullable(value, () => err)` at nullable boundaries.
+3. **A thrown callback never escapes a pipeline** — every combinator catches it
+   and converts it to a `Defect`. So there is **no `try/catch` around Result
+   pipelines, ever**; the `defect` arm of the final `match` is the catch.
+
+## Construct and chain
+
+```ts
+import { Ok, Err, type Result } from "unthrown";
+
+type AgeError = "not_a_number" | "negative";
+
+function parseAge(input: string): Result<number, AgeError> {
+  const n = Number(input);
+  if (Number.isNaN(n)) return Err("not_a_number");
+  if (n < 0) return Err("negative");
+  return Ok(n);
+}
+
+const adult = parseAge(input)
+  .map((n) => n + 1) // callback returns a value
+  .flatMap((n) => (n >= 18 ? Ok(n) : Err("underage"))); // callback returns a Result
+// Result<number, AgeError | "underage"> — flatMap unions the error channels
+```
+
+`Ok(v)` / `Err(e)` are plain functions (not classes — never `new`). `Ok()` with
+no argument makes a `Result<void, never>`. There is deliberately **no `Defect`
+constructor** — defects arise from throws and boundary triage only. Narrow with
+`r.isOk()` / `r.isErr()` / `r.isDefect()` (type predicates) or a `switch` on
+`r.tag`.
+
+## Boundaries: every throw/rejection is triaged
+
+Throwing or rejecting code enters through a boundary that forces a **triage
+decision** via `qualify(cause, defect) => E | Defect` — decide per cause whether
+it is a modeled error or a defect. `qualify` must be **synchronous** (an `async`
+qualify does not compile). There is no path that puts `unknown` in `E`.
+
+```ts
+import {
+  fromPromise,
+  fromThrowable,
+  fromSafeThrowable,
+  fromSafePromise,
+  fromNullable,
+} from "unthrown";
+
+// Promise → AsyncResult; each rejection cause triaged
+const user = fromPromise(fetchUser(id), (cause, defect) =>
+  cause instanceof NotFoundError ? ("not_found" as const) : defect(cause),
+);
+
+// Throwing fn → wrapped fn returning Result (wraps the FUNCTION, not a call)
+const parse = fromThrowable(
+  (text: string) => JSON.parse(text) as unknown,
+  (cause, defect) => (cause instanceof SyntaxError ? ("invalid_json" as const) : defect(cause)),
+);
+parse("nope"); // => Err("invalid_json")
+
+// "every throw here is a bug" → E = never, no qualify
+const decode = fromSafeThrowable((row: Row) => schema.parse(row));
+const cfg = fromSafePromise(loadConfig()); // async twin
+
+// nullable APIs (the Option replacement)
+fromNullable(map.get(key), () => "absent" as const); // Result<V, "absent">
+```
+
+The `Defect` arm of `qualify`'s return is **subtracted** from `E` — a
+defect-only qualify yields `E = never`. The `defect` helper is **injected** as
+the second argument; never import it.
+
+## The error channel: matched exhaustively, never blanket-handled
+
+The error combinators carry a `*Cases` suffix and take a **matcher callback**,
+not a plain `(e) => …` callback (there is no `mapErr`). The callback receives a
+match builder plus the injected `defect` helper and **returns the un-terminated
+builder** — the combinator calls `.exhaustive()` itself. A missed case **does
+not compile**; enriching `E` breaks every consuming site until each is handled.
+
+```ts
+import { P } from "unthrown";
+
+result.mapErrCases(
+  (matcher, defect) =>
+    matcher
+      .with(P.tag("RecordNotFound"), () => new ReadingNotFound(id)) // transform a case
+      .with(P.tag("DriverError"), (e) => defect(e.cause)), // deliberately defect a case
+);
+```
+
+- The five: `mapErrCases` (transform `E`), `flatMapErrCases` (fallback
+  `Result`), `recoverErrCases` (error → success value, `E` becomes `never`),
+  `tapErrCases` / `flatTapErrCases` (observe; the error flows through).
+- Match on **any structure**: `P.tag("X")` for `_tag`, plain literals
+  (`.with("negative", …)`), object patterns (`.with({ code: "NOT_FOUND" }, …)`),
+  `P.instanceOf`, `P.when`. Cases sharing a handler are **grouped**
+  (`.with(P.tag("A"), P.tag("B"), handler)`), never wildcarded.
+- **`P._` is an escape hatch, not the default.** It absorbs every future case —
+  the exact hole the matcher closes. Legitimate only in a helper generic in `E`
+  (nothing enumerable) or when `E` is a single non-union type; such sites carry
+  an `oxlint-disable … unthrown/no-catch-all-pattern` comment with a reason.
+- Never call `.exhaustive()` / `.otherwise()` yourself in these callbacks — you
+  return the builder. `matcher.returnType<R>()` (called first) pins the output
+  type when a signature decides it.
+- A branch that returns `defect(cause)` or throws contributes nothing to the
+  outgoing `E` (the `Defect` arm is subtracted).
+
+## Eliminate at the edge
+
+Fold all three channels once, at the edge — an HTTP adapter needs no
+surrounding `try/catch`:
+
+```ts
+const message = result.match({
+  ok: (age) => `age is ${age}`,
+  errCases: (matcher) =>
+    matcher.with("negative", () => "must be positive").with("not_a_number", () => "not a number"),
+  defect: (cause) => {
+    logger.error(cause);
+    return "something went wrong";
+  },
+});
+```
+
+Extractors (when a fold is overkill): `get()` compiles **only** on
+`Result<T, never>`; `getErr()` only on `Result<never, E>` — empty the opposite
+channel first. `getOr(fallback)` / `getOrElse(f)` / `getOrNull()` /
+`getOrUndefined()` recover an `Err` to a fallback. **All of them panic
+(rethrow the cause) on a Defect** — a defect is a bug, not an absent value.
+`getOrThrow()` throws the modeled error as-is (the sanctioned escape hatch
+under a `no-throw` lint rule); it compiles only when `E` is non-empty. The
+removed v4 names `unwrap*` / `orElse` / `recover` / `matchTags` do not exist.
+
+## AsyncResult: sync callbacks, boundaries for async work
+
+`AsyncResult<T, E>` is the awaitable twin — same combinators. Its **internal
+promise never rejects**: `await asyncResult` always yields a `Result`. Three
+deltas:
+
+1. **Combinator callbacks are synchronous.** A raw `Promise` return does not
+   compile (it would bypass qualification). Async work re-enters through a
+   boundary and composes with `flatMap`:
+   ```ts
+   const status = await findUser(id) // Result<User, NotFound>
+     .toAsync() // lift sync → AsyncResult
+     .flatMap((u) => fromPromise(loadOrders(u.id), (c, d) => d(c)))
+     .map((orders) => orders.length) // sync callback, stays async
+     .match({
+       ok: (n) => n,
+       errCases: (m) => m.with(P.tag("NotFound"), () => 0),
+       defect: () => -1,
+     });
+   ```
+2. The `Result`-returning combinators (`flatMap`, `flatTap`, `bind`,
+   `flatMapErrCases`, `flatTapErrCases`, `recoverDefect`) accept a callback
+   returning a `Result` **or** an `AsyncResult` — mix sync and async steps.
+3. Eliminators return a `Promise` — `await result.match({…})`, or `await` the
+   `AsyncResult` first and match synchronously.
+
+Pre-lifted constructors for the sync branch of an async function: `OkAsync(v)`
+/ `ErrAsync(e)` (not `Ok(v).toAsync()`).
+
+## TaggedError: the error convention
+
+```ts
+import { TaggedError } from "unthrown";
+
+class NotFound extends TaggedError("NotFound") {} // empty payload → new NotFound()
+class HttpError extends TaggedError("HttpError")<{ status: number }> {
+  override message = `http ${this.status}`; // message: a class field, NEVER a payload field
+}
+new HttpError({ status: 500 }); // .status, ._tag, instanceof Error
+```
+
+The payload carries **only structured domain fields** — `name`, `message`, and
+`stack` are reserved (`?: never`); `cause` is allowed (it is `Error.cause`).
+Match with `P.tag("HttpError")`. `options.name` sets the display name when the
+tag is namespaced (`TaggedError("pkg/NotFound", { name: "NotFound" })`).
+
+## Mistakes agents make (habits from neverthrow/Effect/fp-ts)
+
+| Habit                                                                          | In unthrown                                                                                         |
+| ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| `mapErr((e) => …)`, `orElse`, `andThen`                                        | Don't exist. `mapErrCases`/`flatMapErrCases` with the matcher; `flatMap`.                           |
+| `r.unwrap()` / `unwrapOr(x)`                                                   | Removed. `get()` (needs `E = never`) / `getOr(x)`.                                                  |
+| `Option` / `Some` / `None`                                                     | No Option. `T \| undefined`, `Result<T, NotFound>`, `fromNullable`.                                 |
+| `try { pipeline } catch`                                                       | Never needed — throws become Defects; `match`'s `defect` arm is the catch.                          |
+| `Result<T, unknown>` / `Result<T, Error>`                                      | Banned (lint: `no-ambiguous-error-type`). Model concrete cases.                                     |
+| `async (v) => …` inside `map`/`flatMap`/matcher branches                       | Compile error by design. Use `fromPromise` + `flatMap`.                                             |
+| `.with(P._, …)` as a default fallback                                          | Enumerate or group cases; `P._` only for generic-`E` helpers, with a lint-disable + reason.         |
+| Constructing a Defect (`Defect(x)`)                                            | No constructor. `throw` (the net catches it) or the injected `defect` helper at triage sites.       |
+| `message` in a TaggedError payload                                             | Reserved. `override message = …` on the class; context goes in typed fields.                        |
+| `tap((v) => auditLog.record(v))` where the effect returns a Result/AsyncResult | Effect outcome silently dropped/floats. Use `flatTap` on the matching surface.                      |
+| Serializing a Result (JSON, structuredClone)                                   | Unsupported by design. `match` at the boundary; re-enter via constructors on the other side.        |
+| `throw` in app code for known failures                                         | Return `Err(...)`. `throw` is for genuine defects only (the opt-in `no-throw` rule bans even that). |
+
+## References
+
+- **[references/api.md](references/api.md)** — the full combinator table
+  (by-intent + per-channel behavior), matcher patterns (`P.*`), do-notation
+  (`Do`/`bind`/`let`), aggregates (`all`/`allFromDict` + async), guards,
+  facade namespaces (`Result.*`/`AsyncResult.*`), and utility types. Read when
+  choosing a combinator or writing anything beyond the basics above.
+- **[references/ecosystem.md](references/ecosystem.md)** — the `@unthrown/*`
+  satellite packages: vitest matchers (`toBeOk`/`toBeErrTagged`/…), the six
+  oxlint rules, Prisma extension (`try*` delegates), oRPC bridge,
+  standard-schema validation, and the effect/neverthrow/boxed interop bridges.
+  Read when tests, lint config, or one of those integrations is involved.

--- a/skills/unthrown/SKILL.md
+++ b/skills/unthrown/SKILL.md
@@ -7,8 +7,9 @@ description: Write and review TypeScript that uses the unthrown library — erro
 
 Errors as values for TypeScript, with a separate **defect channel** for the
 unexpected. Ordinary errors are _unthrown_ — returned as values; only a true
-defect ever throws (at extraction). Zero runtime dependencies; the exhaustive
-matcher (`match` / `P`) is built in.
+defect ever throws (at extraction — `getOrThrow` being the one deliberate
+escape hatch that throws a modeled error). Zero runtime dependencies; the
+exhaustive matcher (`match` / `P`) is built in.
 
 Full docs: https://btravstack.github.io/unthrown/
 

--- a/skills/unthrown/references/api.md
+++ b/skills/unthrown/references/api.md
@@ -1,0 +1,198 @@
+# unthrown API reference
+
+Contents: [Combinators by intent](#combinators-by-intent) ·
+[Per-channel behavior](#per-channel-behavior) ·
+[Easy-to-confuse pairs](#easy-to-confuse-pairs) ·
+[Matcher patterns](#matcher-patterns) ·
+[Do-notation](#do-notation) · [Aggregates](#aggregates) ·
+[Guards](#guards) · [Facade namespaces](#facade-namespaces) ·
+[Utility types](#utility-types) · [Runtime facts](#runtime-facts)
+
+## Combinators by intent
+
+Same set on `Result` and `AsyncResult`. Error combinators abbreviate their
+matcher callback as `(matcher) => …`.
+
+| I want to…                                     | use               | signature                                                    | channel      |
+| ---------------------------------------------- | ----------------- | ------------------------------------------------------------ | ------------ |
+| transform the success value                    | `map`             | `(v: T) => U` → `Result<U, E>`                               | Ok           |
+| chain a `Result`-returning step                | `flatMap`         | `(v: T) => Result<U, E2>` → `Result<U, E \| E2>`             | Ok           |
+| run a side effect, keep the value              | `tap`             | `(v: T) => void` → `Result<T, E>`                            | Ok           |
+| run a **failable** side effect, keep the value | `flatTap`         | `(v: T) => Result<unknown, E2>` → `Result<T, E \| E2>`       | Ok           |
+| validate a success / refine its type           | `ensure`          | `((v: T) => boolean, (v: T) => E2)` → `Result<T, E \| E2>`   | Ok           |
+| sequence steps into a named scope              | `Do`/`bind`/`let` | `bind(k, (scope) => Result<U, E2>)` → `Result<{…}, E \| E2>` | Ok           |
+| replace the value with a constant              | `as`              | `(value: U)` → `Result<U, E>`                                | Ok           |
+| drop the value (becomes `void`)                | `discard`         | `()` → `Result<void, E>`                                     | Ok           |
+| transform the error (matched)                  | `mapErrCases`     | `(matcher) => …` → `Result<T, E2>`                           | Err          |
+| try a fallback that returns a `Result`         | `flatMapErrCases` | `(matcher) => …` → `Result<T \| U, E2>`                      | Err          |
+| turn an error into a success value             | `recoverErrCases` | `(matcher) => …` → `Result<T \| U, never>`                   | Err          |
+| run a side effect on the error                 | `tapErrCases`     | `(matcher) => …` → `Result<T, E>`                            | Err          |
+| run a **failable** side effect on the error    | `flatTapErrCases` | `(matcher) => …` → `Result<T, E \| E2>`                      | Err          |
+| recover from a defect (rare)                   | `recoverDefect`   | `(cause) => Result<U, E2>` → `Result<T \| U, E \| E2>`       | Defect       |
+| observe a defect (log it)                      | `tapDefect`       | `(cause) => void` → `Result<T, E>`                           | Defect       |
+| observe **any** failure (error or defect)      | `tapFailure`      | `(f: FailureView<E>) => void` → `Result<T, E>`               | Err + Defect |
+| handle all three channels at the edge          | `match`           | `{ ok, errCases, defect }` → `R`                             | all          |
+
+`ensure` with a type-guard predicate narrows `T` to `U`. A `flatMap` whose
+callback is just a predicate wearing a bind costume
+(`flatMap((x) => c ? Ok(x) : Err(e))`) should be `ensure(c, () => e)` — it
+names the intent and passes the same `Ok` through (the opt-in `prefer-ensure`
+lint rule flags this).
+
+There is deliberately **no** `recoverFailure` and no channel-moving operators
+(`Err`→`Defect` erases the modeled type; `Defect`→`Err` would put `unknown` in
+`E`). The deliberate `Err`→`Defect` form is a `defect(cause)` branch in an
+error matcher.
+
+## Per-channel behavior
+
+A combinator touches only its own channel; the other two flow through.
+
+| method                            | on `Ok` | on `Err`      | on `Defect` | resulting `E`   |
+| --------------------------------- | ------- | ------------- | ----------- | --------------- |
+| `map` / `tap`                     | runs    | passes        | passes      | `E`             |
+| `flatMap` / `flatTap` / `ensure`  | runs    | passes        | passes      | `E \| E2`       |
+| `mapErrCases` / `flatMapErrCases` | passes  | branch        | passes      | `E2`            |
+| `recoverErrCases`                 | passes  | branch → `Ok` | passes      | `never`         |
+| `tapErrCases` / `flatTapErrCases` | passes  | branch        | passes      | `E` / `E \| E2` |
+| `recoverDefect`                   | passes  | passes        | runs        | `E \| E2`       |
+| `tapDefect`                       | passes  | passes        | runs        | `E`             |
+| `tapFailure`                      | passes  | runs          | runs        | `E`             |
+| `match`                           | `ok()`  | `errCases()`  | `defect()`  | —               |
+
+Caveat: `recoverErrCases`'s `never` empties only the **error** channel — a
+`Defect` can still be present at runtime and flows past it untouched. Do not
+read `Result<T, never>` as "cannot fail"; `get()` still panics on a defect.
+
+## Easy-to-confuse pairs
+
+- **`map` vs `flatMap`** — callback returns a plain value → `map`; returns a
+  `Result` → `flatMap` (else you nest `Result<Result<…>>`).
+- **`flatMap` vs `flatTap`** — `flatMap` replaces the value with the
+  callback's; `flatTap` keeps the original and threads only the effect's error.
+- **`tap` vs `flatTap`** — decided by what the effect returns. Cannot fail
+  (logging, metric) → `tap`; returns `Result`/`AsyncResult` → `flatTap`
+  (inside `tap` the effect's outcome is silently dropped or floats).
+- **`flatMapErrCases` vs `recoverErrCases`** — recover produces a plain success
+  value (`E` → `never`); flatMapErrCases produces another `Result` (may still
+  be `Err`).
+- **`recoverErrCases` vs `recoverDefect`** — modeled `Err` vs `Defect`;
+  neither is the other's fallback.
+- **`tapErrCases`+`tapDefect` vs `tapFailure`** — same effect for both failure
+  kinds → `tapFailure`; its callback gets the discriminated variant
+  (`ErrView | DefectView`), branch on `failure.tag`.
+
+## Matcher patterns
+
+`match(value)` / `P` are exported from `unthrown` (built in, no ts-pattern).
+Inside error combinators the builder arrives as the callback's `matcher`
+parameter — return it **un-terminated**. Standalone (e.g. matching a whole
+`Result`) you terminate it yourself with `.exhaustive()`.
+
+| pattern                             | matches                                             |
+| ----------------------------------- | --------------------------------------------------- |
+| `P.tag("X")`                        | `{ _tag: "X" }` — narrows to that variant + payload |
+| a literal (`"negative"`, `404`)     | itself                                              |
+| an object (`{ code: "NOT_FOUND" }`) | shallow structural match                            |
+| `P.instanceOf(Cls)`                 | `instanceof`                                        |
+| `P.when((x) => boolean)`            | guard (a type guard narrows)                        |
+| `P.union(a, b)`                     | any of the sub-patterns                             |
+| `P.string` / `P.number`             | any string / number                                 |
+| `P._` (alias `P.any`)               | everything — escape hatch only (see SKILL.md)       |
+
+- Group cases sharing a handler: `.with(P.tag("A"), P.tag("B"), handler)`.
+- `matcher.returnType<R>()` — call directly after receiving the matcher; pins
+  every branch to `R` and makes the match evaluate to `R`. Needed to write a
+  `defect(…)` branch in `flatTapErrCases`.
+- Deliberately unsupported: deep structural inversion, `P.select`, array
+  patterns.
+- Matching a whole `Result` works natively:
+  `match(r).with({ tag: "Ok" }, ({ value }) => …).with({ tag: "Err" }, …).with({ tag: "Defect" }, …).exhaustive()`.
+- `NonExhaustiveError` (exported) is thrown when a rogue value slips past the
+  types with no matching arm; inside combinators the throw-to-defect net turns
+  it into a `Defect`, in `match` it throws.
+
+## Do-notation
+
+`Do()` starts an empty object scope (`Ok({})`); `bind` sequences a
+`Result`-returning step under a name; `let` binds a pure value. `DoAsync()`
+(alias `AsyncResult.Do`) is the pre-lifted async twin — its `bind` also
+accepts `AsyncResult`-returning callbacks.
+
+```ts
+import { Do } from "unthrown";
+
+const r = Do()
+  .bind("user", () => findUser(id)) // Result<User, NotFound>
+  .bind("plan", ({ user }) => findPlan(user)) // errors union
+  .let("label", ({ user, plan }) => `${user.name}/${plan.name}`)
+  .map(({ label }) => label);
+// Result<string, NotFound | PlanError>
+```
+
+Errors/defects short-circuit; a throw in a step becomes a `Defect`. There is
+**no** generator (`gen`/`yield*`) do-notation — deliberately excluded.
+
+## Aggregates
+
+All four short-circuit on the first `Err`, any `Defect` dominates, and none
+accumulate errors (deliberately excluded).
+
+- `all([r1, r2])` — tuple in, positional tuple out
+  (`Result<[A, B], E1 | E2>`); a dynamic `Result<T, E>[]` collapses to
+  `Result<T[], E>`.
+- `allFromDict({ a: ra, b: rb })` → `Result<{ a: A; b: B }, E>` — named
+  parallel work without tupling.
+- `allAsync` / `allFromDictAsync` — the `AsyncResult` twins; resolve
+  concurrently, never reject. Facade: `AsyncResult.all` / `AsyncResult.allFromDict`.
+
+## Guards
+
+- Methods `r.isOk()` / `r.isErr()` / `r.isDefect()` and standalone
+  `isOk(r)` / `isErr(r)` / `isDefect(r)` — all narrow (to
+  `OkView`/`ErrView`/`DefectView`).
+- `isResult(x)` — narrows `unknown` to `Result<unknown, unknown>`; survives
+  dual-package/cross-realm copies (brand fallback). A structural
+  `{ tag: "Ok" }` look-alike is **not** a Result.
+
+## Facade namespaces
+
+The free functions are primary (tree-shakeable). Two opt-in companion objects
+group them **by what they return**:
+
+- `Result.*`: `Ok`, `Err`, `Do`, `fromNullable`, `fromThrowable`,
+  `fromSafeThrowable`, `all`, `allFromDict`, `isOk`/`isErr`/`isDefect`/`isResult`.
+- `AsyncResult.*`: `Ok` (= `OkAsync`), `Err` (= `ErrAsync`), `Do`
+  (= `DoAsync`), `fromPromise`, `fromSafePromise`, `all` (= `allAsync`),
+  `allFromDict` (= `allFromDictAsync`).
+
+Both are value + type companions — `Result<T, E>` / `AsyncResult<T, E>` are the
+same names as types.
+
+## Utility types
+
+| type                                             | purpose                                                       |
+| ------------------------------------------------ | ------------------------------------------------------------- |
+| `Result<T, E>` / `AsyncResult<T, E>`             | the public types                                              |
+| `OkView<T, E>` / `ErrView<E, T>` / `DefectView`  | the narrowed variants                                         |
+| `FailureView<E, T>`                              | `ErrView \| DefectView` — what `tapFailure` receives          |
+| `OkOf<R>` / `ErrOf<R>`                           | extract a `Result`'s channels from a function return type     |
+| `AsyncOkOf<R>` / `AsyncErrOf<R>`                 | same for `AsyncResult`                                        |
+| `NotThenable<R>`                                 | compile-time ban on thenable callback returns                 |
+| `ErrMatcher<E>`                                  | the matcher-callback parameter type (parameter position only) |
+| `TaggedErrorConstructor` / `TaggedErrorInstance` | type an `extends TaggedError(…)` site externally              |
+
+`GetError` (exported) is the defensive wrong-variant error `get`/`getErr`
+throw — reachable only via casts or raw JS.
+
+## Runtime facts
+
+- Result instances and both prototypes are `Object.freeze`d — variants cannot
+  be forged by mutation.
+- `get`/`getErr`/`getOr…` on a `Defect` rethrow the **original cause** with its
+  original stack (they panic).
+- A throw inside a failure **observer** (`tapErrCases`/`tapDefect`/
+  `tapFailure`/`flatTapErrCases`) produces a `Defect` whose cause is
+  `AggregateError([thrown, original])` — observing a failure never destroys it.
+- An `AsyncResult`'s internal promise never rejects; `await` always yields a
+  `Result`.

--- a/skills/unthrown/references/api.md
+++ b/skills/unthrown/references/api.md
@@ -33,6 +33,11 @@ matcher callback as `(matcher) => …`.
 | observe **any** failure (error or defect)      | `tapFailure`      | `(f: FailureView<E>) => void` → `Result<T, E>`               | Err + Defect |
 | handle all three channels at the edge          | `match`           | `{ ok, errCases, defect }` → `R`                             | all          |
 
+Signatures are abbreviated to intent: a `=> void` return means the callback's
+return value is ignored, and every callback not constrained to return a
+`Result` is actually typed `(…) => R & NotThenable<R>` — a thenable/async
+callback is a compile error (see [Utility types](#utility-types)).
+
 `ensure` with a type-guard predicate narrows `T` to `U`. A `flatMap` whose
 callback is just a predicate wearing a bind costume
 (`flatMap((x) => c ? Ok(x) : Err(e))`) should be `ensure(c, () => e)` — it
@@ -171,16 +176,16 @@ same names as types.
 
 ## Utility types
 
-| type                                             | purpose                                                       |
-| ------------------------------------------------ | ------------------------------------------------------------- |
-| `Result<T, E>` / `AsyncResult<T, E>`             | the public types                                              |
-| `OkView<T, E>` / `ErrView<E, T>` / `DefectView`  | the narrowed variants                                         |
-| `FailureView<E, T>`                              | `ErrView \| DefectView` — what `tapFailure` receives          |
-| `OkOf<R>` / `ErrOf<R>`                           | extract a `Result`'s channels from a function return type     |
-| `AsyncOkOf<R>` / `AsyncErrOf<R>`                 | same for `AsyncResult`                                        |
-| `NotThenable<R>`                                 | compile-time ban on thenable callback returns                 |
-| `ErrMatcher<E>`                                  | the matcher-callback parameter type (parameter position only) |
-| `TaggedErrorConstructor` / `TaggedErrorInstance` | type an `extends TaggedError(…)` site externally              |
+| type                                             | purpose                                                                                                             |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| `Result<T, E>` / `AsyncResult<T, E>`             | the public types                                                                                                    |
+| `OkView<T, E>` / `ErrView<E, T>` / `DefectView`  | the narrowed variants                                                                                               |
+| `FailureView<E, T = never>`                      | `ErrView \| DefectView` — what `tapFailure` receives (`T` is phantom; `FailureView<MyError>` is the usual spelling) |
+| `OkOf<R>` / `ErrOf<R>`                           | extract a `Result`'s channels from a function return type                                                           |
+| `AsyncOkOf<R>` / `AsyncErrOf<R>`                 | same for `AsyncResult`                                                                                              |
+| `NotThenable<R>`                                 | compile-time ban on thenable callback returns                                                                       |
+| `ErrMatcher<E>`                                  | the matcher-callback parameter type (parameter position only)                                                       |
+| `TaggedErrorConstructor` / `TaggedErrorInstance` | type an `extends TaggedError(…)` site externally                                                                    |
 
 `GetError` (exported) is the defensive wrong-variant error `get`/`getErr`
 throw — reachable only via casts or raw JS.

--- a/skills/unthrown/references/ecosystem.md
+++ b/skills/unthrown/references/ecosystem.md
@@ -1,0 +1,131 @@
+# @unthrown/* satellite packages
+
+Contents: [Testing: @unthrown/vitest](#testing-unthrownvitest) ·
+[Linting: @unthrown/oxlint](#linting-unthrownoxlint) ·
+[Prisma](#prisma-unthrownprisma) · [oRPC](#orpc-unthrownorpc) ·
+[Validation: @unthrown/standard-schema](#validation-unthrownstandard-schema) ·
+[Interop bridges](#interop-bridges-effect-neverthrow-boxed)
+
+Every satellite takes core (`unthrown`) as a peer/`workspace:^` dependency —
+never pin core exactly (dual-copy hazard with `isResult`'s `instanceof`).
+
+## Testing: @unthrown/vitest
+
+Importing the package registers matchers via `expect.extend` (its one
+import-time side effect) and a module-level `afterEach`.
+
+| matcher                            | asserts                                                                                                                                             |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `toBeOk()` / `toBeOkWith(value)`   | Ok / Ok with deep-equal value                                                                                                                       |
+| `toBeErr()` / `toBeErrWith(error)` | Err / Err with deep-equal error                                                                                                                     |
+| `toBeErrTagged(tag, payload?)`     | Err carrying a TaggedError with `_tag === tag`; optional payload is deep-compared (exact for a plain object, partial for `expect.objectContaining`) |
+| `toBeDefect()`                     | Defect                                                                                                                                              |
+
+They detect a thenable `AsyncResult` and await internally:
+
+```ts
+await expect(asyncResult).toBeErrTagged("NotFound", { id: "42" });
+```
+
+A forgotten `await` on an async assertion fails the test at its end
+(`failOnForgottenAwait`, auto-registered), naming the pending matchers. Manual
+wiring exports: the six raw matcher functions, `failOnForgottenAwait`, and the
+`UnthrownMatchers` type.
+
+## Linting: @unthrown/oxlint
+
+An oxlint JS plugin (peer `oxlint`). Six rules; scope-analysis keyed to
+unthrown imports, so they only fire on unthrown's `Result`.
+
+**Recommended preset:**
+
+- `no-ambiguous-error-type` — bans `unknown`/`any`/`Error`/`{}`/primitive
+  keywords in `E` (annotations and `returnType<R>()` pins inside `mapErrCases`).
+- `prefer-async-result` — reports `Promise<Result<T, E>>` in favour of
+  `AsyncResult<T, E>` (no autofix on `async` function return annotations or
+  function-type return positions — those must stay `Promise`).
+- `no-unhandled-result` — flags a bare expression statement dropping a
+  `Result` (syntactic; a dropped method chain is out of scope).
+- `no-catch-all-pattern` — reports `P._` / `P.any`; keep-the-wildcard sites
+  (generic-`E` helpers, single-type `E`) carry a targeted `oxlint-disable`
+  with a reason.
+
+**Opt-in (not in the preset):**
+
+- `no-throw` — reports every `throw`, pointing at
+  `Err`/`getOrThrow`/`fromSafeThrowable`.
+- `prefer-ensure` — flags `flatMap((x) => c ? Ok(x) : Err(e))` (a predicate
+  wearing a bind costume); report-only, no autofix.
+
+## Prisma: @unthrown/prisma
+
+Peer `@prisma/client` ^7 (node >= 20.19). A client extension:
+
+```ts
+import { unthrownPrisma } from "@unthrown/prisma";
+const db = new PrismaClient({ adapter }).$extends(unthrownPrisma);
+
+db.user.tryFindUniqueOrThrow({ where: { id } });
+// AsyncResult<User, RecordNotFound | DriverError>
+```
+
+- `try*` variants of all seventeen model delegate operations; the error
+  channel is exactly the P-codes that operation can raise:
+  `UniqueConstraintViolation` (P2002), `ForeignKeyViolation` (P2003),
+  `RecordNotFound` (P2025), everything else `DriverError` with the cause
+  preserved. `upsert` and `*Many` batch mutations never carry `RecordNotFound`.
+- `$tryTransaction(cb)` — interactive transaction whose callback speaks
+  `AsyncResult`: an `Err` rolls back and re-surfaces typed; a defect (throwing
+  callback included) rolls back and stays a defect.
+- `tryPaginate(...).withCursor(...)` — cursor pagination.
+- `qualifyPrismaError` — the exported qualify, for hand-rolled boundaries.
+- Raw methods remain the escape hatch for batch `$transaction([...])` and raw
+  SQL.
+
+## oRPC: @unthrown/orpc
+
+Peers `@orpc/client` + optional `@orpc/server` (^2.0.0-beta). Mapping: `Ok` ↔
+output, `Err` ↔ returned _inferable_ `ORPCError` (declared via `.errors({...})`
+or returned as a value), `Defect` ↔ everything else (collapses to
+`INTERNAL_SERVER_ERROR` on the wire). Three entry points, no root export:
+
+- `@unthrown/orpc/server` — `handlerResult(fn)` adapts a `Result`-returning
+  handler; `Err` must be an `ORPCError` (do the `mapErrCases` into
+  `errors.CODE(...)` at the endpoint); a `Defect` rethrows its cause. The
+  callback may be async (an elimination edge, exempt like `match`).
+- `@unthrown/orpc/extensions/result` — opt-in `.result()` builder method
+  (side-effectful import: prototype patches + module augmentation).
+- `@unthrown/orpc/client` — `fromCall(promise)` lifts one call;
+  `createResultClient(client)` wraps a whole router. `E` is the raw inferable
+  `ORPCError` union discriminated by `code` — match with
+  `.with({ code: "NOT_FOUND" }, …)`, not `P.tag`.
+- Event-iterator (streaming) procedures are out of scope — use the raw client.
+
+## Validation: @unthrown/standard-schema
+
+Bridges any Standard Schema validator (Zod, Valibot, ArkType) to `Result`:
+
+- `fromSchema(schema, input)` → `Result<Output, SchemaIssues>`
+- `fromSchemaAsync(schema, input)` → `AsyncResult<Output, SchemaIssues>`
+
+The validation issues are the modeled `E` — no throwing parse.
+
+## Interop bridges (effect, neverthrow, boxed)
+
+Thin `to*`/`from*` bridges. The shape rule: **does the neighbour have a defect
+channel?**
+
+- `@unthrown/effect` — Effect has one (`Cause.die`), so `Result ↔ Exit` is a
+  bijection: `toExit`/`fromExit` (a die-cause defect dominates), plus
+  `toEffect`/`fromEffect` and `toEither`/`fromEither` (`toEither` has no
+  defect target, so it takes a mandatory `onDefect`).
+- `@unthrown/neverthrow` — no defect channel: `fromNeverthrow` /
+  `fromNeverthrowAsync` (only Ok/Err come in); `toNeverthrow` /
+  `toNeverthrowAsync` take a **mandatory** `onDefect: (cause) => E` (forced
+  triage; there is no one-arg form).
+- `@unthrown/boxed` — same rule (peer is `@bloodyowl/boxed`, the maintained
+  scope): `fromBoxed` / `fromBoxedFuture`; `toBoxed` / `toBoxedFuture` with
+  mandatory `onDefect`.
+
+The async names are deliberately asymmetric (`toNeverthrowAsync` vs
+`toBoxedFuture`) — each names the neighbour's own async type.


### PR DESCRIPTION
## What

Adds an [agent skill](https://www.skills.sh/) at `skills/unthrown/` teaching AI coding agents how to use unthrown correctly:

- **`SKILL.md`** — the three-variant mental model (`Ok`/`Err`/`Defect`), construct & chain, boundary qualification, the exhaustive `*Cases` matcher protocol, edge elimination, `AsyncResult`'s sync-callback rule, `TaggedError`, and a "mistakes agents make" table mapping neverthrow/Effect/fp-ts habits (`mapErr`, `unwrap`, `Option`, `try/catch` around pipelines, `P._` fallbacks) to the correct unthrown form.
- **`references/api.md`** — full combinator tables (by intent + per-channel behavior), matcher patterns, do-notation, aggregates, guards, facade namespaces, utility types, runtime facts.
- **`references/ecosystem.md`** — the `@unthrown/*` satellites: vitest matchers, the six oxlint rules, Prisma, oRPC, standard-schema, and the effect/neverthrow/boxed bridges.

Every example was checked against the actual source (signatures verified in `packages/*/src`), not paraphrased.

## Why

Agents trained on neverthrow/Effect misuse unthrown by default — a skill corrects those habits up front, and AI-assisted usability is increasingly part of library adoption.

## Distribution

The layout matches the [skills CLI](https://github.com/vercel-labs/skills) flat convention (`skills/<name>/SKILL.md`), so once merged anyone can run `npx skills add btravstack/unthrown` — no submission step; skills.sh indexes installs automatically.

## Notes

- `skills/` sits outside the pnpm workspace: no package, changeset, build, or test impact. `pnpm format --check` and `pnpm knip` pass (markdown formatted with oxfmt).