### PR TITLE
docs: add the migrating-to-unthrown skill and the Boxed migration guide

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -49,6 +49,7 @@ const GUIDE_SIDEBAR = [
       { text: "Upgrade from 4.x to 5.0", link: "/how-to/upgrade-to-v5" },
       { text: "Migrate from try/catch", link: "/how-to/migrate-from-try-catch" },
       { text: "Migrate from neverthrow", link: "/how-to/migrate-from-neverthrow" },
+      { text: "Migrate from Boxed", link: "/how-to/migrate-from-boxed" },
       { text: "Qualify a boundary", link: "/how-to/qualify-a-boundary" },
       { text: "Model errors", link: "/how-to/model-errors" },
       { text: "Sequence dependent steps", link: "/how-to/sequence-dependent-steps" },

--- a/docs/how-to/migrate-from-boxed.md
+++ b/docs/how-to/migrate-from-boxed.md
@@ -1,0 +1,132 @@
+# Migrate from Boxed
+
+> **How-to.** Boxed (`@bloodyowl/boxed`) and unthrown agree on the core —
+> failures as values, a `Result` you match on — so most of the `Result` surface
+> maps row for row. The real work sits in the types Boxed has and unthrown
+> deliberately does not: `Option`, `AsyncData`, and `Future`'s untriaged error
+> channel. Do those on purpose, not by search-and-replace.
+
+## API mapping
+
+| Boxed                                                    | unthrown                                          | Notes                                                                            |
+| -------------------------------------------------------- | ------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `Result.Ok(v)` / `Result.Error(e)`                       | `Ok(v)` / `Err(e)`                                | free functions, not statics                                                      |
+| `result.map(f)` / `result.flatMap(f)`                    | same                                              | callbacks must be synchronous                                                    |
+| `result.mapError(f)`                                     | `result.mapErrCases((matcher) => …)`              | an exhaustive match — one `.with(…)` arm per case in `E`, not a single callback  |
+| `result.match({ Ok, Error })`                            | `match({ ok, errCases: (matcher) => …, defect })` | the third channel is new — see below                                             |
+| `result.getWithDefault(v)` / `getOr(v)`                  | `result.getOr(v)`                                 | still throws on a Defect (a bug is not an absent value)                          |
+| `result.toUndefined()` / `toNull()`                      | `getOrUndefined()` / `getOrNull()`                | same recovery, `get…` spelling                                                   |
+| `result.tapOk(f)` / `tapError(f)`                        | `tap(f)` / `tapErrCases((matcher) => …)`          | the error observer takes the same exhaustive matcher                             |
+| `Result.fromExecution(fn)`                               | `fromThrowable(fn, qualify)`                      | wraps the **function**; `qualify` triages each throw into `E` or `defect(cause)` |
+| `Result.fromNullable(v)` (+ `fromNull`, `fromUndefined`) | `fromNullable(v, onAbsent)`                       | absence gets a **named** error, not `undefined` in `E`                           |
+| `Result.all([...])` / `allFromDict({...})`               | `all([...])` / `allFromDict({...})`               | same shapes; any `Defect` dominates                                              |
+| `Future<Result<T, E>>`                                   | `AsyncResult<T, E>`                               | both never reject — the kinship that makes this migration natural                |
+| `Future.fromPromise(p)`                                  | `fromPromise(p, qualify)`                         | Boxed hands you `Result<T, Error>`; `qualify` forces the triage instead          |
+| `future.mapOk(f)` / `future.mapError(f)`                 | `asyncResult.map(f)` / `mapErrCases(…)`           | the `Ok`-suffix disappears — the combinators are channel-named already           |
+| `future.flatMapOk(f)`                                    | `asyncResult.flatMap(f)`                          | `f` may return a `Result` or an `AsyncResult`                                    |
+| `future.mapOkToResult(f)`                                | `flatMap(f)` — or `ensure(pred, onFail)`          | when `f` only gates its own argument, `ensure` is the named form                 |
+| `future.mapErrorToResult(f)`                             | `flatMapErrCases((matcher) => …)`                 | fallback on the error channel, exhaustively                                      |
+| `Future.all([...])`                                      | `allAsync([...])`                                 | `Future.allFromDict` → `allFromDictAsync`                                        |
+| `Option`                                                 | —                                                 | deliberately no `Option` — see below                                             |
+| `AsyncData` / `Deferred`                                 | —                                                 | request-lifecycle state, not error handling — see below                          |
+| `Future.retry` / `Future.concurrent`                     | —                                                 | orchestrate with your async tooling **before** the `fromPromise` boundary        |
+
+## Delta 1 — `Option` disappears
+
+unthrown has no `Option` type, on purpose: absence is expressed with the type
+system we already trust. Each `Option` in your code is one of three things —
+decide which, per site:
+
+```ts
+// 1. Absence is a normal, expected shape → T | undefined
+function findCached(sku: string): Item | undefined {
+  return cache.get(sku) ?? undefined;
+}
+
+// 2. Absence is a failure the caller must handle → Result<T, NotFound>
+function requireItem(sku: string): Result<Item, ItemNotFound> {
+  return fromNullable(cache.get(sku), () => new ItemNotFound({ sku }));
+}
+
+// 3. A nullable third-party API crossing into a pipeline → fromNullable at the boundary
+const port = fromNullable(process.env["PORT"], () => "port_unset" as const);
+```
+
+An `Option`-returning helper whose callers all fold with a default
+(`getWithDefault`) is case 1 — the migration usually _deletes_ the combinator
+chain, because with `T | undefined` a plain conditional does the folding.
+`option.toResult(error)` sites are case 2 by definition. Resist inventing a
+local `Option` to keep the shapes — the [design decision](../explanation/design-decisions)
+is that two ways to spell absence is one too many.
+
+## Delta 2 — the error channel is triaged, and defects get their own lane
+
+Boxed's `Future.fromPromise` gives you `Result<T, Error>` — every rejection,
+expected or not, lands in the error channel as `Error` (usually behind an
+`as Error` cast). unthrown's boundary makes you decide, per cause:
+
+```ts
+// Boxed — everything is Error, the cast is load-bearing
+Future.fromPromise(api.get(`/items/${sku}`)).mapError((e) => e as Error);
+
+// unthrown — each rejection is triaged into a named case or the defect channel
+fromPromise(api.get(`/items/${sku}`), (cause, defect) =>
+  isHttpNotFound(cause) ? new ItemNotFound({ sku }) : defect(cause),
+);
+```
+
+If a boundary's rejections really are all one anticipated failure, qualify them
+all into one named case (`(cause) => new FetchFailed({ sku, cause })`) — ignoring
+the injected `defect` helper is a legitimate "fully modeled" decision. What you
+may not do is keep `E = Error`: the
+[`no-ambiguous-error-type`](./lint-your-codebase#no-ambiguous-error-type) rule
+holds the line, and everything that was "whatever, stick it in `Error`" now
+belongs to [the defect channel](../explanation/the-defect-channel).
+
+The payoff mirrors the [neverthrow migration](./migrate-from-neverthrow#delta-1--the-defect-channel):
+a throw inside any combinator becomes a `Defect` and flows to `match`'s
+mandatory `defect` arm, so the defensive `try`/`catch` around pipelines goes
+away.
+
+## Delta 3 — `AsyncData` has no target, and that's fine
+
+`AsyncData` models a request's _lifecycle_ (`NotAsked` / `Loading` / `Done`),
+which is UI state, not error handling — unthrown deliberately stays out of it.
+Two honest options:
+
+```ts
+// Model it yourself — a small discriminated union, matchable natively
+type ItemState =
+  { tag: "NotAsked" } | { tag: "Loading" } | { tag: "Done"; result: Result<Item, FetchFailed> };
+```
+
+or keep using Boxed's `AsyncData` for view state while the data layer speaks
+unthrown — the two compose fine, since the `Done` payload can hold an unthrown
+`Result`. What should **not** survive is `AsyncData` used as an error-handling
+device deep in the data layer. One caveat either way: a `Result` does not
+survive `structuredClone`/JSON — fold it with `match` before persisting or
+sending state over a wire.
+
+## Migrate gradually with the bridge
+
+`@unthrown/boxed` keeps a mixed codebase compiling while you migrate module by
+module: `fromBoxed` / `fromBoxedFuture` lift a still-Boxed dependency into a
+pipeline (never a `Defect` — Boxed has only two channels), and `toBoxed` /
+`toBoxedFuture` serve a not-yet-migrated caller, with a **mandatory `onDefect`**
+so a defect is never silently folded into the caller's `E`. See
+[Interoperate with other libraries](./interoperate-with-libraries) for the
+rules of that seam.
+
+## What you can delete after migrating
+
+- the `as Error` casts on `mapError` — `qualify` replaced them with a decision;
+- `Option` wrapper helpers whose callers all folded with a default — `T | undefined`
+  plus a conditional does it without a wrapper;
+- defensive `try`/`catch` around combinator chains — the defect channel is the
+  backstop now.
+
+## Where to go next
+
+- Why there is no `Option`: [Design decisions](../explanation/design-decisions).
+- The channel Boxed doesn't have: [The Defect Channel](../explanation/the-defect-channel).
+- The same migration from neverthrow: [Migrate from neverthrow](./migrate-from-neverthrow).

--- a/skills/migrating-to-unthrown/SKILL.md
+++ b/skills/migrating-to-unthrown/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: migrating-to-unthrown
+description: Use when migrating a codebase, package, or module from neverthrow or Boxed (@bloodyowl/boxed) to unthrown — porting ok/err/ResultAsync/andThen/mapErr/orElse/safeTry or Option/Future/AsyncData code, planning an incremental multi-file migration, deciding what an old `E = Error`/`unknown` becomes, or keeping not-yet-migrated callers compiling mid-migration.
+---
+
+# Migrating to unthrown
+
+Port neverthrow or Boxed code to unthrown consistently, at repo scale.
+
+**REQUIRED BACKGROUND:** the `unthrown` skill (write/review unthrown code). This
+skill adds only what a _migration_ needs on top: the policy decided once up
+front, the mid-migration seam, and the per-source mapping tables — so eighty
+files get the same answers, not eighty locally-reasonable ones.
+
+Full docs: https://btravstack.github.io/unthrown/ (how-to guides
+"Migrate from neverthrow" / "Migrate from Boxed" are the human-facing pages of
+this skill).
+
+## Decide once, before the first file
+
+These questions recur in every file. Answer them once, write the answers down
+(a `MIGRATION.md` in the repo works), and apply them mechanically — do not
+re-derive per file.
+
+1. **Per boundary: model or defect?** The old code blanket-cast rejections
+   (`(e) => e as Error`). For each boundary kind (db driver, http client,
+   JSON.parse, …), ask: **does anything recover from this error today**
+   (an `orElse`, `unwrapOr`, `getWithDefault`, a rendered fallback)?
+   - Recovered → model it: a `TaggedError` with `{ cause: unknown }` payload
+     (the `@unthrown/prisma` `DriverError` pattern). Behavior is preserved.
+   - Never recovered, only logged/500'd → `defect(cause)`. That blanket path
+     _is_ the defect channel now.
+   - Mixed per cause → triage in `qualify`: named case for the recoverable
+     causes, `defect(cause)` for the rest.
+2. **Error classes are exported.** Under exhaustive matching, a function's
+   error union is part of its public contract — callers need the classes for
+   `P.tag(…)` arms. Export them next to the function.
+3. **Tag naming + payload conventions.** Pick them now (payloads carry typed
+   fields, never `message`; `cause: unknown` is legal). One collision-safe
+   scheme beats eighty ad-hoc ones.
+4. **Boxed only — where does UI state live?** `AsyncData` has no unthrown
+   target. Decide once: hand-rolled `{ tag: "NotAsked" | "Loading" | "Done" }`
+   union, or keep Boxed's `AsyncData` in the view layer holding an unthrown
+   `Result` in `Done`. Never both.
+
+## Migration order and the seam
+
+Migrate **module by module, dependency-leaves first**, keeping the build green
+after every file:
+
+1. Add the bridge package once: `@unthrown/neverthrow` or `@unthrown/boxed`.
+2. Migrate a module fully (see the mapping reference for the source library).
+3. **Untouched callers keep compiling through a seam**: a small compat file
+   that re-exports the migrated functions under their _legacy_ type
+   (`toNeverthrowAsync(result, onDefect)` / `toBoxedFuture(result, onDefect)`).
+   `onDefect` is mandatory — fold the defect into the legacy blanket `Error`
+   to reproduce pre-migration behavior exactly, and mark the seam file as the
+   quarantined un-triage point. Incoming still-legacy dependencies lift with
+   `fromNeverthrow(Async)` / `fromBoxed` / `fromBoxedFuture` (never a Defect —
+   two-channel sources).
+4. Ratchet with lint: enable `@unthrown/oxlint`'s `recommended` preset on
+   migrated paths — it catches the migration's characteristic leftovers
+   (`E = Error`/`unknown`, dropped results, `P._` blanket arms).
+5. When a seam's last legacy caller migrates: delete the seam file, grep for
+   its import and the `to*`/`from*` bridge calls, drop the bridge (and the old
+   library once nothing imports it).
+
+## Verify each file
+
+- `tsc` against the real packages — every migrated file must compile clean
+  under `strict` before moving on.
+- Grep for names that no longer exist (they signal an incomplete port, not a
+  missing import): `unwrap`, `unwrapOr`, `orElse`, `andThen`, `mapErr(`,
+  `safeTry`, `okAsync`, `errAsync`, `matchTags`, `Option.`, `getWithDefault`,
+  `mapOk`, `fromExecution`.
+- Behavior deltas to state in the PR, not discover in prod: extractors panic
+  on a Defect (old code may have swallowed bugs into a fallback), and throws
+  inside combinators now surface at `match`'s `defect` arm instead of
+  escaping.
+
+## References
+
+- **[references/from-neverthrow.md](references/from-neverthrow.md)** — the
+  neverthrow→unthrown mapping table, the `mapErr`/`orElse`/`safeTry`/`match`
+  rewrites, the `combineWithAllErrors` gap, and a worked seam.
+- **[references/from-boxed.md](references/from-boxed.md)** — the Boxed→unthrown
+  mapping table (Result, Future, statics), the `Option` decision tree, and the
+  `AsyncData`/`retry`/`concurrent` gaps.

--- a/skills/migrating-to-unthrown/SKILL.md
+++ b/skills/migrating-to-unthrown/SKILL.md
@@ -51,13 +51,15 @@ after every file:
 1. Add the bridge package once: `@unthrown/neverthrow` or `@unthrown/boxed`.
 2. Migrate a module fully (see the mapping reference for the source library).
 3. **Untouched callers keep compiling through a seam**: a small compat file
-   that re-exports the migrated functions under their _legacy_ type
-   (`toNeverthrowAsync(result, onDefect)` / `toBoxedFuture(result, onDefect)`).
-   `onDefect` is mandatory — fold the defect into the legacy blanket `Error`
-   to reproduce pre-migration behavior exactly, and mark the seam file as the
-   quarantined un-triage point. Incoming still-legacy dependencies lift with
-   `fromNeverthrow(Async)` / `fromBoxed` / `fromBoxedFuture` (never a Defect —
-   two-channel sources).
+   that re-exports the migrated functions under their _legacy_ type — sync:
+   `toNeverthrow(result, onDefect)` / `toBoxed(result, onDefect)`; async:
+   `toNeverthrowAsync(asyncResult, onDefect)` /
+   `toBoxedFuture(asyncResult, onDefect)` (the async pair takes the
+   `AsyncResult`). `onDefect` is mandatory — fold the defect into the legacy
+   blanket `Error` to reproduce pre-migration behavior exactly, and mark the
+   seam file as the quarantined un-triage point. Incoming still-legacy
+   dependencies lift with `fromNeverthrow` / `fromNeverthrowAsync` /
+   `fromBoxed` / `fromBoxedFuture` (never a Defect — two-channel sources).
 4. Ratchet with lint: enable `@unthrown/oxlint`'s `recommended` preset on
    migrated paths — it catches the migration's characteristic leftovers
    (`E = Error`/`unknown`, dropped results, `P._` blanket arms).

--- a/skills/migrating-to-unthrown/references/from-boxed.md
+++ b/skills/migrating-to-unthrown/references/from-boxed.md
@@ -1,0 +1,70 @@
+# Boxed (@bloodyowl/boxed) → unthrown
+
+Apply mechanically; the judgment calls live in SKILL.md's decide-once list.
+
+## Mapping table
+
+| Boxed                                        | unthrown                                          | Notes                                                                                       |
+| -------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `Result.Ok(v)` / `Result.Error(e)`           | `Ok(v)` / `Err(e)`                                | free functions, not statics                                                                 |
+| `result.map(f)` / `flatMap(f)`               | same                                              | callbacks must be synchronous                                                               |
+| `result.mapError(f)`                         | `mapErrCases((matcher) => …)`                     | exhaustive — one arm per case; no blanket callback                                          |
+| `result.match({ Ok, Error })`                | `match({ ok, errCases: (matcher) => …, defect })` | the `defect` arm is new and mandatory                                                       |
+| `result.getWithDefault(v)` / `getOr(v)`      | `getOr(v)`                                        | panics on a Defect                                                                          |
+| `result.toUndefined()` / `toNull()`          | `getOrUndefined()` / `getOrNull()`                |                                                                                             |
+| `result.tapOk(f)` / `tapError(f)`            | `tap(f)` / `tapErrCases((matcher) => …)`          |                                                                                             |
+| `result.isOk()` / `isError()`                | `isOk()` / `isErr()`                              | plus `isDefect()`                                                                           |
+| `Result.fromExecution(fn)`                   | `fromThrowable(fn, qualify)`                      | every-throw-modeled needs an explicit qualify; every-throw-a-bug is `fromSafeThrowable(fn)` |
+| `Result.fromPromise(p)`                      | `fromPromise(p, qualify)`                         | triage per cause instead of `E = Error`                                                     |
+| `Result.fromNullable/fromNull/fromUndefined` | `fromNullable(v, onAbsent)`                       | absence gets a named error                                                                  |
+| `Result.fromPredicate` / `fromOption`        | `ensure(pred, onFail)` / see Option tree          |                                                                                             |
+| `Result.all([...])` / `allFromDict({...})`   | `all([...])` / `allFromDict({...})`               | same shapes; async: `allAsync` / `allFromDictAsync`                                         |
+| `Future<Result<T, E>>`                       | `AsyncResult<T, E>`                               | both never reject                                                                           |
+| `Future.fromPromise(p)` (+ `.mapError` cast) | `fromPromise(p, qualify)`                         | the `as Error` cast becomes a triage decision                                               |
+| `future.mapOk(f)` / `mapError(f)`            | `map(f)` / `mapErrCases(…)`                       | the `Ok` suffix disappears                                                                  |
+| `future.flatMapOk(f)`                        | `flatMap(f)`                                      | `f` may return `Result` or `AsyncResult`                                                    |
+| `future.mapOkToResult(f)`                    | `flatMap(f)` — or `ensure(pred, onFail)`          | when `f` only gates its own argument, `ensure` (invert the condition)                       |
+| `future.mapErrorToResult(f)`                 | `flatMapErrCases(…)`                              |                                                                                             |
+| `Future.all` / `allFromDict`                 | `allAsync` / `allFromDictAsync`                   |                                                                                             |
+| `future.get()` / `onResolve`                 | `await asyncResult` then handle the `Result`      |                                                                                             |
+| `Option`                                     | — (decision tree below)                           |                                                                                             |
+| `AsyncData` / `Deferred`                     | — (see below)                                     |                                                                                             |
+| `Future.retry` / `Future.concurrent`         | —                                                 | orchestrate before the `fromPromise` boundary with plain async tooling                      |
+
+## The Option decision tree
+
+Per `Option` site, exactly one of three (apply the same choice to a helper's
+whole caller-set, not per caller):
+
+1. **Absence is a normal shape** (all callers fold with a default) →
+   `T | undefined`. The combinator chain usually _deletes_ into a plain
+   conditional; `Option.fromNullable(x).flatMap(guard)` becomes
+   `x != null && guard ? x : undefined`.
+2. **Absence is a failure callers must handle** (`option.toResult(e)` sites are
+   this by definition) → `Result<T, NotFound>` via
+   `fromNullable(v, () => new NotFound({ … }))`.
+3. **A nullable third-party value entering a pipeline** → `fromNullable` at the
+   boundary.
+
+Do not build a local `Option` to preserve shapes; `match({ Some, None })`
+becomes a conditional (case 1) or an `errCases` arm (case 2).
+
+## AsyncData / Deferred
+
+Request-lifecycle state, not error handling — no unthrown target, by design.
+Per the decide-once list, either hand-roll the union
+(`{ tag: "NotAsked" } | { tag: "Loading" } | { tag: "Done"; result: Result<…> }`
+— matchable with unthrown's structural `match(state).with({ tag: "Done" }, …)`)
+or keep Boxed's `AsyncData` in the view layer with an unthrown `Result` inside
+`Done`. A `Result` does not survive `structuredClone`/JSON — fold with `match`
+before persisting state.
+
+## The seam (untouched Boxed callers)
+
+Same shape as the neverthrow seam (SKILL.md): serve legacy callers via
+`toBoxed(result, onDefect)` / `toBoxedFuture(asyncResult, onDefect)` from
+`@unthrown/boxed` — `onDefect` mandatorily folds a defect into the legacy `E`,
+reproducing the old everything-in-`Error` behavior; quarantine and delete when
+the last Boxed caller migrates. Incoming Boxed values lift with `fromBoxed` /
+`fromBoxedFuture` (never a Defect). `Option` has no bridge — it crosses as
+`toUndefined()` at the seam.

--- a/skills/migrating-to-unthrown/references/from-neverthrow.md
+++ b/skills/migrating-to-unthrown/references/from-neverthrow.md
@@ -1,0 +1,107 @@
+# neverthrow → unthrown
+
+Apply mechanically; the judgment calls live in SKILL.md's decide-once list.
+
+## Mapping table
+
+| neverthrow                                | unthrown                                          | Notes                                                                           |
+| ----------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `ok(v)` / `err(e)`                        | `Ok(v)` / `Err(e)`                                | capitalized free functions                                                      |
+| `okAsync(v)` / `errAsync(e)`              | `OkAsync(v)` / `ErrAsync(e)`                      | pre-lifted async constructors                                                   |
+| `result.map(f)`                           | same                                              | callback must be synchronous                                                    |
+| `result.andThen(f)`                       | `result.flatMap(f)`                               | one name per concept                                                            |
+| `result.andTee(f)` / `andThrough(f)`      | `tap(f)` / `flatTap(f)`                           |                                                                                 |
+| `result.mapErr(f)`                        | `mapErrCases((matcher) => …)`                     | exhaustive: one `.with(…)` arm per case in `E` — see rewrite below              |
+| `result.orElse(f)`                        | `flatMapErrCases(…)` or `recoverErrCases(…)`      | fallback `Result` vs plain recovery value — see rewrite below                   |
+| `result.match(okFn, errFn)`               | `match({ ok, errCases: (matcher) => …, defect })` | object handlers; the `defect` arm is new and mandatory                          |
+| `result.unwrapOr(v)`                      | `getOr(v)`                                        | all `unwrap*` names are removed; still panics on a Defect                       |
+| `result.isOk()` / `isErr()`               | same                                              | plus `isDefect()`                                                               |
+| `result.value` / `result.error`           | same, after narrowing                             |                                                                                 |
+| `ResultAsync`                             | `AsyncResult`                                     | `await` collapses it to a `Result`; it never rejects                            |
+| `ResultAsync.fromPromise(p, mapErr)`      | `fromPromise(p, qualify)`                         | `qualify(cause, defect)` must triage — the mapper was total, this is a decision |
+| `ResultAsync.fromSafePromise(p)`          | `fromSafePromise(p)`                              | a rejection becomes a `Defect`, not an `Err`                                    |
+| `Result.fromThrowable(fn, mapErr)`        | `fromThrowable(fn, qualify)`                      | wraps the function; same triage                                                 |
+| `Result.combine([...])`                   | `all([...])` / `allAsync([...])`                  | record variant: `allFromDict` / `allFromDictAsync`                              |
+| `Result.combineWithAllErrors([...])`      | —                                                 | accumulation is deliberately excluded — see gap below                           |
+| `safeTry(function* () { yield* … })`      | `Do()` / `DoAsync()` + `.bind(name, f)` + `.let`  | see rewrite below                                                               |
+| `fromPromise` re-thrown / `_unsafeUnwrap` | `get()` (needs `E = never`) / `getOrThrow()`      | type-gated extraction; no `_unsafe*` family                                     |
+
+## The three non-mechanical rewrites
+
+**`mapErr` → named cases.** The old callback silently absorbed every case; the
+matcher makes each one explicit. Group cases sharing a handler — never `P._`:
+
+```ts
+// before: .mapErr((e) => new ApiError(e))
+.mapErrCases((matcher) =>
+  matcher.with(P.tag("NotFound"), P.tag("Conflict"), (e) => new ApiError({ cause: e })))
+```
+
+If the old `E` was `Error`/`unknown`, first apply the decide-once boundary
+policy to give it real cases — do not port the blanket type.
+
+**`orElse` → pick by what the fallback returns.** A fallback _value_ is
+`recoverErrCases` (empties `E`); a fallback _Result_ (which may itself fail) is
+`flatMapErrCases`. `okAsync(fallback)` inside an `orElse` is the value form:
+
+```ts
+// before: .orElse(() => okAsync({ ...user, orders: 0 }))
+.recoverErrCases((matcher) => matcher.with("orders_unavailable", () => ({ ...user, orders: 0 })))
+```
+
+**`safeTry` → do-notation.** Each `yield* x.safeUnwrap()` becomes a
+`.bind("name", (scope) => step)` (steps may return `Result` or `AsyncResult`;
+errors union automatically); the final `ok(...)` becomes `.map(...)`:
+
+```ts
+// before: safeTry(async function* () { const u = yield* findUser(id).safeUnwrap(); … })
+DoAsync()
+  .bind("user", () => findUser(id))
+  .bind("prefs", () => parseUser(raw))
+  .map(({ user, prefs }) => ({ user, prefs }));
+```
+
+## Gap: `combineWithAllErrors`
+
+unthrown has no error accumulation, deliberately. Options, in order: validate
+with `@unthrown/standard-schema` (a validator's issue list is one modeled
+error carrying all issues); or model the aggregate as one error case whose
+payload holds the collected failures, built by folding the results yourself at
+that one site. Do not fake a `Validation` type.
+
+## The seam (untouched neverthrow callers)
+
+Serve legacy callers the _exact_ legacy signature from a small compat file;
+cut over the old module to `export * from "./the-seam"` so import paths don't
+move:
+
+```ts
+// user-service.compat.ts — quarantined un-triage point; delete when the last
+// legacy caller migrates.
+import { toNeverthrowAsync } from "@unthrown/neverthrow";
+import type { ResultAsync } from "neverthrow";
+import { P } from "unthrown";
+import { findUser as migrated, type User } from "./user-service.migrated";
+
+const asError = (cause: unknown): Error =>
+  cause instanceof Error ? cause : new Error(String(cause), { cause });
+
+export function findUser(id: string): ResultAsync<User, Error> {
+  // onDefect folds a defect into the legacy blanket Error — byte-for-byte the
+  // old behavior, where every rejection landed in E.
+  return toNeverthrowAsync(
+    migrated(id).mapErrCases(
+      (matcher, defect) =>
+        matcher
+          .with(P.tag("DbError"), (e) => asError(e.cause)) // unwrap to the raw driver error
+          .with(P.tag("UserNotFound"), (e) => e as Error), // TaggedError extends Error
+    ),
+    (cause) => asError(cause),
+  );
+}
+```
+
+Incoming legacy dependencies lift with `fromNeverthrow` / `fromNeverthrowAsync`
+(two channels in — never a Defect). Removal: delete the compat file, grep for
+its import and for `toNeverthrow`, drop `@unthrown/neverthrow`, then
+`neverthrow` itself once nothing imports it.


### PR DESCRIPTION
Adds the second agent skill, **`skills/migrating-to-unthrown/`** (for skills.sh distribution, like #172), plus the missing human-facing migration page, **`docs/how-to/migrate-from-boxed.md`** (the neverthrow page already existed).

## Scoped by baseline testing

Following skill-authoring TDD, three baseline scenarios ran first — subagents with only the existing `unthrown` skill migrating a trap-rich neverthrow module, a Boxed module (Option / Future / AsyncData / `fromExecution`), and a seam scenario with an untouchable neverthrow caller. All three produced **correct, strict-`tsc`-clean output** (compile-verified against the built packages), so the skill deliberately does not re-teach the API. What the baselines *did* fail at, and what the skill carries:

- **Policy consistency at repo scale** — both migration agents invented model-vs-defect policy per file and explicitly punted ("worth deciding once for the remaining files"). The skill's decide-once list answers those questions up front: per-boundary triage keyed on *does anything recover from this error today?*, exported error classes as public contract, tag/payload conventions, and the Boxed UI-state decision.
- **The mid-migration workflow** — leaf-first order, the bridge compat-seam procedure (`toNeverthrowAsync` / `toBoxedFuture` with the mandatory `onDefect` folding defects into the legacy blanket `Error`, quarantined and deletable), the `@unthrown/oxlint` recommended-preset ratchet, and per-file verification including a removed-names grep.

Two mapping references do the mechanical part: `references/from-neverthrow.md` (the table, the three non-mechanical rewrites — `mapErr`→named cases, `orElse`→`recoverErrCases`/`flatMapErrCases`, `safeTry`→do-notation — the `combineWithAllErrors` gap, a worked seam) and `references/from-boxed.md` (the table verified against `@bloodyowl/boxed`'s installed types, the Option decision tree, the `AsyncData`/`retry`/`concurrent` gaps).

## Verification

A GREEN-phase agent given the seam scenario *with* the skill followed it by name: applied the decide-once policy instead of reinventing it, produced the prescribed compat seam (quarantine comment, cutover re-export, removal criteria), ran the leftover grep, and delivered a `MIGRATION.md` for the remaining files — independently re-verified with `tsc` (clean, frozen legacy caller included). Honest caveat: the demonstrated win is consistency and policy compliance, not token economy.

The docs page follows the existing neverthrow page's shape and is wired into the sidebar; the docs site builds clean, and the full repo gate passes. No changeset — skills and docs aren't published packages (same as #172).