### PR TITLE
fix(prisma)!: keep only domain outcomes in E, defect the rest

### DIFF
--- a/.changeset/wild-moons-smoke.md
+++ b/.changeset/wild-moons-smoke.md
@@ -1,0 +1,47 @@
+---
+"@unthrown/prisma": minor
+---
+
+Fix an unsound error channel on `tryCreate` / `tryUpsert`, route Prisma's
+bug-shaped errors to the defect channel, and make `after`/`before` mutually
+exclusive.
+
+**`tryCreate` and `tryUpsert` now carry `RecordNotFound`.** A nested `connect`
+pointing at a record that does not exist raises `P2025`, even though neither
+operation has a row of its own to miss:
+
+```ts
+db.post.tryCreate({ data: { title, author: { connect: { id: 999 } } } });
+// Err(RecordNotFound) — P2025
+```
+
+Their unions previously excluded it, so the runtime produced an error the type
+said was impossible. An exhaustive `mapErrCases` over the declared union then had
+no arm for the value that arrived, the matcher threw `NonExhaustiveError`, and
+the throw-to-defect net turned a modeled database failure into a `Defect`.
+`P2018` — the same failure reported from the to-many side of a nested write —
+now maps to `RecordNotFound` too, instead of falling through to `DriverError`.
+The **batch** mutations (`tryCreateMany` / `tryUpdateMany` and their `*AndReturn`
+twins) are unchanged: they accept no nested writes, so they remain genuinely free
+of `RecordNotFound`.
+
+**Prisma's non-query errors now take the defect channel.**
+`PrismaClientValidationError` (a malformed query — unreachable without casting
+the `Prisma.Exact` args away), `PrismaClientInitializationError` and
+`PrismaClientRustPanicError` are bugs and environment faults, not anticipated
+outcomes, so they no longer land in `E` as `DriverError`. `DriverError` now means
+what it says: the database refused the query — connection drops, timeouts,
+unmapped P-codes. `PrismaClientUnknownRequestError` deliberately stays a
+`DriverError`. Cursor pagination keeps one carve-out: a validation error out of
+`withCursor` remains a modeled `DriverError`, because the cursor is an opaque
+string from a client rather than code you wrote.
+
+**`withCursor`'s `after` and `before` are now mutually exclusive.** Passing both
+type-checked and silently ignored `after`.
+
+Breaking, but shipped as a minor: `qualifyPrismaError` now takes the injected
+`defect` helper as a second argument. It is a `qualify`, so passing it to a
+boundary is unchanged (`fromPromise(db.$queryRaw\`…\`, qualifyPrismaError)`);
+only direct invocation needs updating. Handling the widened create/upsert unions
+is a compile error at every call site until each new case is named — which is
+the point.

--- a/.changeset/wild-moons-smoke.md
+++ b/.changeset/wild-moons-smoke.md
@@ -2,12 +2,49 @@
 "@unthrown/prisma": minor
 ---
 
-Fix an unsound error channel on `tryCreate` / `tryUpsert`, route Prisma's
-bug-shaped errors to the defect channel, and make `after`/`before` mutually
-exclusive.
+Make `E` domain outcomes only: infrastructure failures become defects, and fix
+an unsound error channel on `tryCreate` / `tryUpsert`.
+
+**`E` now carries only what you would actually branch on.** Three P-codes
+describe a domain outcome and stay modeled — `UniqueConstraintViolation` (P2002,
+409), `ForeignKeyViolation` (P2003, 400), `RecordNotFound` (P2025/P2018, 404).
+**Everything infrastructural is now a defect**: a dropped connection, a pool
+timeout, a deadlock, an unmapped P-code, a malformed query, a client that could
+not start, an engine panic.
+
+Nobody writes domain logic for a severed TCP connection — you log it and return a
+500, which is exactly what `match`'s `defect` arm already does. Modelling those
+failures only forced every call site to carry an arm that duplicated its own
+`defect` arm:
+
+```ts
+// before — the same handling, written twice, at every call site:
+errCases: (matcher) => matcher
+  .with(P.tag("UniqueConstraintViolation"), (e) => resp.conflict(e.fields))
+  .with(P.tag("DriverError"), (e) => resp.serverError(e)),
+defect: (cause) => resp.serverError(cause),
+```
+
+A defect is not a crash: it flows through the pipeline untouched and is folded at
+the edge like any other unmodeled failure.
+
+Consequences:
+
+- **The `DriverError` class is removed.** Nothing routes to it any more; the
+  original Prisma error reaches your `defect` arm unwrapped, with its `code`,
+  `meta` and stack intact.
+- **A read has no modeled failure**: `tryFindMany` is
+  `AsyncResult<User[], never>`. Absence is still `null`.
+- **Pagination gains `InvalidCursor`**, the one carve-out. A cursor is an opaque
+  string from a client, so a `parseCursor` that rejects it — or a query Prisma
+  refuses to validate — is anticipated input you answer with a 400. A throw out
+  of `getCursor`, which reads rows you just fetched, is a bug and stays a defect.
+- **Retrying a deadlock (P2034) or pool timeout (P2024)** now goes through
+  `recoverDefect` rather than a tag match — one place in a codebase, versus an
+  arm at every call site.
 
 **`tryCreate` and `tryUpsert` now carry `RecordNotFound`.** A nested `connect`
-pointing at a record that does not exist raises `P2025`, even though neither
+pointing at a record that does not exist raises P2025, even though neither
 operation has a row of its own to miss:
 
 ```ts
@@ -18,30 +55,16 @@ db.post.tryCreate({ data: { title, author: { connect: { id: 999 } } } });
 Their unions previously excluded it, so the runtime produced an error the type
 said was impossible. An exhaustive `mapErrCases` over the declared union then had
 no arm for the value that arrived, the matcher threw `NonExhaustiveError`, and
-the throw-to-defect net turned a modeled database failure into a `Defect`.
-`P2018` — the same failure reported from the to-many side of a nested write —
-now maps to `RecordNotFound` too, instead of falling through to `DriverError`.
-The **batch** mutations (`tryCreateMany` / `tryUpdateMany` and their `*AndReturn`
-twins) are unchanged: they accept no nested writes, so they remain genuinely free
-of `RecordNotFound`.
-
-**Prisma's non-query errors now take the defect channel.**
-`PrismaClientValidationError` (a malformed query — unreachable without casting
-the `Prisma.Exact` args away), `PrismaClientInitializationError` and
-`PrismaClientRustPanicError` are bugs and environment faults, not anticipated
-outcomes, so they no longer land in `E` as `DriverError`. `DriverError` now means
-what it says: the database refused the query — connection drops, timeouts,
-unmapped P-codes. `PrismaClientUnknownRequestError` deliberately stays a
-`DriverError`. Cursor pagination keeps one carve-out: a validation error out of
-`withCursor` remains a modeled `DriverError`, because the cursor is an opaque
-string from a client rather than code you wrote.
+the throw-to-defect net turned a modeled database failure into a `Defect`. P2018
+— the same failure from the to-many side of a nested write — now maps to
+`RecordNotFound` too. The batch mutations (`tryCreateMany` / `tryUpdateMany` and
+their `*AndReturn` twins) accept no nested writes, so they remain free of it.
 
 **`withCursor`'s `after` and `before` are now mutually exclusive.** Passing both
 type-checked and silently ignored `after`.
 
-Breaking, but shipped as a minor: `qualifyPrismaError` now takes the injected
-`defect` helper as a second argument. It is a `qualify`, so passing it to a
-boundary is unchanged (`fromPromise(db.$queryRaw\`…\`, qualifyPrismaError)`);
-only direct invocation needs updating. Handling the widened create/upsert unions
-is a compile error at every call site until each new case is named — which is
-the point.
+Breaking, shipped as a minor: `qualifyPrismaError` takes the injected `defect`
+helper as a second argument (it is a `qualify`, so passing it to a boundary is
+unchanged — only direct invocation needs updating), the `DriverError` class is
+gone, and every error union changed. Each of those is a compile error at the call
+site rather than a silent behaviour change — which is the point.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -731,25 +731,34 @@ AsyncResult<infer T, …>` — structural inference over the whole method surfac
 - `packages/prisma` → `@unthrown/prisma` (peerDep `@prisma/client` ^7; a Prisma
   Client **extension** — `$extends(unthrownPrisma)` adds `try*` variants of
   **all seventeen** model delegate operations alongside the raw promise ones,
-  each an `AsyncResult` whose error channel is exactly the P-codes that
-  operation can raise: `UniqueConstraintViolation` P2002, `ForeignKeyViolation`
-  P2003, `RecordNotFound` P2025 **and P2018** (the to-one and to-many sides of
-  "a record this write depended on was not found" — the same failure, so one
-  tag), other query failures `DriverError` with the cause preserved. Only the
-  **batch** mutations (`createMany`/`updateMany` + their `*AndReturn` twins) are
-  free of `RecordNotFound`: they accept no nested writes and zero matches is
+  each an `AsyncResult` whose error channel is exactly the **domain outcomes**
+  that operation can raise — and nothing else. `E` holds only the three P-codes
+  a caller branches on: `UniqueConstraintViolation` P2002 (409),
+  `ForeignKeyViolation` P2003 (400), `RecordNotFound` P2025 **and P2018** (404 —
+  the to-one and to-many sides of "a record this write depended on was not
+  found", the same failure, so one tag). **Every infrastructure failure is a
+  `Defect`**: a dropped connection, a pool timeout (P2024), a deadlock (P2034),
+  an unmapped P-code, `PrismaClientValidationError` (a malformed query,
+  unreachable without casting the `Prisma.Exact` args away),
+  `PrismaClientInitializationError`, `PrismaClientRustPanicError`,
+  `PrismaClientUnknownRequestError`, a non-Prisma cause. The rule is "would you
+  branch on it?" — nobody writes domain logic for a severed TCP connection, they
+  log it and 500, which is exactly what `match`'s `defect` arm already does;
+  modelling those would force **every call site** to carry an arm duplicating
+  its own `defect` arm. (A defect is not a crash — it flows through the pipeline
+  untouched and is folded at the edge like any other unmodeled failure.) So a
+  **read has `E = never`** (absence is `null`; a database that will not answer is
+  a defect), and there is **no `DriverError` class** — it was removed
+  2026-08 when the last of its contents moved to the defect channel. A retry
+  wrapper for P2024/P2034 therefore uses `recoverDefect` and inspects the cause:
+  one place in a codebase, versus an arm at every call site. Only the **batch**
+  mutations (`createMany`/`updateMany` + their `*AndReturn` twins) are free of
+  `RecordNotFound`: they accept no nested writes and zero matches is
   `Ok({ count: 0 })`. `create` and `upsert` **do** carry it — neither misses a
   row of its own, but a nested `connect` to a non-existent record raises P2025
   (an unsound omission until 2026-08: the runtime produced a `RecordNotFound`
   the type excluded, so a type-exhaustive `mapErrCases` threw
-  `NonExhaustiveError` and the modeled error silently became a `Defect`).
-  Prisma's **non-query** error classes —
-  `PrismaClientValidationError` (a malformed query, unreachable without casting
-  the `Prisma.Exact` args away), `PrismaClientInitializationError`,
-  `PrismaClientRustPanicError` — are routed to the **defect** channel rather
-  than into `E` (Thesis #1: `DriverError` means the database refused the query,
-  not "everything else"); `PrismaClientUnknownRequestError` deliberately stays a
-  `DriverError` (the query did fail, just without a P-code). Also
+  `NonExhaustiveError` and the modeled error silently became a `Defect`). Also
   `$tryTransaction` (an interactive transaction whose callback
   speaks `AsyncResult` — an `Err` rolls back and re-surfaces typed; a defect
   rolls back and stays a defect, a throwing callback included) and
@@ -757,9 +766,12 @@ AsyncResult<infer T, …>` — structural inference over the whole method surfac
   `prisma-extension-pagination` cursor API with its unmerged #35 fix folded
   in; `after`/`before` are mutually exclusive in the type — passing both used to
   drop `after` silently — and pagination carries the **one carve-out** to the
-  defect routing above: a validation error there stays a modeled `DriverError`,
-  because the cursor is an opaque string from a client, not code the developer
-  wrote). Qualification happens once inside the extension via the exported
+  defect routing above: its `E` is `InvalidCursor`, minted both from a Prisma
+  validation error and from a throw out of the caller's `parseCursor` on a
+  request cursor (marked by the internal `CursorParseFailure` sentinel), because
+  a cursor is an opaque string from a client and garbage in it is a 400, not a
+  bug. A throw out of `getCursor` — which reads rows _we_ fetched — is
+  deliberately NOT marked, so it stays a defect). Qualification happens once inside the extension via the exported
   `qualifyPrismaError`, which **is** a `qualify` — `(cause, defect)`, generic in
   the marker type so core's non-exported `Defect` need not be named — and so
   drops straight into a `fromPromise` at a boundary of your own; the raw methods

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -733,16 +733,37 @@ AsyncResult<infer T, …>` — structural inference over the whole method surfac
   **all seventeen** model delegate operations alongside the raw promise ones,
   each an `AsyncResult` whose error channel is exactly the P-codes that
   operation can raise: `UniqueConstraintViolation` P2002, `ForeignKeyViolation`
-  P2003, `RecordNotFound` P2025, everything else `DriverError` with the cause
-  preserved — `upsert` and the `*Many` batch mutations never carry P2025 (an
-  upsert miss creates; zero batch matches is `Ok({ count: 0 })`). Also
+  P2003, `RecordNotFound` P2025 **and P2018** (the to-one and to-many sides of
+  "a record this write depended on was not found" — the same failure, so one
+  tag), other query failures `DriverError` with the cause preserved. Only the
+  **batch** mutations (`createMany`/`updateMany` + their `*AndReturn` twins) are
+  free of `RecordNotFound`: they accept no nested writes and zero matches is
+  `Ok({ count: 0 })`. `create` and `upsert` **do** carry it — neither misses a
+  row of its own, but a nested `connect` to a non-existent record raises P2025
+  (an unsound omission until 2026-08: the runtime produced a `RecordNotFound`
+  the type excluded, so a type-exhaustive `mapErrCases` threw
+  `NonExhaustiveError` and the modeled error silently became a `Defect`).
+  Prisma's **non-query** error classes —
+  `PrismaClientValidationError` (a malformed query, unreachable without casting
+  the `Prisma.Exact` args away), `PrismaClientInitializationError`,
+  `PrismaClientRustPanicError` — are routed to the **defect** channel rather
+  than into `E` (Thesis #1: `DriverError` means the database refused the query,
+  not "everything else"); `PrismaClientUnknownRequestError` deliberately stays a
+  `DriverError` (the query did fail, just without a P-code). Also
   `$tryTransaction` (an interactive transaction whose callback
   speaks `AsyncResult` — an `Err` rolls back and re-surfaces typed; a defect
   rolls back and stays a defect, a throwing callback included) and
   `tryPaginate(...).withCursor(...)` (the
   `prisma-extension-pagination` cursor API with its unmerged #35 fix folded
-  in). Qualification happens once inside the extension via the exported
-  `qualifyPrismaError`; the raw methods stay as the escape hatch for batch
+  in; `after`/`before` are mutually exclusive in the type — passing both used to
+  drop `after` silently — and pagination carries the **one carve-out** to the
+  defect routing above: a validation error there stays a modeled `DriverError`,
+  because the cursor is an opaque string from a client, not code the developer
+  wrote). Qualification happens once inside the extension via the exported
+  `qualifyPrismaError`, which **is** a `qualify` — `(cause, defect)`, generic in
+  the marker type so core's non-exported `Defect` need not be named — and so
+  drops straight into a `fromPromise` at a boundary of your own; the raw methods
+  stay as the escape hatch for batch
   `$transaction([...])` and raw SQL. Tested against a
   real in-memory SQLite client (`@prisma/adapter-better-sqlite3`) with a
   generated, gitignored test client; **deliberately outside the fixed version

--- a/docs/how-to/use-with-prisma.md
+++ b/docs/how-to/use-with-prisma.md
@@ -38,27 +38,60 @@ write a handler for a case that can't happen.
 | --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
 | `tryFindMany` / `tryFindUnique` / `tryFindFirst` / `tryCount` / `tryAggregate` / `tryGroupBy` | `DriverError`                                                                       |
 | `tryFindUniqueOrThrow` / `tryFindFirstOrThrow`                                                | `RecordNotFound \| DriverError`                                                     |
-| `tryCreate` / `tryCreateMany` / `tryCreateManyAndReturn`                                      | `UniqueConstraintViolation \| ForeignKeyViolation \| DriverError`                   |
-| `tryUpsert`                                                                                   | `UniqueConstraintViolation \| ForeignKeyViolation \| DriverError`                   |
+| `tryCreate` / `tryUpsert`                                                                     | `UniqueConstraintViolation \| ForeignKeyViolation \| RecordNotFound \| DriverError` |
 | `tryUpdate`                                                                                   | `RecordNotFound \| UniqueConstraintViolation \| ForeignKeyViolation \| DriverError` |
-| `tryUpdateMany` / `tryUpdateManyAndReturn`                                                    | `UniqueConstraintViolation \| ForeignKeyViolation \| DriverError`                   |
 | `tryDelete`                                                                                   | `RecordNotFound \| ForeignKeyViolation \| DriverError`                              |
+| `tryCreateMany` / `tryCreateManyAndReturn`                                                    | `UniqueConstraintViolation \| ForeignKeyViolation \| DriverError`                   |
+| `tryUpdateMany` / `tryUpdateManyAndReturn`                                                    | `UniqueConstraintViolation \| ForeignKeyViolation \| DriverError`                   |
 | `tryDeleteMany`                                                                               | `ForeignKeyViolation \| DriverError`                                                |
 | `tryPaginate(...).withCursor(...)`                                                            | `DriverError`                                                                       |
 
-Note where `RecordNotFound` does **not** appear: `tryUpsert` (a miss _creates_) and
-the batch mutations (`*Many` — zero matches is `Ok({ count: 0 })`, not an error).
+Note where `RecordNotFound` does **not** appear: the **batch** mutations (`*Many`
+and their `*AndReturn` twins). Those are the only operations genuinely free of it —
+they accept no nested writes, and zero matches is `Ok({ count: 0 })`, not an error.
+
+`tryCreate` and `tryUpsert` _do_ carry it, which is worth a second look: neither
+has a row of its own to miss, but a **nested `connect`** does.
+
+```ts
+db.post.tryCreate({ data: { title, author: { connect: { id: authorId } } } });
+// Err(RecordNotFound) when that author does not exist — P2025.
+```
 
 The tagged errors map to Prisma's P-codes: `UniqueConstraintViolation` is `P2002`
 (and carries the offending `fields`), `ForeignKeyViolation` is `P2003`, and
-`RecordNotFound` is `P2025`. Everything else — connection drops, timeouts, unmapped
-codes, non-Prisma causes — folds into `DriverError` with the original `cause`
-preserved.
+`RecordNotFound` is `P2025` — plus `P2018`, which says the same thing from the
+to-many side of a nested write. Other query failures — connection drops, timeouts,
+unmapped codes, non-Prisma causes — fold into `DriverError` with the original
+`cause` preserved.
 
 ::: tip Absence is not an error
 `tryFindUnique` returns `Ok(null)` for a miss — a missing row is an anticipated
 value, not a failure. Reach for `tryFindUniqueOrThrow` when the absence _is_ the
 error you want to model (`RecordNotFound`).
+:::
+
+## What does _not_ reach your error channel
+
+`DriverError` is the "the database refused the query" bucket, not an
+everything-else bucket. Three of Prisma's error classes are bugs or environment
+faults rather than outcomes, so they go to the
+[defect channel](../explanation/the-defect-channel) instead:
+
+| Prisma error                      | Why it is a defect                                                                                           |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `PrismaClientValidationError`     | The query is malformed. `try*` args are `Prisma.Exact`-typed — reaching this means the types were cast away. |
+| `PrismaClientInitializationError` | The client could not start: bad datasource URL, engine/version mismatch.                                     |
+| `PrismaClientRustPanicError`      | The query engine panicked.                                                                                   |
+
+`PrismaClientUnknownRequestError` is deliberately _not_ in that list: the query
+really did fail in the database, just without a P-code to name it — a `DriverError`.
+
+::: tip The one carve-out: pagination cursors
+A cursor is an **opaque string from the outside world**, turned into a query by
+your `parseCursor`. So a validation error out of `withCursor` stays a modeled
+`DriverError` — a client sending garbage is anticipated input you turn into a 400,
+not a bug. See [Cursor pagination](#cursor-pagination) below.
 :::
 
 ## Handle the errors
@@ -79,11 +112,15 @@ return created.match({
       .with(P.tag("UniqueConstraintViolation"), (e) =>
         resp.conflict(`taken: ${e.fields.join(", ")}`),
       )
-      .with(P.tag("ForeignKeyViolation"), () => resp.badRequest("unknown reference"))
+      .with(P.tag("ForeignKeyViolation"), P.tag("RecordNotFound"), () =>
+        resp.badRequest("unknown reference"),
+      )
       .with(P.tag("DriverError"), (e) => resp.serverError(e)),
   defect: (cause) => resp.serverError(cause),
 });
-// No RecordNotFound arm — a create can't raise it, and the type knows.
+// Exactly the four cases a create can raise — no more, no fewer. Add a P-code
+// to the union and every call site like this one stops compiling until it is
+// handled.
 ```
 
 When several tags deserve the same response, **group** them in one arm rather
@@ -92,8 +129,11 @@ lights the call site up:
 
 ```ts
 matcher
-  .with(P.tag("UniqueConstraintViolation"), P.tag("ForeignKeyViolation"), () =>
-    resp.badRequest("bad write"),
+  .with(
+    P.tag("UniqueConstraintViolation"),
+    P.tag("ForeignKeyViolation"),
+    P.tag("RecordNotFound"),
+    () => resp.badRequest("bad write"),
   )
   .with(P.tag("DriverError"), (e) => resp.serverError(e));
 ```
@@ -146,12 +186,17 @@ page.match({
 });
 ```
 
-Three deliberate differences from upstream: a cursor pointing at a now-filtered-out
+Four deliberate differences from upstream: a cursor pointing at a now-filtered-out
 row doesn't skip the first element (folds in the fix for
 [deptyped/prisma-extension-pagination#35](https://github.com/deptyped/prisma-extension-pagination/issues/35));
-`before` + `limit: null` is a compile error; and the default cursor preserves the
-id's type (all-digit → number/`bigint`, otherwise string). Provide `getCursor` /
-`parseCursor` for composite keys.
+`after` and `before` are mutually exclusive (a page runs in one direction, and
+passing both used to silently drop `after`); `before` + `limit: null` is a compile
+error; and the default cursor preserves the id's type (all-digit → number/`bigint`,
+otherwise string). Provide `getCursor` / `parseCursor` for composite keys.
+
+A malformed cursor stays a modeled `DriverError` rather than becoming a defect —
+the one place a Prisma validation error is treated as anticipated input, because
+the cursor comes from the client rather than from your code.
 
 ## Raw methods and raw SQL
 
@@ -167,6 +212,11 @@ import { qualifyPrismaError } from "@unthrown/prisma";
 const rows = fromPromise(db.$queryRaw`SELECT 1`, qualifyPrismaError);
 //    ^? AsyncResult<unknown, UniqueConstraintViolation | ForeignKeyViolation | RecordNotFound | DriverError>
 ```
+
+`qualifyPrismaError` **is** a `qualify` — the boundary injects the `defect`
+helper as its second argument, so the same triage you get inside the extension
+(including routing the three bug-shaped Prisma errors to the defect channel)
+applies to your own boundaries for free.
 
 See the [API reference](/api/prisma/) for every method's exact signature.
 

--- a/docs/how-to/use-with-prisma.md
+++ b/docs/how-to/use-with-prisma.md
@@ -21,7 +21,7 @@ import { PrismaClient } from "./generated/prisma/client.ts";
 const db = new PrismaClient({ adapter }).$extends(unthrownPrisma);
 
 const users = db.user.tryFindMany({ select: { id: true } });
-//    ^? AsyncResult<{ id: number }[], DriverError>
+//    ^? AsyncResult<{ id: number }[], never>
 ```
 
 Qualification happens **once, inside the extension** — no raw `Promise`, and so no
@@ -30,21 +30,29 @@ inference survives the wrap, so the success type is still narrowed by your query
 
 ## Per-operation error unions
 
-Each operation's error channel is only what that operation can actually raise — a
-read cannot fail with a `UniqueConstraintViolation` _in the type_, so you never
-write a handler for a case that can't happen.
+`E` carries **only domain outcomes** — things a caller did, or a legitimate state
+conflict, that your code actually branches on. Each operation's channel is
+exactly what that operation can raise, so you never write a handler for a case
+that can't happen:
 
-| Method                                                                                        | Error channel                                                                       |
-| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| `tryFindMany` / `tryFindUnique` / `tryFindFirst` / `tryCount` / `tryAggregate` / `tryGroupBy` | `DriverError`                                                                       |
-| `tryFindUniqueOrThrow` / `tryFindFirstOrThrow`                                                | `RecordNotFound \| DriverError`                                                     |
-| `tryCreate` / `tryUpsert`                                                                     | `UniqueConstraintViolation \| ForeignKeyViolation \| RecordNotFound \| DriverError` |
-| `tryUpdate`                                                                                   | `RecordNotFound \| UniqueConstraintViolation \| ForeignKeyViolation \| DriverError` |
-| `tryDelete`                                                                                   | `RecordNotFound \| ForeignKeyViolation \| DriverError`                              |
-| `tryCreateMany` / `tryCreateManyAndReturn`                                                    | `UniqueConstraintViolation \| ForeignKeyViolation \| DriverError`                   |
-| `tryUpdateMany` / `tryUpdateManyAndReturn`                                                    | `UniqueConstraintViolation \| ForeignKeyViolation \| DriverError`                   |
-| `tryDeleteMany`                                                                               | `ForeignKeyViolation \| DriverError`                                                |
-| `tryPaginate(...).withCursor(...)`                                                            | `DriverError`                                                                       |
+| Method                                                                                        | Error channel                                                        |
+| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `tryFindMany` / `tryFindUnique` / `tryFindFirst` / `tryCount` / `tryAggregate` / `tryGroupBy` | `never`                                                              |
+| `tryFindUniqueOrThrow` / `tryFindFirstOrThrow`                                                | `RecordNotFound`                                                     |
+| `tryCreate` / `tryUpsert` / `tryUpdate`                                                       | `UniqueConstraintViolation \| ForeignKeyViolation \| RecordNotFound` |
+| `tryDelete`                                                                                   | `ForeignKeyViolation \| RecordNotFound`                              |
+| `tryCreateMany` / `tryCreateManyAndReturn`                                                    | `UniqueConstraintViolation \| ForeignKeyViolation`                   |
+| `tryUpdateMany` / `tryUpdateManyAndReturn`                                                    | `UniqueConstraintViolation \| ForeignKeyViolation`                   |
+| `tryDeleteMany`                                                                               | `ForeignKeyViolation`                                                |
+| `tryPaginate(...).withCursor(...)`                                                            | `InvalidCursor`                                                      |
+
+`UniqueConstraintViolation` is `P2002` (a 409, and it carries the offending
+`fields`), `ForeignKeyViolation` is `P2003` (a 400), and `RecordNotFound` is
+`P2025` — plus `P2018`, which says the same thing from the to-many side of a
+nested write (a 404).
+
+A **read has no modeled failure at all**. Absence is `null`, and a database that
+will not answer is a defect — so `tryFindMany` is `AsyncResult<User[], never>`.
 
 Note where `RecordNotFound` does **not** appear: the **batch** mutations (`*Many`
 and their `*AndReturn` twins). Those are the only operations genuinely free of it —
@@ -58,40 +66,51 @@ db.post.tryCreate({ data: { title, author: { connect: { id: authorId } } } });
 // Err(RecordNotFound) when that author does not exist — P2025.
 ```
 
-The tagged errors map to Prisma's P-codes: `UniqueConstraintViolation` is `P2002`
-(and carries the offending `fields`), `ForeignKeyViolation` is `P2003`, and
-`RecordNotFound` is `P2025` — plus `P2018`, which says the same thing from the
-to-many side of a nested write. Other query failures — connection drops, timeouts,
-unmapped codes, non-Prisma causes — fold into `DriverError` with the original
-`cause` preserved.
-
 ::: tip Absence is not an error
 `tryFindUnique` returns `Ok(null)` for a miss — a missing row is an anticipated
 value, not a failure. Reach for `tryFindUniqueOrThrow` when the absence _is_ the
 error you want to model (`RecordNotFound`).
 :::
 
-## What does _not_ reach your error channel
+## Everything infrastructural is a defect
 
-`DriverError` is the "the database refused the query" bucket, not an
-everything-else bucket. Three of Prisma's error classes are bugs or environment
-faults rather than outcomes, so they go to the
-[defect channel](../explanation/the-defect-channel) instead:
+A dropped connection, a pool timeout, a deadlock, an unmapped P-code, a malformed
+query, a client that could not start, an engine panic — none of those reaches your
+error channel. They go to the
+[defect channel](../explanation/the-defect-channel), with the original cause
+preserved.
 
-| Prisma error                      | Why it is a defect                                                                                           |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `PrismaClientValidationError`     | The query is malformed. `try*` args are `Prisma.Exact`-typed — reaching this means the types were cast away. |
-| `PrismaClientInitializationError` | The client could not start: bad datasource URL, engine/version mismatch.                                     |
-| `PrismaClientRustPanicError`      | The query engine panicked.                                                                                   |
+That is not a demotion. **A defect is not a crash**: it flows through the pipeline
+untouched and is folded at the edge by `match`'s `defect` handler, exactly where
+you already turn unexpected failures into a 500. The channel means "not worth
+threading through domain code", not "fatal".
 
-`PrismaClientUnknownRequestError` is deliberately _not_ in that list: the query
-really did fail in the database, just without a P-code to name it — a `DriverError`.
+The test is simple — _would you branch on it?_ You genuinely handle a duplicate
+email (409) or a missing parent row (404). You do not write domain logic for a
+severed TCP connection; you log it and return a 500. Modelling it would only force
+every call site to carry an arm that does the same thing as the `defect` arm
+sitting right beside it:
+
+```ts
+// What modelling infrastructure failures would cost you, at EVERY call site:
+errCases: (matcher) => matcher
+  .with(P.tag("UniqueConstraintViolation"), (e) => resp.conflict(e.fields))
+  .with(P.tag("DriverError"), (e) => resp.serverError(e)),   // ← this
+defect: (cause) => resp.serverError(cause),                   // ← and this
+```
 
 ::: tip The one carve-out: pagination cursors
 A cursor is an **opaque string from the outside world**, turned into a query by
-your `parseCursor`. So a validation error out of `withCursor` stays a modeled
-`DriverError` — a client sending garbage is anticipated input you turn into a 400,
-not a bug. See [Cursor pagination](#cursor-pagination) below.
+your `parseCursor`. A client sending garbage is anticipated input you answer with
+a 400 — so it is modeled, as `InvalidCursor`. A throw out of `getCursor` (which
+reads rows _you_ fetched) is a bug, and stays a defect. See
+[Cursor pagination](#cursor-pagination) below.
+:::
+
+::: warning Retries
+Deadlocks (`P2034`) and pool timeouts (`P2024`) are defects too, so a retry
+wrapper reaches for `recoverDefect` and inspects the cause, rather than matching a
+tag. That is one place in a codebase — versus an arm at every call site.
 :::
 
 ## Handle the errors
@@ -114,13 +133,13 @@ return created.match({
       )
       .with(P.tag("ForeignKeyViolation"), P.tag("RecordNotFound"), () =>
         resp.badRequest("unknown reference"),
-      )
-      .with(P.tag("DriverError"), (e) => resp.serverError(e)),
+      ),
   defect: (cause) => resp.serverError(cause),
 });
-// Exactly the four cases a create can raise — no more, no fewer. Add a P-code
-// to the union and every call site like this one stops compiling until it is
-// handled.
+// Exactly the three cases a create can raise — no more, no fewer. Add a case to
+// the union and every call site like this one stops compiling until it is
+// handled. Everything else (a dropped connection, a deadlock, a bug) lands in
+// the one `defect` arm.
 ```
 
 When several tags deserve the same response, **group** them in one arm rather
@@ -128,14 +147,12 @@ than reaching for a wildcard — the list stays explicit, so a new P-code still
 lights the call site up:
 
 ```ts
-matcher
-  .with(
-    P.tag("UniqueConstraintViolation"),
-    P.tag("ForeignKeyViolation"),
-    P.tag("RecordNotFound"),
-    () => resp.badRequest("bad write"),
-  )
-  .with(P.tag("DriverError"), (e) => resp.serverError(e));
+matcher.with(
+  P.tag("UniqueConstraintViolation"),
+  P.tag("ForeignKeyViolation"),
+  P.tag("RecordNotFound"),
+  () => resp.badRequest("bad write"),
+);
 ```
 
 ## Transactions
@@ -153,7 +170,7 @@ const moved = db.$tryTransaction((tx) =>
       tx.account.tryUpdate({ where: { id: to }, data: { balance: { increment: amount } } }),
     ),
 );
-//    ^? AsyncResult<Account, RecordNotFound | UniqueConstraintViolation | ForeignKeyViolation | DriverError>
+//    ^? AsyncResult<Account, RecordNotFound | UniqueConstraintViolation | ForeignKeyViolation>
 // Any Err → both updates rolled back, and the Err is in `moved`.
 ```
 
@@ -177,11 +194,11 @@ import { P } from "unthrown";
 const page = await db.user
   .tryPaginate({ where: { active: true }, orderBy: { id: "asc" } })
   .withCursor({ limit: 20, after: req.query.cursor });
-//    ^? Result<[User[], CursorPaginationMeta], DriverError>
+//    ^? Result<[User[], CursorPaginationMeta], InvalidCursor>
 
 page.match({
   ok: ([users, meta]) => json({ users, nextCursor: meta.endCursor, hasMore: meta.hasNextPage }),
-  errCases: (matcher) => matcher.with(P.tag("DriverError"), (e) => serverError(e)),
+  errCases: (matcher) => matcher.with(P.tag("InvalidCursor"), () => badRequest("bad cursor")),
   defect: serverError,
 });
 ```
@@ -194,9 +211,11 @@ passing both used to silently drop `after`); `before` + `limit: null` is a compi
 error; and the default cursor preserves the id's type (all-digit → number/`bigint`,
 otherwise string). Provide `getCursor` / `parseCursor` for composite keys.
 
-A malformed cursor stays a modeled `DriverError` rather than becoming a defect —
-the one place a Prisma validation error is treated as anticipated input, because
-the cursor comes from the client rather than from your code.
+A malformed cursor is a modeled `InvalidCursor` rather than a defect — the one
+place a Prisma validation error is treated as anticipated input, because the
+cursor comes from the client rather than from your code. A throw out of
+`getCursor`, which reads rows the query just returned, is a bug and stays a
+defect.
 
 ## Raw methods and raw SQL
 
@@ -210,7 +229,7 @@ import { fromPromise } from "unthrown";
 import { qualifyPrismaError } from "@unthrown/prisma";
 
 const rows = fromPromise(db.$queryRaw`SELECT 1`, qualifyPrismaError);
-//    ^? AsyncResult<unknown, UniqueConstraintViolation | ForeignKeyViolation | RecordNotFound | DriverError>
+//    ^? AsyncResult<unknown, UniqueConstraintViolation | ForeignKeyViolation | RecordNotFound>
 ```
 
 `qualifyPrismaError` **is** a `qualify` — the boundary injects the `defect`

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -36,21 +36,37 @@ await db.user.tryCreate({ data }).match({
   errCases: (matcher) =>
     matcher
       .with(P.tag("UniqueConstraintViolation"), (e) => conflict(e.fields))
+      .with(P.tag("RecordNotFound"), () => badRequest("unknown reference"))
       .with(P.tag("ForeignKeyViolation"), P.tag("DriverError"), (e) => serverError(e)),
   defect: serverError,
 });
 ```
 
-- **Per-operation errors** — reads (`tryFindMany` / `tryFindUnique` /
-  `tryFindFirst` / `tryCount` / `tryAggregate` / `tryGroupBy`) fail only with
-  `DriverError`; writes (`tryCreate` / `tryCreateMany` / `tryCreateManyAndReturn`
-  / `tryUpsert` / `tryUpdateMany` / `tryUpdateManyAndReturn`) add
-  `UniqueConstraintViolation` (P2002) and `ForeignKeyViolation` (P2003);
-  `tryFindUniqueOrThrow` / `tryFindFirstOrThrow` / `tryUpdate` / `tryDelete` add
-  `RecordNotFound` (P2025) — the batch mutations and `tryUpsert` never carry it
-  (zero matches is `Ok({ count: 0 })`; an upsert miss creates). `tryDeleteMany`
-  models only `ForeignKeyViolation`. Everything else folds into `DriverError`
-  with the cause preserved.
+- **Per-operation errors** — every operation carries `DriverError`; on top of
+  that:
+
+  | Operation                                                                                     | Adds                                                                 |
+  | --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+  | `tryFindMany` / `tryFindUnique` / `tryFindFirst` / `tryCount` / `tryAggregate` / `tryGroupBy` | — (reads fail only in the driver)                                    |
+  | `tryFindUniqueOrThrow` / `tryFindFirstOrThrow`                                                | `RecordNotFound`                                                     |
+  | `tryCreate` / `tryUpsert`                                                                     | `UniqueConstraintViolation`, `ForeignKeyViolation`, `RecordNotFound` |
+  | `tryUpdate`                                                                                   | `UniqueConstraintViolation`, `ForeignKeyViolation`, `RecordNotFound` |
+  | `tryDelete`                                                                                   | `ForeignKeyViolation`, `RecordNotFound`                              |
+  | `tryCreateMany` / `tryCreateManyAndReturn` / `tryUpdateMany` / `tryUpdateManyAndReturn`       | `UniqueConstraintViolation`, `ForeignKeyViolation`                   |
+  | `tryDeleteMany`                                                                               | `ForeignKeyViolation`                                                |
+
+  `UniqueConstraintViolation` is P2002 (and carries the offending `fields`),
+  `ForeignKeyViolation` is P2003, `RecordNotFound` is P2025/P2018. Only the
+  **batch** mutations are free of `RecordNotFound`: they take no nested writes,
+  and zero matches is `Ok({ count: 0 })`. `tryCreate` and `tryUpsert` carry it
+  because a nested `connect` can point at a row that does not exist.
+
+- **Bugs stay bugs** — a malformed query, a client that cannot start and an
+  engine panic (`PrismaClientValidationError` /
+  `PrismaClientInitializationError` / `PrismaClientRustPanicError`) go to the
+  **defect** channel, not into `E`. `DriverError` means the database refused
+  the query — connection drops, timeouts, unmapped P-codes — which is an
+  anticipated outcome worth handling.
 - **`$tryTransaction`** — an interactive transaction whose callback speaks
   `AsyncResult`: an `Err` triggers a ROLLBACK and comes out as the same typed
   `Err`; a defect also rolls back and stays a defect. The `try*` methods are
@@ -79,7 +95,10 @@ const page = await db.user
   .tryPaginate({ where: { active: true }, orderBy: { id: "asc" } })
   .withCursor({ limit: 20, after: req.query.cursor });
 // Ok([users, { hasPreviousPage, hasNextPage, startCursor, endCursor }])
-// | Err(DriverError) — a malformed cursor included.
+// | Err(DriverError) — a malformed cursor included: it comes from a client, so
+//   it stays a value you can turn into a 400, never a defect.
+// `after` and `before` are mutually exclusive, and `before` + `limit: null` is
+// a compile error.
 
 // Custom serialization (composite keys, non-id cursors):
 const liked = await db.like.tryPaginate({ orderBy: { postId: "asc" } }).withCursor({

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -13,7 +13,7 @@ pnpm add @unthrown/prisma unthrown
 
 `$extends(unthrownPrisma)` adds `try*` variants of the model delegate operations
 **alongside** the raw promise ones. Each returns an `AsyncResult` whose error
-channel is exactly the set of P-codes that operation can produce, mapped to
+channel is exactly the **domain** outcomes that operation can produce, mapped to
 tagged errors — a read cannot fail with `UniqueConstraintViolation` _in the
 type_. Qualification happens once, inside the extension: no raw Promise ever
 reaches your code.
@@ -26,47 +26,52 @@ import { PrismaClient } from "./generated/prisma/client.ts";
 const db = new PrismaClient({ adapter }).$extends(unthrownPrisma);
 
 const users = db.user.tryFindMany({ select: { id: true } });
-//    ^? AsyncResult<{ id: number }[], DriverError>
-//       `select` / `include` payload inference survives the wrap.
+//    ^? AsyncResult<{ id: number }[], never>
+//       A read has no modeled failure. `select` / `include` payload
+//       inference survives the wrap.
 
 await db.user.tryCreate({ data }).match({
   ok: (user) => created(user),
-  // every P-code `tryCreate` can raise gets an arm — cases sharing a handler
+  // every case `tryCreate` can raise gets an arm — cases sharing a handler
   // are grouped, so nothing is absorbed unnamed:
   errCases: (matcher) =>
     matcher
       .with(P.tag("UniqueConstraintViolation"), (e) => conflict(e.fields))
-      .with(P.tag("RecordNotFound"), () => badRequest("unknown reference"))
-      .with(P.tag("ForeignKeyViolation"), P.tag("DriverError"), (e) => serverError(e)),
+      .with(P.tag("ForeignKeyViolation"), P.tag("RecordNotFound"), () =>
+        badRequest("unknown reference"),
+      ),
+  // a dropped connection, a deadlock, a bug — one arm, at the edge:
   defect: serverError,
 });
 ```
 
-- **Per-operation errors** — every operation carries `DriverError`; on top of
-  that:
+- **`E` is domain outcomes only** — things a caller did, or a legitimate state
+  conflict, that your code actually branches on:
 
-  | Operation                                                                                     | Adds                                                                 |
+  | Operation                                                                                     | Error channel                                                        |
   | --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
-  | `tryFindMany` / `tryFindUnique` / `tryFindFirst` / `tryCount` / `tryAggregate` / `tryGroupBy` | — (reads fail only in the driver)                                    |
+  | `tryFindMany` / `tryFindUnique` / `tryFindFirst` / `tryCount` / `tryAggregate` / `tryGroupBy` | `never`                                                              |
   | `tryFindUniqueOrThrow` / `tryFindFirstOrThrow`                                                | `RecordNotFound`                                                     |
-  | `tryCreate` / `tryUpsert`                                                                     | `UniqueConstraintViolation`, `ForeignKeyViolation`, `RecordNotFound` |
-  | `tryUpdate`                                                                                   | `UniqueConstraintViolation`, `ForeignKeyViolation`, `RecordNotFound` |
-  | `tryDelete`                                                                                   | `ForeignKeyViolation`, `RecordNotFound`                              |
-  | `tryCreateMany` / `tryCreateManyAndReturn` / `tryUpdateMany` / `tryUpdateManyAndReturn`       | `UniqueConstraintViolation`, `ForeignKeyViolation`                   |
+  | `tryCreate` / `tryUpsert` / `tryUpdate`                                                       | `UniqueConstraintViolation \| ForeignKeyViolation \| RecordNotFound` |
+  | `tryDelete`                                                                                   | `ForeignKeyViolation \| RecordNotFound`                              |
+  | `tryCreateMany` / `tryCreateManyAndReturn` / `tryUpdateMany` / `tryUpdateManyAndReturn`       | `UniqueConstraintViolation \| ForeignKeyViolation`                   |
   | `tryDeleteMany`                                                                               | `ForeignKeyViolation`                                                |
+  | `tryPaginate(...).withCursor(...)`                                                            | `InvalidCursor`                                                      |
 
-  `UniqueConstraintViolation` is P2002 (and carries the offending `fields`),
-  `ForeignKeyViolation` is P2003, `RecordNotFound` is P2025/P2018. Only the
-  **batch** mutations are free of `RecordNotFound`: they take no nested writes,
-  and zero matches is `Ok({ count: 0 })`. `tryCreate` and `tryUpsert` carry it
-  because a nested `connect` can point at a row that does not exist.
+  `UniqueConstraintViolation` is P2002 (409, and carries the offending
+  `fields`), `ForeignKeyViolation` is P2003 (400), `RecordNotFound` is
+  P2025/P2018 (404). Only the **batch** mutations are free of `RecordNotFound`:
+  they take no nested writes, and zero matches is `Ok({ count: 0 })`.
+  `tryCreate` and `tryUpsert` carry it because a nested `connect` can point at a
+  row that does not exist.
 
-- **Bugs stay bugs** — a malformed query, a client that cannot start and an
-  engine panic (`PrismaClientValidationError` /
-  `PrismaClientInitializationError` / `PrismaClientRustPanicError`) go to the
-  **defect** channel, not into `E`. `DriverError` means the database refused
-  the query — connection drops, timeouts, unmapped P-codes — which is an
-  anticipated outcome worth handling.
+- **Everything infrastructural is a defect** — a dropped connection, a pool
+  timeout, a deadlock, an unmapped P-code, a malformed query, an engine panic.
+  Nobody writes domain logic for those: they are logged and turned into a 500 by
+  the one `defect` arm you already have at the edge. Putting them in `E` would
+  only force every call site to carry an arm duplicating its own `defect` arm.
+  (A defect is not a crash — it flows through the pipeline untouched and is
+  folded at the edge like any other unmodeled failure.)
 - **`$tryTransaction`** — an interactive transaction whose callback speaks
   `AsyncResult`: an `Err` triggers a ROLLBACK and comes out as the same typed
   `Err`; a defect also rolls back and stays a defect. The `try*` methods are
@@ -95,8 +100,8 @@ const page = await db.user
   .tryPaginate({ where: { active: true }, orderBy: { id: "asc" } })
   .withCursor({ limit: 20, after: req.query.cursor });
 // Ok([users, { hasPreviousPage, hasNextPage, startCursor, endCursor }])
-// | Err(DriverError) — a malformed cursor included: it comes from a client, so
-//   it stays a value you can turn into a 400, never a defect.
+// | Err(InvalidCursor) — the cursor is the only part of the query that came from
+//   outside, so it is the only modeled failure: answer it with a 400.
 // `after` and `before` are mutually exclusive, and `before` + `limit: null` is
 // a compile error.
 

--- a/packages/prisma/src/index.spec.ts
+++ b/packages/prisma/src/index.spec.ts
@@ -132,8 +132,7 @@ describe("try* model methods", () => {
           matcher
             .with(P.tag("UniqueConstraintViolation"), () => "conflict" as const)
             .with(P.tag("ForeignKeyViolation"), () => "bad-reference" as const)
-            .with(P.tag("RecordNotFound"), () => "missing" as const)
-            .with(P.tag("DriverError"), () => "unavailable" as const),
+            .with(P.tag("RecordNotFound"), () => "missing" as const),
         ),
     ).toBeErrWith("missing");
   });
@@ -278,12 +277,10 @@ describe("$tryTransaction", () => {
     await expect(db.user.tryCount()).toBeOkWith(0);
   });
 
-  it("a callback that THROWS (instead of returning an AsyncResult) is a defect, not a DriverError", async ({
-    db,
-  }) => {
+  it("a callback that THROWS (instead of returning an AsyncResult) is a defect", async ({ db }) => {
     // The throw bypasses every combinator (no AsyncResult exists yet), so it
     // reaches the transaction boundary raw. A bug must stay a defect — never
-    // be downgraded to a modeled DriverError.
+    // be downgraded into the modeled error channel.
     await expect(
       db.$tryTransaction(() => {
         throw new Error("sync callback bug");
@@ -298,7 +295,7 @@ describe("$tryTransaction", () => {
     // Out of contract: the callback resolves to `42` instead of a Result.
     // Dispatching on `result.isOk` would then throw a TypeError OUTSIDE the
     // sentinel try/catch, reject the transaction with a non-Rollback cause,
-    // and be downgraded into a modeled DriverError. A bug must stay a defect
+    // and be downgraded into the modeled error channel. A bug must stay a defect
     // — and the write made before the rogue return must be rolled back.
     const rogue = (async (tx: { user: { tryCreate: (args: unknown) => PromiseLike<unknown> } }) => {
       await tx.user.tryCreate({ data: { email: "rogue@example.com" } });
@@ -320,7 +317,7 @@ describe("$tryTransaction", () => {
     ).toBeErrTagged("UniqueConstraintViolation");
   });
 
-  it("qualifies a transaction-level failure (commit after timeout) as DriverError", async ({
+  it("routes a transaction-level failure (commit after timeout) to the defect channel", async ({
     db,
   }) => {
     // The callback outlives the transaction timeout WITHOUT touching `tx`, so the
@@ -330,7 +327,7 @@ describe("$tryTransaction", () => {
         () => fromSafePromise(new Promise((resolve) => setTimeout(resolve, 100))).map(() => "ok"),
         { timeout: 10 },
       ),
-    ).toBeErrTagged("DriverError");
+    ).toBeDefect();
   });
 });
 
@@ -465,12 +462,14 @@ describe("tryPaginate / withCursor", () => {
     ]);
   });
 
-  it("surfaces a default cursor over a selection without id as DriverError", async ({
+  // `getCursor` reads rows WE fetched, so a throw there is a bug in the caller's
+  // selection, not bad input from a client — the defect channel, not InvalidCursor.
+  it("routes a default cursor over a selection without id to the DEFECT channel", async ({
     seededDb: db,
   }) => {
     await expect(
       db.user.tryPaginate({ select: { email: true } }).withCursor({ limit: 2 }),
-    ).toBeErrTagged("DriverError");
+    ).toBeDefect();
   });
 
   // The pagination carve-out. Prisma rejects this with a
@@ -478,12 +477,41 @@ describe("tryPaginate / withCursor", () => {
   // channel — but here the cursor is an OPAQUE STRING from the outside world, so
   // a client sending garbage is anticipated input, not a bug. It must stay a
   // modeled Err the caller can turn into a 400.
-  it("surfaces a malformed cursor as DriverError, not a defect", async ({ seededDb: db }) => {
+  it("models a malformed cursor as InvalidCursor, not a defect", async ({ seededDb: db }) => {
     // Default parseCursor keeps a non-numeric cursor as a string — invalid for
     // this model's Int id, so Prisma rejects it.
     await expect(
       db.user.tryPaginate({ orderBy: { id: "asc" } }).withCursor({ limit: 2, after: "not-an-id" }),
-    ).toBeErrTagged("DriverError");
+    ).toBeErrTagged("InvalidCursor");
+  });
+
+  // The other half of the carve-out: the caller's own `parseCursor` rejecting a
+  // client-supplied string is the same anticipated bad input.
+  it("models a throwing parseCursor on a request cursor as InvalidCursor", async ({
+    seededDb: db,
+  }) => {
+    await expect(
+      db.user.tryPaginate({ orderBy: { id: "asc" } }).withCursor({
+        limit: 2,
+        after: "garbage",
+        parseCursor: (cursor) => {
+          throw new Error(`unparseable: ${cursor}`);
+        },
+      }),
+    ).toBeErrTagged("InvalidCursor");
+  });
+
+  // ...but the SAME throw while re-parsing a cursor we generated ourselves is a
+  // bug in the caller's cursor functions, and stays a defect.
+  it("routes a throwing getCursor to the DEFECT channel", async ({ seededDb: db }) => {
+    await expect(
+      db.user.tryPaginate({ orderBy: { id: "asc" } }).withCursor({
+        limit: 2,
+        getCursor: () => {
+          throw new Error("no cursor for this row");
+        },
+      }),
+    ).toBeDefect();
   });
 
   // The `before` + `limit: null` combination is typed away at the public
@@ -683,30 +711,22 @@ describe("qualifyPrismaError", () => {
     },
   );
 
-  it("maps an unhandled P-code to DriverError", () => {
-    const cause = known("P2024");
-    expect(qualify(cause)).toEqual(expect.objectContaining({ _tag: "DriverError", cause }));
-  });
-
-  it("maps a non-Prisma rejection to DriverError, preserving the cause", () => {
-    const cause = new Error("socket hang up");
-    expect(qualify(cause)).toEqual(expect.objectContaining({ _tag: "DriverError", cause }));
-  });
-
-  it("keeps PrismaClientUnknownRequestError in the error channel (the query DID fail)", () => {
-    const cause = named("PrismaClientUnknownRequestError");
-    expect(qualify(cause)).toEqual(expect.objectContaining({ _tag: "DriverError", cause }));
-  });
-
-  // Thesis #1: `E` lists only anticipated failures. A malformed query, a client
-  // that cannot start and an engine panic are bugs / environment faults, so they
-  // must take the defect channel rather than masquerading as a DriverError.
+  // Thesis #1: `E` lists only the failures a caller branches on. Everything
+  // infrastructural takes the defect channel — nobody writes domain logic for a
+  // dropped connection, they log it and 500, which is what `match`'s `defect`
+  // arm already does.
   it.each([
-    "PrismaClientValidationError",
-    "PrismaClientInitializationError",
-    "PrismaClientRustPanicError",
-  ])("routes %s to the DEFECT channel, not to E", (name) => {
-    const cause = named(name);
+    ["a connection-pool timeout", () => known("P2024")],
+    ["a write conflict / deadlock", () => known("P2034")],
+    ["an unreachable database server", () => known("P1001")],
+    ["any other unmapped P-code", () => known("P2021")],
+    ["a malformed query", () => named("PrismaClientValidationError")],
+    ["a client that could not start", () => named("PrismaClientInitializationError")],
+    ["an engine panic", () => named("PrismaClientRustPanicError")],
+    ["an unknown request error", () => named("PrismaClientUnknownRequestError")],
+    ["a non-Prisma rejection", () => new Error("socket hang up")],
+  ])("routes %s to the DEFECT channel, not to E", (_label, make) => {
+    const cause = make();
     expect(qualify(cause)).toEqual(defect(cause));
   });
 });

--- a/packages/prisma/src/index.spec.ts
+++ b/packages/prisma/src/index.spec.ts
@@ -8,7 +8,7 @@
 import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
 import { PrismaClientKnownRequestError } from "@prisma/client/runtime/client";
 import "@unthrown/vitest";
-import { Err, fromSafePromise, TaggedError } from "unthrown";
+import { Err, fromSafePromise, P, TaggedError } from "unthrown";
 import { describe, expect, test } from "vitest";
 
 import { PrismaClient } from "./generated/prisma/client.ts";
@@ -98,6 +98,52 @@ describe("try* model methods", () => {
       "RecordNotFound",
     );
     await expect(db.user.tryDelete({ where: { id: 999 } })).toBeErrTagged("RecordNotFound");
+  });
+
+  // `create` and `upsert` have no row of their own to miss, but a nested
+  // `connect` pointing at a record that does not exist raises P2025 all the
+  // same — so RecordNotFound belongs in their unions.
+  it("models a nested connect to a missing record as RecordNotFound (create and upsert)", async ({
+    db,
+  }) => {
+    await expect(
+      db.post.tryCreate({ data: { title: "orphan", author: { connect: { id: 999 } } } }),
+    ).toBeErrTagged("RecordNotFound");
+    await expect(
+      db.post.tryUpsert({
+        where: { id: 999 },
+        create: { title: "orphan", author: { connect: { id: 999 } } },
+        update: {},
+      }),
+    ).toBeErrTagged("RecordNotFound");
+  });
+
+  // The regression this guards: while CreateError omitted RecordNotFound, the
+  // match below was exhaustive *by type* yet had no arm for the value that
+  // actually arrived — the matcher threw NonExhaustiveError and the
+  // throw-to-defect net turned a modeled database failure into a Defect.
+  it("keeps that nested-connect failure a VALUE under an exhaustive match (never a Defect)", async ({
+    db,
+  }) => {
+    await expect(
+      db.post
+        .tryCreate({ data: { title: "orphan", author: { connect: { id: 999 } } } })
+        .mapErrCases((matcher) =>
+          matcher
+            .with(P.tag("UniqueConstraintViolation"), () => "conflict" as const)
+            .with(P.tag("ForeignKeyViolation"), () => "bad-reference" as const)
+            .with(P.tag("RecordNotFound"), () => "missing" as const)
+            .with(P.tag("DriverError"), () => "unavailable" as const),
+        ),
+    ).toBeErrWith("missing");
+  });
+
+  // A malformed query is a BUG, not an anticipated outcome — `Prisma.Exact`
+  // rejects it in typed code, so reaching it means the types were cast away.
+  it("routes a malformed query (a Prisma validation error) to the DEFECT channel", async ({
+    db,
+  }) => {
+    await expect(db.user.tryFindMany({ where: { bogus: true } } as never)).toBeDefect();
   });
 
   it("updates, deletes, and counts through the bridge", async ({ db }) => {
@@ -356,7 +402,7 @@ describe("tryPaginate / withCursor", () => {
     ]);
   });
 
-  // The fix carried over from deptyped/prisma-extension-pagination#36 (#35):
+  // The fix carried over from deptyped/prisma-extension-pagination#35:
   // when the AFTER cursor row was mutated and no longer matches the filter, the
   // first element of the page must NOT be skipped.
   it("does not skip the first element when the after cursor no longer matches the filter", async ({
@@ -427,7 +473,12 @@ describe("tryPaginate / withCursor", () => {
     ).toBeErrTagged("DriverError");
   });
 
-  it("surfaces a malformed cursor as DriverError", async ({ seededDb: db }) => {
+  // The pagination carve-out. Prisma rejects this with a
+  // PrismaClientValidationError, which the `try*` surface routes to the DEFECT
+  // channel — but here the cursor is an OPAQUE STRING from the outside world, so
+  // a client sending garbage is anticipated input, not a bug. It must stay a
+  // modeled Err the caller can turn into a 400.
+  it("surfaces a malformed cursor as DriverError, not a defect", async ({ seededDb: db }) => {
     // Default parseCursor keeps a non-numeric cursor as a string — invalid for
     // this model's Int id, so Prisma rejects it.
     await expect(
@@ -576,9 +627,19 @@ describe("qualifyPrismaError", () => {
       ...(meta ? { meta } : {}),
     });
 
+  // Stands in for the `defect` helper a boundary injects: a distinguishable
+  // marker, so a test can tell "routed to the defect channel" from "mapped".
+  const DEFECTED = Symbol("defected");
+  const defect = (cause: unknown) => ({ [DEFECTED]: cause }) as const;
+  const qualify = (cause: unknown) => qualifyPrismaError(cause, defect);
+
+  // A Prisma error class the extension recognizes by `name` alone (the runtime
+  // module path moves between Prisma majors, so `instanceof` is not an option).
+  const named = (name: string) => Object.assign(new Error("boom"), { name });
+
   it("maps P2002 to UniqueConstraintViolation with the offending fields", () => {
     const cause = known("P2002", { target: ["email"] });
-    expect(qualifyPrismaError(cause)).toEqual(
+    expect(qualify(cause)).toEqual(
       expect.objectContaining({ _tag: "UniqueConstraintViolation", fields: ["email"], cause }),
     );
   });
@@ -587,13 +648,13 @@ describe("qualifyPrismaError", () => {
     const cause = known("P2002", {
       driverAdapterError: { cause: { constraint: { fields: ["email"] } } },
     });
-    expect(qualifyPrismaError(cause)).toEqual(
+    expect(qualify(cause)).toEqual(
       expect.objectContaining({ _tag: "UniqueConstraintViolation", fields: ["email"], cause }),
     );
   });
 
   it("maps P2002 without a target to an empty field list", () => {
-    expect(qualifyPrismaError(known("P2002"))).toEqual(
+    expect(qualify(known("P2002"))).toEqual(
       expect.objectContaining({ _tag: "UniqueConstraintViolation", fields: [] }),
     );
   });
@@ -604,36 +665,48 @@ describe("qualifyPrismaError", () => {
     { driverAdapterError: { cause: { constraint: "junk" } } },
     { driverAdapterError: { cause: { constraint: { fields: "email" } } } },
   ])("maps P2002 with a malformed meta (%j) to an empty field list", (meta) => {
-    expect(qualifyPrismaError(known("P2002", meta))).toEqual(
+    expect(qualify(known("P2002", meta))).toEqual(
       expect.objectContaining({ _tag: "UniqueConstraintViolation", fields: [] }),
     );
   });
 
   it("maps P2003 to ForeignKeyViolation", () => {
     const cause = known("P2003");
-    expect(qualifyPrismaError(cause)).toEqual(
-      expect.objectContaining({ _tag: "ForeignKeyViolation", cause }),
-    );
+    expect(qualify(cause)).toEqual(expect.objectContaining({ _tag: "ForeignKeyViolation", cause }));
   });
 
-  it("maps P2025 to RecordNotFound", () => {
-    const cause = known("P2025");
-    expect(qualifyPrismaError(cause)).toEqual(
-      expect.objectContaining({ _tag: "RecordNotFound", cause }),
-    );
-  });
+  it.each(["P2025", "P2018"])(
+    "maps %s to RecordNotFound (the to-one and to-many sides of the same failure)",
+    (code) => {
+      const cause = known(code);
+      expect(qualify(cause)).toEqual(expect.objectContaining({ _tag: "RecordNotFound", cause }));
+    },
+  );
 
   it("maps an unhandled P-code to DriverError", () => {
     const cause = known("P2024");
-    expect(qualifyPrismaError(cause)).toEqual(
-      expect.objectContaining({ _tag: "DriverError", cause }),
-    );
+    expect(qualify(cause)).toEqual(expect.objectContaining({ _tag: "DriverError", cause }));
   });
 
   it("maps a non-Prisma rejection to DriverError, preserving the cause", () => {
     const cause = new Error("socket hang up");
-    expect(qualifyPrismaError(cause)).toEqual(
-      expect.objectContaining({ _tag: "DriverError", cause }),
-    );
+    expect(qualify(cause)).toEqual(expect.objectContaining({ _tag: "DriverError", cause }));
+  });
+
+  it("keeps PrismaClientUnknownRequestError in the error channel (the query DID fail)", () => {
+    const cause = named("PrismaClientUnknownRequestError");
+    expect(qualify(cause)).toEqual(expect.objectContaining({ _tag: "DriverError", cause }));
+  });
+
+  // Thesis #1: `E` lists only anticipated failures. A malformed query, a client
+  // that cannot start and an engine panic are bugs / environment faults, so they
+  // must take the defect channel rather than masquerading as a DriverError.
+  it.each([
+    "PrismaClientValidationError",
+    "PrismaClientInitializationError",
+    "PrismaClientRustPanicError",
+  ])("routes %s to the DEFECT channel, not to E", (name) => {
+    const cause = named(name);
+    expect(qualify(cause)).toEqual(defect(cause));
   });
 });

--- a/packages/prisma/src/index.ts
+++ b/packages/prisma/src/index.ts
@@ -11,7 +11,8 @@
 //   const db = new PrismaClient({ adapter }).$extends(unthrownPrisma);
 //
 //   await db.user.tryCreate({ data }).match({ ok, errCases, defect });
-//   // errCases matches UniqueConstraintViolation | ForeignKeyViolation | DriverError
+//   // errCases matches UniqueConstraintViolation | ForeignKeyViolation
+//   //                | RecordNotFound | DriverError
 //
 // The raw promise methods stay available on purpose: they are the escape hatch
 // for batch `$transaction([...])`, which needs unexecuted `PrismaPromise`s.
@@ -44,19 +45,29 @@ export class UniqueConstraintViolation extends TaggedError("UniqueConstraintViol
 export class ForeignKeyViolation extends TaggedError("ForeignKeyViolation")<{ cause: unknown }> {}
 
 /**
- * A record required by the operation does not exist (Prisma error `P2025`) —
- * the missing row of a `findUniqueOrThrow`, `update`, or `delete`.
+ * A record required by the operation does not exist (Prisma errors `P2025` and
+ * `P2018`) — the missing row of a `findUniqueOrThrow`, `update`, or `delete`,
+ * **or** the missing target of a nested `connect`.
+ *
+ * @remarks
+ * The nested-`connect` case is why `tryCreate` and `tryUpsert` carry this error
+ * despite never "missing" a row of their own: `create({ data: { author: {
+ * connect: { id } } } })` raises `P2025` when that author does not exist (and
+ * `P2018` for the to-many side of the same mistake). Both codes say the same
+ * thing — a record the write depended on was not found — so both map here.
  */
 export class RecordNotFound extends TaggedError("RecordNotFound")<{ cause: unknown }> {}
 
 /**
- * Any other query failure: connection drops, timeouts, unmapped P-codes,
+ * A genuine query failure: connection drops, timeouts, unmapped P-codes,
  * driver-level errors.
  *
  * @remarks
- * Prisma validation errors land here too. Arguably a malformed query is a
- * programmer bug rather than an anticipated outcome; triage it further at the
- * call site if the distinction matters to you.
+ * This is the "the database refused the query" bucket — an anticipated outcome
+ * of talking to a database over a network. It is deliberately NOT the
+ * everything-else bucket: a malformed query, a client that cannot start, and an
+ * engine panic are bugs rather than outcomes, so they take the **defect**
+ * channel instead (see {@link qualifyPrismaError}).
  */
 export class DriverError extends TaggedError("DriverError")<{ cause: unknown }> {}
 
@@ -89,6 +100,28 @@ const isKnownRequestError = (cause: unknown): cause is KnownRequestError =>
   cause.name === "PrismaClientKnownRequestError" &&
   typeof (cause as { code?: unknown }).code === "string";
 
+// Prisma's non-query error classes — recognized by `name` for the same reason
+// as above. None of these is an anticipated outcome of running a query:
+//
+//   PrismaClientValidationError    — the query itself is malformed (a bug: the
+//                                    `try*` surface types its args with
+//                                    `Prisma.Exact`, so reaching this means the
+//                                    types were cast away)
+//   PrismaClientInitializationError — the client could not start (bad datasource
+//                                    URL, engine/version mismatch)
+//   PrismaClientRustPanicError     — the query engine panicked
+//
+// `PrismaClientUnknownRequestError` is deliberately absent: the query really did
+// fail in the database, just without a P-code to name it. That is a DriverError.
+const DEFECT_ERROR_NAMES: ReadonlySet<string> = new Set([
+  "PrismaClientValidationError",
+  "PrismaClientInitializationError",
+  "PrismaClientRustPanicError",
+]);
+
+const isValidationError = (cause: unknown): boolean =>
+  cause instanceof Error && cause.name === "PrismaClientValidationError";
+
 // The offending column set of a P2002, wherever this Prisma version put it:
 // `meta.target` (the classic engine shape) or
 // `meta.driverAdapterError.cause.constraint.fields` (the driver-adapter shape).
@@ -107,24 +140,47 @@ const constraintFields = (meta: unknown): readonly string[] => {
 };
 
 /**
- * Qualify a Prisma rejection into a tagged error — the runtime half of the
- * bridge.
+ * Qualify a Prisma rejection — the runtime half of the bridge, and a ready-made
+ * `qualify` for any boundary you build yourself (raw SQL, a batch
+ * `$transaction([...])`).
  *
  * @remarks
  * Recognized P-codes map to their dedicated errors (`P2002` →
  * {@link UniqueConstraintViolation}, `P2003` → {@link ForeignKeyViolation},
- * `P2025` → {@link RecordNotFound}); everything else — including non-Prisma
- * causes — folds into {@link DriverError} with the cause preserved.
+ * `P2025` / `P2018` → {@link RecordNotFound}); other query failures fold into
+ * {@link DriverError} with the cause preserved.
+ *
+ * Prisma's **non-query** errors — a malformed query
+ * (`PrismaClientValidationError`), a client that could not start
+ * (`PrismaClientInitializationError`), an engine panic
+ * (`PrismaClientRustPanicError`) — are routed to the **defect** channel instead
+ * of `E`: they are bugs and environment faults, not anticipated outcomes of a
+ * query, and unthrown's first rule is that `E` lists only modeled failures.
  *
  * @param cause - the rejected value from a Prisma query.
+ * @param defect - the defect helper the boundary injects (never import it).
+ *
+ * @example
+ * ```ts
+ * // Pass it straight to a boundary — `defect` is injected for you.
+ * const rows = fromPromise(db.$queryRaw`SELECT 1`, qualifyPrismaError);
+ * ```
  */
-export const qualifyPrismaError = (cause: unknown): PrismaQueryError => {
+export const qualifyPrismaError = <D>(
+  cause: unknown,
+  defect: (cause: unknown) => D,
+): PrismaQueryError | D => {
+  if (cause instanceof Error && DEFECT_ERROR_NAMES.has(cause.name)) return defect(cause);
   if (isKnownRequestError(cause)) {
     switch (cause.code) {
       case "P2002":
         return new UniqueConstraintViolation({ fields: constraintFields(cause.meta), cause });
       case "P2003":
         return new ForeignKeyViolation({ cause });
+      // P2025 ("depends on records that were required but not found") and P2018
+      // ("the required connected records were not found") are the same failure
+      // reported from the to-one and to-many sides of a nested write.
+      case "P2018":
       case "P2025":
         return new RecordNotFound({ cause });
       default:
@@ -136,14 +192,19 @@ export const qualifyPrismaError = (cause: unknown): PrismaQueryError => {
 
 // Per-operation error unions — the static half. Reads can only fail in the
 // driver; writes add the constraint violations their SQL can raise; `*OrThrow`
-// and mutations of a specific record add P2025. The batch mutations (`*Many`)
-// and `upsert` never raise P2025: zero matches is `Ok({ count: 0 })`, and an
-// upsert miss creates.
+// and mutations of a specific record add RecordNotFound for their missing row.
+//
+// RecordNotFound also reaches `create` and `upsert`, which have no row of their
+// own to miss: a nested `connect` to a record that does not exist raises P2025
+// (to-one) or P2018 (to-many). The BATCH mutations are the ones genuinely free
+// of it — `createMany` / `updateMany` and their `*AndReturn` twins accept no
+// nested writes, and zero matches is `Ok({ count: 0 })`, never an error.
 type ReadError = DriverError;
-type CreateError = UniqueConstraintViolation | ForeignKeyViolation | DriverError;
+type CreateError = UniqueConstraintViolation | ForeignKeyViolation | RecordNotFound | DriverError;
+type CreateManyError = UniqueConstraintViolation | ForeignKeyViolation | DriverError;
 type UpdateError = RecordNotFound | UniqueConstraintViolation | ForeignKeyViolation | DriverError;
 type DeleteError = RecordNotFound | ForeignKeyViolation | DriverError;
-type UpsertError = UniqueConstraintViolation | ForeignKeyViolation | DriverError;
+type UpsertError = UniqueConstraintViolation | ForeignKeyViolation | RecordNotFound | DriverError;
 type UpdateManyError = UniqueConstraintViolation | ForeignKeyViolation | DriverError;
 type DeleteManyError = ForeignKeyViolation | DriverError;
 
@@ -162,6 +223,18 @@ const query = (self: unknown, op: string, args?: unknown): AsyncResult<unknown, 
     () => (Prisma.getExtensionContext(self) as unknown as UntypedDelegate)[op]!(args),
     qualifyPrismaError,
   );
+
+// Pagination's own triage. A cursor is an OPAQUE STRING from the outside world
+// (a query parameter), turned into a `where` input by caller-supplied
+// `parseCursor` — so a query Prisma refuses to validate is an anticipated
+// bad-input outcome here, not the programmer bug it is on the `Prisma.Exact`-typed
+// `try*` surface. It stays a modeled DriverError; every other cause is triaged
+// exactly as elsewhere.
+const qualifyPaginationError = <D>(
+  cause: unknown,
+  defect: (cause: unknown) => D,
+): PrismaQueryError | D =>
+  isValidationError(cause) ? new DriverError({ cause }) : qualifyPrismaError(cause, defect);
 
 // The rollback sentinel: an `Err` (or defect) inside `$tryTransaction`'s
 // callback is thrown so Prisma aborts the transaction, then unwrapped back out
@@ -338,7 +411,9 @@ export const unthrownPrisma = Prisma.defineExtension({
 
       /**
        * `create`, qualified: constraint violations are modeled —
-       * {@link UniqueConstraintViolation} and {@link ForeignKeyViolation}.
+       * {@link UniqueConstraintViolation} and {@link ForeignKeyViolation} — and
+       * so is a nested `connect` to a row that does not exist
+       * ({@link RecordNotFound}).
        */
       tryCreate<T, A>(
         this: T,
@@ -351,16 +426,17 @@ export const unthrownPrisma = Prisma.defineExtension({
       },
 
       /**
-       * `createMany`, qualified: the batch count, or the same modeled
-       * constraint violations as `tryCreate`.
+       * `createMany`, qualified: the batch count, or the constraint violations
+       * the batch can raise. No {@link RecordNotFound} — `createMany` accepts
+       * no nested writes, so there is no `connect` to miss.
        */
       tryCreateMany<T, A>(
         this: T,
         args: Prisma.Exact<A, Prisma.Args<T, "createMany">>,
-      ): AsyncResult<Prisma.Result<T, A, "createMany">, CreateError> {
+      ): AsyncResult<Prisma.Result<T, A, "createMany">, CreateManyError> {
         return query(this, "createMany", args) as AsyncResult<
           Prisma.Result<T, A, "createMany">,
-          CreateError
+          CreateManyError
         >;
       },
 
@@ -368,10 +444,10 @@ export const unthrownPrisma = Prisma.defineExtension({
       tryCreateManyAndReturn<T, A>(
         this: T,
         args: Prisma.Exact<A, Prisma.Args<T, "createManyAndReturn">>,
-      ): AsyncResult<Prisma.Result<T, A, "createManyAndReturn">, CreateError> {
+      ): AsyncResult<Prisma.Result<T, A, "createManyAndReturn">, CreateManyError> {
         return query(this, "createManyAndReturn", args) as AsyncResult<
           Prisma.Result<T, A, "createManyAndReturn">,
-          CreateError
+          CreateManyError
         >;
       },
 
@@ -390,9 +466,10 @@ export const unthrownPrisma = Prisma.defineExtension({
       },
 
       /**
-       * `upsert`, qualified: no {@link RecordNotFound} in the union — a miss
-       * *creates* — but the write can still hit the modeled constraint
-       * violations.
+       * `upsert`, qualified: a missing *target* is never an error — a miss
+       * **creates** — but the write can still hit the modeled constraint
+       * violations, and a nested `connect` in either branch can still raise
+       * {@link RecordNotFound}.
        */
       tryUpsert<T, A>(
         this: T,
@@ -487,12 +564,19 @@ export const unthrownPrisma = Prisma.defineExtension({
         Prisma.Result<T, A, "findMany">,
         NonNullable<Prisma.Args<T, "findMany">["cursor"]>
       > {
-        const delegate = Prisma.getExtensionContext(this) as unknown as PaginationDelegate;
         return {
+          // Everything runs inside the THUNK, `getExtensionContext` included —
+          // the same discipline as `query` above, so no synchronous throw can
+          // escape the boundary as a raw throw.
           withCursor: (options: Parameters<typeof paginateWithCursor>[2]) =>
             fromPromise(
-              paginateWithCursor(delegate, args as object | undefined, options),
-              qualifyPrismaError,
+              () =>
+                paginateWithCursor(
+                  Prisma.getExtensionContext(this) as unknown as PaginationDelegate,
+                  args as object | undefined,
+                  options,
+                ),
+              qualifyPaginationError,
             ),
         } as unknown as CursorPaginator<
           Prisma.Result<T, A, "findMany">,
@@ -582,7 +666,7 @@ export const unthrownPrisma = Prisma.defineExtension({
             ? cause.wasDefect
               ? defect(cause.carried)
               : (cause.carried as PrismaQueryError)
-            : qualifyPrismaError(cause),
+            : qualifyPrismaError(cause, defect),
       );
       // A non-defect `Rollback` carries the callback's own `Err` value, so the
       // channel is really `E | PrismaQueryError` — re-attached here.

--- a/packages/prisma/src/index.ts
+++ b/packages/prisma/src/index.ts
@@ -8,11 +8,27 @@
 // type. Qualification happens once, inside the extension (Thesis #3): no raw
 // Promise ever crosses into a combinator.
 //
+// `E` carries ONLY domain outcomes — things a caller did, or a legitimate state
+// conflict, that your code branches on:
+//
+//   UniqueConstraintViolation  P2002  → 409
+//   ForeignKeyViolation        P2003  → 400
+//   RecordNotFound             P2025/P2018 → 404
+//
+// Everything infrastructural — a dropped connection, a pool timeout, a deadlock,
+// an unmapped P-code, a malformed query, an engine panic — is a DEFECT. Nobody
+// branches on those in domain code; they are logged and turned into a 500 by the
+// one `defect` arm you already write at the edge. Modelling them would have every
+// call site carry an arm that does exactly what the `defect` arm beside it does.
+//
 //   const db = new PrismaClient({ adapter }).$extends(unthrownPrisma);
 //
 //   await db.user.tryCreate({ data }).match({ ok, errCases, defect });
 //   // errCases matches UniqueConstraintViolation | ForeignKeyViolation
-//   //                | RecordNotFound | DriverError
+//   //                | RecordNotFound  — and nothing else
+//
+// So a read has NO modeled failure: `tryFindMany` is `AsyncResult<User[], never>`
+// (absence is `null`, not an error).
 //
 // The raw promise methods stay available on purpose: they are the escape hatch
 // for batch `$transaction([...])`, which needs unexecuted `PrismaPromise`s.
@@ -23,6 +39,7 @@ import { type AsyncResult, fromPromise, isResult, type Result, TaggedError } fro
 import {
   type CursorPaginationMeta,
   type CursorPaginationOptions,
+  CursorParseFailure,
   type PaginationDelegate,
   paginateWithCursor,
 } from "./pagination.js";
@@ -59,31 +76,31 @@ export class ForeignKeyViolation extends TaggedError("ForeignKeyViolation")<{ ca
 export class RecordNotFound extends TaggedError("RecordNotFound")<{ cause: unknown }> {}
 
 /**
- * A genuine query failure: connection drops, timeouts, unmapped P-codes,
- * driver-level errors.
+ * The cursor handed to `withCursor` could not be used — the caller's
+ * `parseCursor` rejected it, or the query it produced was one Prisma refuses.
  *
  * @remarks
- * This is the "the database refused the query" bucket — an anticipated outcome
- * of talking to a database over a network. It is deliberately NOT the
- * everything-else bucket: a malformed query, a client that cannot start, and an
- * engine panic are bugs rather than outcomes, so they take the **defect**
- * channel instead (see {@link qualifyPrismaError}).
+ * The one anticipated failure of pagination, and the reason it is modeled at
+ * all: a cursor is an **opaque string from the outside world** (a query
+ * parameter), so a client sending garbage is input you answer with a 400 — not
+ * a bug in your code. Every other pagination failure is a defect, like any other
+ * query.
  */
-export class DriverError extends TaggedError("DriverError")<{ cause: unknown }> {}
+export class InvalidCursor extends TaggedError("InvalidCursor")<{ cause: unknown }> {}
 
 /**
- * The full union of tagged errors a Prisma query can surface.
+ * The full union of domain errors a Prisma **query** can surface.
  *
  * @remarks
  * This is the RUNTIME-side union: {@link qualifyPrismaError} maps into it. Each
- * `try*` method narrows the static type to the codes its operation can
- * actually hit (a read is typed `DriverError` only).
+ * `try*` method narrows the static type to the codes its operation can actually
+ * hit — a read hits none of them, so it is typed `never`.
+ *
+ * Infrastructure failures are deliberately absent: they are defects, not values
+ * (see {@link qualifyPrismaError}). {@link InvalidCursor} is absent too — it
+ * belongs to pagination, not to a query.
  */
-export type PrismaQueryError =
-  | UniqueConstraintViolation
-  | ForeignKeyViolation
-  | RecordNotFound
-  | DriverError;
+export type PrismaQueryError = UniqueConstraintViolation | ForeignKeyViolation | RecordNotFound;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
@@ -100,25 +117,7 @@ const isKnownRequestError = (cause: unknown): cause is KnownRequestError =>
   cause.name === "PrismaClientKnownRequestError" &&
   typeof (cause as { code?: unknown }).code === "string";
 
-// Prisma's non-query error classes — recognized by `name` for the same reason
-// as above. None of these is an anticipated outcome of running a query:
-//
-//   PrismaClientValidationError    — the query itself is malformed (a bug: the
-//                                    `try*` surface types its args with
-//                                    `Prisma.Exact`, so reaching this means the
-//                                    types were cast away)
-//   PrismaClientInitializationError — the client could not start (bad datasource
-//                                    URL, engine/version mismatch)
-//   PrismaClientRustPanicError     — the query engine panicked
-//
-// `PrismaClientUnknownRequestError` is deliberately absent: the query really did
-// fail in the database, just without a P-code to name it. That is a DriverError.
-const DEFECT_ERROR_NAMES: ReadonlySet<string> = new Set([
-  "PrismaClientValidationError",
-  "PrismaClientInitializationError",
-  "PrismaClientRustPanicError",
-]);
-
+// Recognized by `name` for the same reason as above.
 const isValidationError = (cause: unknown): boolean =>
   cause instanceof Error && cause.name === "PrismaClientValidationError";
 
@@ -145,17 +144,19 @@ const constraintFields = (meta: unknown): readonly string[] => {
  * `$transaction([...])`).
  *
  * @remarks
- * Recognized P-codes map to their dedicated errors (`P2002` →
- * {@link UniqueConstraintViolation}, `P2003` → {@link ForeignKeyViolation},
- * `P2025` / `P2018` → {@link RecordNotFound}); other query failures fold into
- * {@link DriverError} with the cause preserved.
+ * The three P-codes that describe a **domain** outcome map to their tagged
+ * errors — `P2002` → {@link UniqueConstraintViolation}, `P2003` →
+ * {@link ForeignKeyViolation}, `P2025` / `P2018` → {@link RecordNotFound}.
  *
- * Prisma's **non-query** errors — a malformed query
- * (`PrismaClientValidationError`), a client that could not start
- * (`PrismaClientInitializationError`), an engine panic
- * (`PrismaClientRustPanicError`) — are routed to the **defect** channel instead
- * of `E`: they are bugs and environment faults, not anticipated outcomes of a
- * query, and unthrown's first rule is that `E` lists only modeled failures.
+ * **Everything else is a defect**, with the original cause preserved: a dropped
+ * connection, a pool timeout, a deadlock, an unmapped P-code, a malformed query,
+ * a client that could not start, an engine panic. None of those is something
+ * domain code branches on — they are logged and turned into a 500 at the edge,
+ * which is precisely what the defect channel is for. Modelling them would force
+ * every call site to carry an arm that duplicates its own `defect` arm.
+ *
+ * A defect is not a crash: it flows through the pipeline untouched and is folded
+ * by `match`'s `defect` handler like any other unmodeled failure.
  *
  * @param cause - the rejected value from a Prisma query.
  * @param defect - the defect helper the boundary injects (never import it).
@@ -170,7 +171,6 @@ export const qualifyPrismaError = <D>(
   cause: unknown,
   defect: (cause: unknown) => D,
 ): PrismaQueryError | D => {
-  if (cause instanceof Error && DEFECT_ERROR_NAMES.has(cause.name)) return defect(cause);
   if (isKnownRequestError(cause)) {
     switch (cause.code) {
       case "P2002":
@@ -187,26 +187,29 @@ export const qualifyPrismaError = <D>(
         break;
     }
   }
-  return new DriverError({ cause });
+  return defect(cause);
 };
 
-// Per-operation error unions — the static half. Reads can only fail in the
-// driver; writes add the constraint violations their SQL can raise; `*OrThrow`
-// and mutations of a specific record add RecordNotFound for their missing row.
+// Per-operation error unions — the static half, and only DOMAIN outcomes (every
+// infrastructure failure is a defect, so it appears in none of these).
+//
+// A read therefore has NO modeled failure at all: absence is `null`, and a
+// database that will not answer is a defect. Writes carry the constraint
+// violations their SQL can raise; `*OrThrow` and mutations of a specific record
+// add RecordNotFound for their missing row.
 //
 // RecordNotFound also reaches `create` and `upsert`, which have no row of their
 // own to miss: a nested `connect` to a record that does not exist raises P2025
 // (to-one) or P2018 (to-many). The BATCH mutations are the ones genuinely free
 // of it — `createMany` / `updateMany` and their `*AndReturn` twins accept no
 // nested writes, and zero matches is `Ok({ count: 0 })`, never an error.
-type ReadError = DriverError;
-type CreateError = UniqueConstraintViolation | ForeignKeyViolation | RecordNotFound | DriverError;
-type CreateManyError = UniqueConstraintViolation | ForeignKeyViolation | DriverError;
-type UpdateError = RecordNotFound | UniqueConstraintViolation | ForeignKeyViolation | DriverError;
-type DeleteError = RecordNotFound | ForeignKeyViolation | DriverError;
-type UpsertError = UniqueConstraintViolation | ForeignKeyViolation | RecordNotFound | DriverError;
-type UpdateManyError = UniqueConstraintViolation | ForeignKeyViolation | DriverError;
-type DeleteManyError = ForeignKeyViolation | DriverError;
+type CreateError = UniqueConstraintViolation | ForeignKeyViolation | RecordNotFound;
+type CreateManyError = UniqueConstraintViolation | ForeignKeyViolation;
+type UpdateError = RecordNotFound | UniqueConstraintViolation | ForeignKeyViolation;
+type DeleteError = RecordNotFound | ForeignKeyViolation;
+type UpsertError = UniqueConstraintViolation | ForeignKeyViolation | RecordNotFound;
+type UpdateManyError = UniqueConstraintViolation | ForeignKeyViolation;
+type DeleteManyError = ForeignKeyViolation;
 
 // The untyped runtime call under the typed surface: `getExtensionContext`
 // resolves the concrete delegate and the promise is qualified at the boundary,
@@ -224,17 +227,28 @@ const query = (self: unknown, op: string, args?: unknown): AsyncResult<unknown, 
     qualifyPrismaError,
   );
 
-// Pagination's own triage. A cursor is an OPAQUE STRING from the outside world
-// (a query parameter), turned into a `where` input by caller-supplied
-// `parseCursor` — so a query Prisma refuses to validate is an anticipated
-// bad-input outcome here, not the programmer bug it is on the `Prisma.Exact`-typed
-// `try*` surface. It stays a modeled DriverError; every other cause is triaged
-// exactly as elsewhere.
+// Pagination's own triage — the one place a Prisma VALIDATION error is a value
+// rather than a defect. A cursor is an OPAQUE STRING from the outside world (a
+// query parameter), turned into a `where` input by caller-supplied
+// `parseCursor`, so:
+//
+//   - `parseCursor` itself rejecting the string (flagged by the CursorParseFailure
+//     sentinel — a throw out of `getCursor`, which reads rows WE fetched, is a bug
+//     and is deliberately not flagged), and
+//   - a query Prisma refuses to validate, which for a cursor-driven `findMany` is
+//     overwhelmingly the cursor rather than the `Prisma.Exact`-typed query args
+//
+// are both anticipated bad input: an InvalidCursor you answer with a 400. Every
+// other cause is triaged exactly as it is everywhere else — a defect.
 const qualifyPaginationError = <D>(
   cause: unknown,
   defect: (cause: unknown) => D,
-): PrismaQueryError | D =>
-  isValidationError(cause) ? new DriverError({ cause }) : qualifyPrismaError(cause, defect);
+): InvalidCursor | D =>
+  cause instanceof CursorParseFailure
+    ? new InvalidCursor({ cause: cause.cause })
+    : isValidationError(cause)
+      ? new InvalidCursor({ cause })
+      : defect(cause);
 
 // The rollback sentinel: an `Err` (or defect) inside `$tryTransaction`'s
 // callback is thrown so Prisma aborts the transaction, then unwrapped back out
@@ -256,7 +270,7 @@ class Rollback extends Error {
  * is narrower (it lists only what YOUR database supports), but a shareable
  * extension cannot name a generated type — this union at least rejects typos
  * at compile time; a level your database does not support still fails at
- * runtime as a {@link DriverError}.
+ * runtime as a defect (an unsupported level is a bug, not an outcome).
  */
 export type TransactionIsolationLevel =
   | "ReadUncommitted"
@@ -274,12 +288,13 @@ export type TransactionIsolationLevel =
  */
 export type CursorPaginator<Results extends readonly unknown[], Cursor> = {
   /**
-   * Run the paginated query: the page and its metadata, or a
-   * {@link DriverError}.
+   * Run the paginated query: the page and its metadata, or an
+   * {@link InvalidCursor} — the only modeled failure, since the cursor is the
+   * only part of the query that came from outside.
    */
   readonly withCursor: (
     options: CursorPaginationOptions<Results[number], Cursor>,
-  ) => AsyncResult<[Results, CursorPaginationMeta], DriverError>;
+  ) => AsyncResult<[Results, CursorPaginationMeta], InvalidCursor>;
 };
 
 // Mirrors Prisma's `ITXClientDenyList` — what an interactive-transaction client
@@ -311,32 +326,29 @@ type TxDenyList =
  * const db = new PrismaClient({ adapter }).$extends(unthrownPrisma);
  *
  * const users = db.user.tryFindMany({ select: { id: true } });
- * //    ^? AsyncResult<{ id: number }[], DriverError>
+ * //    ^? AsyncResult<{ id: number }[], never>  — a read has no modeled failure
  * ```
  */
 export const unthrownPrisma = Prisma.defineExtension({
   name: "@unthrown/prisma",
   model: {
     $allModels: {
-      /** `findMany`, qualified: the list, or a {@link DriverError}. */
+      /** `findMany`, qualified: the list. A read has no modeled failure. */
       tryFindMany<T, A = Record<string, never>>(
         this: T,
         args?: Prisma.Exact<A, Prisma.Args<T, "findMany">>,
-      ): AsyncResult<Prisma.Result<T, A, "findMany">, ReadError> {
-        return query(this, "findMany", args) as AsyncResult<
-          Prisma.Result<T, A, "findMany">,
-          ReadError
-        >;
+      ): AsyncResult<Prisma.Result<T, A, "findMany">, never> {
+        return query(this, "findMany", args) as AsyncResult<Prisma.Result<T, A, "findMany">, never>;
       },
 
-      /** `findUnique`, qualified: the row or `null`, or a {@link DriverError}. */
+      /** `findUnique`, qualified: the row or `null` — absence is not an error. */
       tryFindUnique<T, A>(
         this: T,
         args: Prisma.Exact<A, Prisma.Args<T, "findUnique">>,
-      ): AsyncResult<Prisma.Result<T, A, "findUnique">, ReadError> {
+      ): AsyncResult<Prisma.Result<T, A, "findUnique">, never> {
         return query(this, "findUnique", args) as AsyncResult<
           Prisma.Result<T, A, "findUnique">,
-          ReadError
+          never
         >;
       },
 
@@ -347,21 +359,21 @@ export const unthrownPrisma = Prisma.defineExtension({
       tryFindUniqueOrThrow<T, A>(
         this: T,
         args: Prisma.Exact<A, Prisma.Args<T, "findUniqueOrThrow">>,
-      ): AsyncResult<Prisma.Result<T, A, "findUniqueOrThrow">, RecordNotFound | DriverError> {
+      ): AsyncResult<Prisma.Result<T, A, "findUniqueOrThrow">, RecordNotFound> {
         return query(this, "findUniqueOrThrow", args) as AsyncResult<
           Prisma.Result<T, A, "findUniqueOrThrow">,
-          RecordNotFound | DriverError
+          RecordNotFound
         >;
       },
 
-      /** `findFirst`, qualified: the first match or `null`, or a {@link DriverError}. */
+      /** `findFirst`, qualified: the first match or `null`. */
       tryFindFirst<T, A = Record<string, never>>(
         this: T,
         args?: Prisma.Exact<A, Prisma.Args<T, "findFirst">>,
-      ): AsyncResult<Prisma.Result<T, A, "findFirst">, ReadError> {
+      ): AsyncResult<Prisma.Result<T, A, "findFirst">, never> {
         return query(this, "findFirst", args) as AsyncResult<
           Prisma.Result<T, A, "findFirst">,
-          ReadError
+          never
         >;
       },
 
@@ -372,10 +384,10 @@ export const unthrownPrisma = Prisma.defineExtension({
       tryFindFirstOrThrow<T, A = Record<string, never>>(
         this: T,
         args?: Prisma.Exact<A, Prisma.Args<T, "findFirstOrThrow">>,
-      ): AsyncResult<Prisma.Result<T, A, "findFirstOrThrow">, RecordNotFound | DriverError> {
+      ): AsyncResult<Prisma.Result<T, A, "findFirstOrThrow">, RecordNotFound> {
         return query(this, "findFirstOrThrow", args) as AsyncResult<
           Prisma.Result<T, A, "findFirstOrThrow">,
-          RecordNotFound | DriverError
+          RecordNotFound
         >;
       },
 
@@ -383,18 +395,18 @@ export const unthrownPrisma = Prisma.defineExtension({
       tryCount<T, A = Record<string, never>>(
         this: T,
         args?: Prisma.Exact<A, Prisma.Args<T, "count">>,
-      ): AsyncResult<Prisma.Result<T, A, "count">, ReadError> {
-        return query(this, "count", args) as AsyncResult<Prisma.Result<T, A, "count">, ReadError>;
+      ): AsyncResult<Prisma.Result<T, A, "count">, never> {
+        return query(this, "count", args) as AsyncResult<Prisma.Result<T, A, "count">, never>;
       },
 
       /** `aggregate`, qualified. */
       tryAggregate<T, A>(
         this: T,
         args: Prisma.Exact<A, Prisma.Args<T, "aggregate">>,
-      ): AsyncResult<Prisma.Result<T, A, "aggregate">, ReadError> {
+      ): AsyncResult<Prisma.Result<T, A, "aggregate">, never> {
         return query(this, "aggregate", args) as AsyncResult<
           Prisma.Result<T, A, "aggregate">,
-          ReadError
+          never
         >;
       },
 
@@ -402,11 +414,8 @@ export const unthrownPrisma = Prisma.defineExtension({
       tryGroupBy<T, A>(
         this: T,
         args: Prisma.Exact<A, Prisma.Args<T, "groupBy">>,
-      ): AsyncResult<Prisma.Result<T, A, "groupBy">, ReadError> {
-        return query(this, "groupBy", args) as AsyncResult<
-          Prisma.Result<T, A, "groupBy">,
-          ReadError
-        >;
+      ): AsyncResult<Prisma.Result<T, A, "groupBy">, never> {
+        return query(this, "groupBy", args) as AsyncResult<Prisma.Result<T, A, "groupBy">, never>;
       },
 
       /**
@@ -547,14 +556,14 @@ export const unthrownPrisma = Prisma.defineExtension({
        * pagination owns those. A cursor pointing at a record that no longer
        * matches the query filter is handled correctly (the first element of
        * the page is not skipped). A throwing `parseCursor` — e.g. a malformed
-       * cursor from an API client — surfaces as a {@link DriverError}.
+       * cursor from an API client — surfaces as an {@link InvalidCursor}.
        *
        * @example
        * ```ts
        * const page = await db.user
        *   .tryPaginate({ where: { active: true }, orderBy: { id: "asc" } })
        *   .withCursor({ limit: 20, after: req.query.cursor });
-       * // Ok([users, { hasNextPage, endCursor, ... }]) | Err(DriverError)
+       * // Ok([users, { hasNextPage, endCursor, ... }]) | Err(InvalidCursor)
        * ```
        */
       tryPaginate<T, A>(
@@ -596,9 +605,15 @@ export const unthrownPrisma = Prisma.defineExtension({
      * `AsyncResult<T, E | PrismaQueryError>`. A defect inside the callback also
      * rolls back and stays a defect — including a callback that *throws*
      * instead of returning an `AsyncResult` (a bug, never downgraded to a
-     * modeled `DriverError`). The `try*` methods are available on `tx`
+     * modeled error). The `try*` methods are available on `tx`
      * (extensions propagate into the interactive transaction); the deny list
      * additionally removes `$tryTransaction` itself — no nesting.
+     *
+     * The `| PrismaQueryError` is not merely defensive: a deferred constraint
+     * surfaces its violation at COMMIT rather than at the statement, so the
+     * transaction boundary itself can produce one. Prisma's own machinery
+     * failing any other way (a `maxWait` / `timeout` expiry, a lost connection)
+     * is infrastructure, and so a defect like everywhere else.
      *
      * @example
      * ```ts
@@ -640,7 +655,7 @@ export const unthrownPrisma = Prisma.defineExtension({
               // A callback that resolves to a NON-Result (out of contract —
               // e.g. a raw value from untyped code) is a bug, exactly like a
               // throwing callback: the TypeError is caught below, so it rolls
-              // back as a DEFECT — never downgraded to a modeled DriverError
+              // back as a DEFECT — never downgraded to a modeled error
               // (which is what dispatching `returned.isOk()` outside this
               // try/catch used to do).
               if (!isResult(returned)) {

--- a/packages/prisma/src/pagination.ts
+++ b/packages/prisma/src/pagination.ts
@@ -26,6 +26,9 @@ export type CursorPaginationMeta = {
  * Options of `withCursor`, in the style of `prisma-extension-pagination`.
  *
  * @remarks
+ * `after` and `before` are mutually exclusive — a page runs in one direction,
+ * and passing both used to silently drop `after`. Pick a direction.
+ *
  * `limit: null` returns everything (from the `after` cursor when given).
  * Combining `limit: null` with `before` is a compile error — "everything
  * before the cursor, backwards, unbounded" is not something Prisma's negative
@@ -42,8 +45,6 @@ export type CursorPaginationMeta = {
  * @typeParam Cursor - the model's `cursor` input (its unique-where shape).
  */
 export type CursorPaginationOptions<Row, Cursor> = {
-  /** An opaque cursor: results strictly AFTER this record. */
-  after?: string;
   /** Serialize a row into an opaque cursor. Defaults to `String(row.id)`. */
   getCursor?: (row: Row) => string;
   /** Parse an opaque cursor back into the model's `cursor` input. */
@@ -52,12 +53,24 @@ export type CursorPaginationOptions<Row, Cursor> = {
   | {
       /** Page size. */
       limit: number;
+      /** An opaque cursor: results strictly AFTER this record. */
+      after?: string;
+      /** Cannot be combined with `after` — a page runs in one direction. */
+      before?: never;
+    }
+  | {
+      /** Page size. */
+      limit: number;
       /** An opaque cursor: results strictly BEFORE this record. */
       before?: string;
+      /** Cannot be combined with `before` — a page runs in one direction. */
+      after?: never;
     }
   | {
       /** `null` returns all results. Cannot be combined with `before`. */
       limit: null;
+      /** An opaque cursor: results strictly AFTER this record. */
+      after?: string;
       before?: never;
     }
 );

--- a/packages/prisma/src/pagination.ts
+++ b/packages/prisma/src/pagination.ts
@@ -106,6 +106,26 @@ const defaultParseCursor = (cursor: string): unknown => {
   return { id: Number.isSafeInteger(n) ? n : BigInt(cursor) };
 };
 
+/**
+ * Sentinel marking a throw out of the caller's `parseCursor` on a **request**
+ * cursor — the one pagination failure caused by outside input rather than by
+ * our own code.
+ *
+ * @remarks
+ * It exists so the boundary can tell that case apart from an identical-looking
+ * throw out of `getCursor` (which reads rows the query just returned, so a
+ * failure there is a bug). Only the two request cursors — `after` / `before` —
+ * are wrapped; the round-trip parse inside `sameCursor` is not.
+ */
+export class CursorParseFailure extends Error {
+  constructor(
+    readonly cursor: string,
+    override readonly cause: unknown,
+  ) {
+    super("@unthrown/prisma: the cursor could not be parsed");
+  }
+}
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
 
@@ -157,8 +177,20 @@ export const paginateWithCursor = async (
   const getCursor = (options.getCursor ?? defaultGetCursor) as (row: unknown) => string;
   const parseCursor = options.parseCursor ?? defaultParseCursor;
 
+  // The two cursors that came from OUTSIDE. A throw here is bad input, not a
+  // bug, so it is marked for the boundary to model as an InvalidCursor.
+  const parseRequestCursor = (cursor: string): unknown => {
+    try {
+      return parseCursor(cursor);
+    } catch (cause) {
+      throw new CursorParseFailure(cursor, cause);
+    }
+  };
+
   // Is this row the cursor row? Compared through the cursor round-trip, so it
-  // works for any serialization the caller chose.
+  // works for any serialization the caller chose. Deliberately NOT wrapped: this
+  // parses a cursor we just produced from a row we just fetched, so a throw is a
+  // bug in `getCursor` / `parseCursor`, and stays a defect.
   const sameCursor = (row: unknown, cursor: unknown): boolean =>
     cursorEquals(parseCursor(getCursor(row)), cursor);
 
@@ -167,7 +199,7 @@ export const paginateWithCursor = async (
   let hasNextPage = false;
 
   if (typeof before === "string") {
-    const cursor = parseCursor(before);
+    const cursor = parseRequestCursor(before);
     // Backwards from the cursor, over-fetched by two: one slot for the cursor
     // row itself (present only when it still matches the filter), one to know
     // whether a previous page exists. The forward probe answers hasNextPage —
@@ -187,7 +219,7 @@ export const paginateWithCursor = async (
     }
     hasNextPage = nextProbe.length > 0;
   } else if (typeof after === "string") {
-    const cursor = parseCursor(after);
+    const cursor = parseRequestCursor(after);
     // Forwards from the cursor, over-fetched by two (same slots as above,
     // mirrored). The backward probe answers hasPreviousPage.
     const [rows, previousProbe] = await Promise.all([

--- a/packages/prisma/src/types.test-d.ts
+++ b/packages/prisma/src/types.test-d.ts
@@ -6,17 +6,19 @@
 // nothing is an unused local); `@ts-expect-error` guards the cases that must NOT
 // compile.
 
-import type { AsyncErrOf, AsyncOkOf } from "unthrown";
+import type { AsyncErrOf, AsyncOkOf, AsyncResult } from "unthrown";
+import { fromPromise } from "unthrown";
 
 import type { PrismaClient } from "./generated/prisma/client.ts";
 import type {
   CursorPaginationMeta,
   DriverError,
   ForeignKeyViolation,
+  PrismaQueryError,
   RecordNotFound,
   UniqueConstraintViolation,
 } from "./index.js";
-import { unthrownPrisma } from "./index.js";
+import { qualifyPrismaError, unthrownPrisma } from "./index.js";
 
 type Equal<X, Y> =
   (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
@@ -45,8 +47,10 @@ const createdRows = db.user.tryCreateManyAndReturn({
   data: [{ email: "a@example.com" }],
   select: { id: true },
 });
+const updated = db.user.tryUpdate({ where: { id: 1 }, data: { name: "x" } });
 const updatedMany = db.user.tryUpdateMany({ where: {}, data: { name: "x" } });
 const updatedRows = db.user.tryUpdateManyAndReturn({ data: { name: "x" }, select: { id: true } });
+const deleted = db.user.tryDelete({ where: { id: 1 } });
 const deletedMany = db.user.tryDeleteMany();
 const aggregated = db.user.tryAggregate({ _count: true });
 const grouped = db.user.tryGroupBy({ by: ["name"] });
@@ -56,6 +60,15 @@ selected.map((rows) => rows.map((r) => r.email));
 
 // @ts-expect-error — an unknown arg key is rejected (`Prisma.Exact`).
 db.user.tryFindMany({ bogus: true });
+
+// --- qualifyPrismaError drops straight into a boundary --------------------------
+
+// It IS a `qualify`: the boundary injects `defect`, and the Defect arm of its
+// return is subtracted from E — so the channel is exactly PrismaQueryError, with
+// no `Defect` leaking into it (E is covariant, so a stray `| Defect` would fail
+// this `satisfies`).
+declare const rawQuery: Promise<unknown>;
+fromPromise(rawQuery, qualifyPrismaError) satisfies AsyncResult<unknown, PrismaQueryError>;
 
 // --- the error channel is per-operation ----------------------------------------
 
@@ -73,6 +86,13 @@ db.user.tryPaginate({ take: 1 });
 db.user.tryPaginate({ cursor: { id: 1 } });
 // @ts-expect-error — `limit: null` cannot be combined with `before`.
 db.user.tryPaginate().withCursor({ limit: null, before: "1" });
+// @ts-expect-error — `after` and `before` are mutually exclusive; a page runs one way.
+db.user.tryPaginate().withCursor({ limit: 1, after: "1", before: "9" });
+
+// Each direction on its own is fine, with or without a bound.
+db.user.tryPaginate().withCursor({ limit: 1, after: "1" });
+db.user.tryPaginate().withCursor({ limit: 1, before: "9" });
+db.user.tryPaginate().withCursor({ limit: null, after: "1" });
 
 db.user.tryPaginate({ select: { id: true } }).withCursor({
   limit: 1,
@@ -118,24 +138,53 @@ export type _Assertions = [
   // reads fail only in the driver; writes carry their constraint violations;
   // `*OrThrow` adds P2025
   Expect<Equal<AsyncErrOf<typeof all>, DriverError>>,
+  Expect<Equal<AsyncErrOf<typeof maybe>, DriverError>>,
+  Expect<Equal<AsyncErrOf<typeof counted>, DriverError>>,
+  // `create` carries RecordNotFound too: a nested `connect` to a row that does
+  // not exist raises P2025 even though a create misses no row of its own.
   Expect<
-    Equal<AsyncErrOf<typeof created>, UniqueConstraintViolation | ForeignKeyViolation | DriverError>
+    Equal<
+      AsyncErrOf<typeof created>,
+      UniqueConstraintViolation | ForeignKeyViolation | RecordNotFound | DriverError
+    >
   >,
   Expect<Equal<AsyncErrOf<typeof fetched>, RecordNotFound | DriverError>>,
+  // the specific-row mutations: the missing row, plus what their SQL can raise
+  Expect<
+    Equal<
+      AsyncErrOf<typeof updated>,
+      RecordNotFound | UniqueConstraintViolation | ForeignKeyViolation | DriverError
+    >
+  >,
+  Expect<Equal<AsyncErrOf<typeof deleted>, RecordNotFound | ForeignKeyViolation | DriverError>>,
   // findFirst: selection narrows, a miss is `null`, and only OrThrow adds P2025
   Expect<Equal<AsyncOkOf<typeof first>, { id: number } | null>>,
   Expect<Equal<AsyncErrOf<typeof first>, DriverError>>,
   Expect<Equal<AsyncErrOf<typeof firstOrThrow>, RecordNotFound | DriverError>>,
-  // upsert never carries RecordNotFound — a miss creates
+  // upsert: a missing *target* is never an error (a miss creates), but a nested
+  // `connect` in either branch still raises RecordNotFound
   Expect<
     Equal<
       AsyncErrOf<typeof upserted>,
+      UniqueConstraintViolation | ForeignKeyViolation | RecordNotFound | DriverError
+    >
+  >,
+  // the batch mutations: counts / rows, and genuinely no RecordNotFound — they
+  // accept no nested writes, and zero matches is `Ok({ count: 0 })`
+  Expect<Equal<AsyncOkOf<typeof createdMany>["count"], number>>,
+  Expect<Equal<AsyncOkOf<typeof createdRows>, { id: number }[]>>,
+  Expect<
+    Equal<
+      AsyncErrOf<typeof createdMany>,
       UniqueConstraintViolation | ForeignKeyViolation | DriverError
     >
   >,
-  // the batch mutations: counts / rows, and no P2025 in their unions
-  Expect<Equal<AsyncOkOf<typeof createdMany>["count"], number>>,
-  Expect<Equal<AsyncOkOf<typeof createdRows>, { id: number }[]>>,
+  Expect<
+    Equal<
+      AsyncErrOf<typeof createdRows>,
+      UniqueConstraintViolation | ForeignKeyViolation | DriverError
+    >
+  >,
   Expect<
     Equal<
       AsyncErrOf<typeof updatedMany>,

--- a/packages/prisma/src/types.test-d.ts
+++ b/packages/prisma/src/types.test-d.ts
@@ -12,7 +12,7 @@ import { fromPromise } from "unthrown";
 import type { PrismaClient } from "./generated/prisma/client.ts";
 import type {
   CursorPaginationMeta,
-  DriverError,
+  InvalidCursor,
   ForeignKeyViolation,
   PrismaQueryError,
   RecordNotFound,
@@ -137,77 +137,61 @@ export type _Assertions = [
   Expect<Equal<AsyncOkOf<typeof created>["email"], string>>,
   // reads fail only in the driver; writes carry their constraint violations;
   // `*OrThrow` adds P2025
-  Expect<Equal<AsyncErrOf<typeof all>, DriverError>>,
-  Expect<Equal<AsyncErrOf<typeof maybe>, DriverError>>,
-  Expect<Equal<AsyncErrOf<typeof counted>, DriverError>>,
+  // a read has NO modeled failure: absence is `null`, and a database that will
+  // not answer is a defect
+  Expect<Equal<AsyncErrOf<typeof all>, never>>,
+  Expect<Equal<AsyncErrOf<typeof maybe>, never>>,
+  Expect<Equal<AsyncErrOf<typeof counted>, never>>,
   // `create` carries RecordNotFound too: a nested `connect` to a row that does
   // not exist raises P2025 even though a create misses no row of its own.
   Expect<
     Equal<
       AsyncErrOf<typeof created>,
-      UniqueConstraintViolation | ForeignKeyViolation | RecordNotFound | DriverError
+      UniqueConstraintViolation | ForeignKeyViolation | RecordNotFound
     >
   >,
-  Expect<Equal<AsyncErrOf<typeof fetched>, RecordNotFound | DriverError>>,
+  Expect<Equal<AsyncErrOf<typeof fetched>, RecordNotFound>>,
   // the specific-row mutations: the missing row, plus what their SQL can raise
   Expect<
     Equal<
       AsyncErrOf<typeof updated>,
-      RecordNotFound | UniqueConstraintViolation | ForeignKeyViolation | DriverError
+      RecordNotFound | UniqueConstraintViolation | ForeignKeyViolation
     >
   >,
-  Expect<Equal<AsyncErrOf<typeof deleted>, RecordNotFound | ForeignKeyViolation | DriverError>>,
+  Expect<Equal<AsyncErrOf<typeof deleted>, RecordNotFound | ForeignKeyViolation>>,
   // findFirst: selection narrows, a miss is `null`, and only OrThrow adds P2025
   Expect<Equal<AsyncOkOf<typeof first>, { id: number } | null>>,
-  Expect<Equal<AsyncErrOf<typeof first>, DriverError>>,
-  Expect<Equal<AsyncErrOf<typeof firstOrThrow>, RecordNotFound | DriverError>>,
+  Expect<Equal<AsyncErrOf<typeof first>, never>>,
+  Expect<Equal<AsyncErrOf<typeof firstOrThrow>, RecordNotFound>>,
   // upsert: a missing *target* is never an error (a miss creates), but a nested
   // `connect` in either branch still raises RecordNotFound
   Expect<
     Equal<
       AsyncErrOf<typeof upserted>,
-      UniqueConstraintViolation | ForeignKeyViolation | RecordNotFound | DriverError
+      UniqueConstraintViolation | ForeignKeyViolation | RecordNotFound
     >
   >,
   // the batch mutations: counts / rows, and genuinely no RecordNotFound — they
   // accept no nested writes, and zero matches is `Ok({ count: 0 })`
   Expect<Equal<AsyncOkOf<typeof createdMany>["count"], number>>,
   Expect<Equal<AsyncOkOf<typeof createdRows>, { id: number }[]>>,
-  Expect<
-    Equal<
-      AsyncErrOf<typeof createdMany>,
-      UniqueConstraintViolation | ForeignKeyViolation | DriverError
-    >
-  >,
-  Expect<
-    Equal<
-      AsyncErrOf<typeof createdRows>,
-      UniqueConstraintViolation | ForeignKeyViolation | DriverError
-    >
-  >,
-  Expect<
-    Equal<
-      AsyncErrOf<typeof updatedMany>,
-      UniqueConstraintViolation | ForeignKeyViolation | DriverError
-    >
-  >,
+  Expect<Equal<AsyncErrOf<typeof createdMany>, UniqueConstraintViolation | ForeignKeyViolation>>,
+  Expect<Equal<AsyncErrOf<typeof createdRows>, UniqueConstraintViolation | ForeignKeyViolation>>,
+  Expect<Equal<AsyncErrOf<typeof updatedMany>, UniqueConstraintViolation | ForeignKeyViolation>>,
   Expect<Equal<AsyncOkOf<typeof updatedRows>, { id: number }[]>>,
-  Expect<Equal<AsyncErrOf<typeof deletedMany>, ForeignKeyViolation | DriverError>>,
-  // the aggregations are reads: DriverError only
-  Expect<Equal<AsyncErrOf<typeof aggregated>, DriverError>>,
-  Expect<Equal<AsyncErrOf<typeof grouped>, DriverError>>,
+  Expect<Equal<AsyncErrOf<typeof deletedMany>, ForeignKeyViolation>>,
+  // the aggregations are reads too
+  Expect<Equal<AsyncErrOf<typeof aggregated>, never>>,
+  Expect<Equal<AsyncErrOf<typeof grouped>, never>>,
   Expect<Equal<AsyncOkOf<typeof aggregated>["_count"], number>>,
   // pagination: the payload is the narrowed page + meta; the error is read-only
   Expect<Equal<AsyncOkOf<typeof paged>[0][number]["email"], string>>,
   Expect<Equal<AsyncOkOf<typeof paged>[1], CursorPaginationMeta>>,
-  Expect<Equal<AsyncErrOf<typeof paged>, DriverError>>,
+  Expect<Equal<AsyncErrOf<typeof paged>, InvalidCursor>>,
   Expect<Equal<AsyncOkOf<typeof pagedSelect>[0], { id: number }[]>>,
   // the transaction unions the callback's errors with the transaction's own
   Expect<
-    Equal<
-      AsyncErrOf<typeof tx>,
-      UniqueConstraintViolation | ForeignKeyViolation | RecordNotFound | DriverError
-    >
+    Equal<AsyncErrOf<typeof tx>, UniqueConstraintViolation | ForeignKeyViolation | RecordNotFound>
   >,
   Expect<Equal<AsyncOkOf<typeof tx>["email"], string>>,
 ];

--- a/packages/prisma/typedoc.json
+++ b/packages/prisma/typedoc.json
@@ -9,7 +9,6 @@
     "DeleteError",
     "UpsertError",
     "UpdateManyError",
-    "DeleteManyError",
     "TxDenyList"
   ]
 }

--- a/packages/prisma/typedoc.json
+++ b/packages/prisma/typedoc.json
@@ -4,6 +4,7 @@
   "out": "docs",
   "intentionallyNotExported": [
     "CreateError",
+    "CreateManyError",
     "UpdateError",
     "DeleteError",
     "UpsertError",


### PR DESCRIPTION
Found while auditing `packages/prisma`. Started as one soundness bug, grew into
the design question underneath it.

## `E` was carrying things nobody branches on

`DriverError` sat in every operation's error channel, so every call site had to
carry an arm that did exactly what the `defect` arm beside it did:

```ts
errCases: (matcher) => matcher
  .with(P.tag("UniqueConstraintViolation"), (e) => resp.conflict(e.fields))
  .with(P.tag("DriverError"), (e) => resp.serverError(e)),   // ← this
defect: (cause) => resp.serverError(cause),                   // ← and this
```

That is ceremony, not modelling. A defect isn't a crash — it flows through the
pipeline untouched and is folded at the edge like any other unmodeled failure —
so the test for `E` is simply *would you branch on it?* You genuinely handle a
duplicate email or a missing parent row. You do not write domain logic for a
severed TCP connection.

So `E` now holds the three P-codes that describe a domain outcome —
`UniqueConstraintViolation` (P2002, 409), `ForeignKeyViolation` (P2003, 400),
`RecordNotFound` (P2025/P2018, 404) — and every infrastructure failure is a
defect: dropped connections, pool timeouts, deadlocks, unmapped P-codes,
malformed queries, engine panics.

| | before | after |
|---|---|---|
| `tryFindMany` / `tryFindUnique` / `tryCount` / … | `DriverError` | `never` |
| `tryFindUniqueOrThrow` / `tryFindFirstOrThrow` | `RecordNotFound \| DriverError` | `RecordNotFound` |
| `tryCreate` / `tryUpsert` / `tryUpdate` | varied, see below | `UniqueConstraintViolation \| ForeignKeyViolation \| RecordNotFound` |
| `tryDelete` | `RecordNotFound \| ForeignKeyViolation \| DriverError` | `ForeignKeyViolation \| RecordNotFound` |
| `tryCreateMany` / `tryUpdateMany` / `*AndReturn` | `… \| DriverError` | `UniqueConstraintViolation \| ForeignKeyViolation` |
| `tryDeleteMany` | `ForeignKeyViolation \| DriverError` | `ForeignKeyViolation` |
| `tryPaginate(...).withCursor(...)` | `DriverError` | `InvalidCursor` |

Consequences:

- **The `DriverError` class is removed.** Nothing routes to it any more, and an
  exported error that can never appear in an `E` would only invite confusion.
  The original Prisma error now reaches your `defect` arm unwrapped, with its
  `code`, `meta` and stack intact — strictly more informative than the wrapper.
- **A read has no modeled failure.** Absence is still `null`.
- **Pagination gains `InvalidCursor`**, the one carve-out. A cursor is an opaque
  string from a client, so a `parseCursor` that rejects it — or a query Prisma
  refuses to validate — is anticipated input you answer with a 400. A throw out
  of `getCursor`, which reads rows *we* just fetched, is a bug and stays a
  defect; a `CursorParseFailure` sentinel is what tells the two apart. This is
  an improvement on the status quo, where the same failure hid inside
  `DriverError` with no name of its own.
- **Retrying P2024 / P2034** now goes through `recoverDefect` and inspects the
  cause, rather than matching a tag. That is one place in a codebase, versus an
  arm at every call site.
- **`$tryTransaction` keeps `| PrismaQueryError`** — not defensively: a deferred
  constraint surfaces its violation at COMMIT, so the boundary itself can
  genuinely produce one.

## The soundness bug that started it

A nested `connect` to a missing record raises **P2025**, but `CreateError` and
`UpsertError` excluded `RecordNotFound` — neither operation misses a row of its
own, so it looked impossible. Confirmed against the package's own SQLite client:

```
db.post.tryCreate({ data: { title: "x", author: { connect: { id: 999 } } } })
  → Err(RecordNotFound)   // cause.code === "P2025", meta.operation === "a nested connect"
```

The runtime therefore produced an error the type said could not occur. A
type-exhaustive `mapErrCases` had no arm for the value that arrived, the matcher
threw `NonExhaustiveError`, and the throw-to-defect net turned a modeled database
failure into a `Defect`:

```
RESULT TAG: Defect
CAUSE: NonExhaustiveError: unthrown: no pattern matched the value {"_tag":"RecordNotFound",…}
```

`upsert` hits the same thing in **both** branches. Both unions now carry
`RecordNotFound`; the batch mutations accept no nested writes, so they stay free
of it. **P2018** — the same failure from the to-many side — maps to
`RecordNotFound` too, instead of falling through.

## Also

- **`after` and `before` are now mutually exclusive.** Passing both type-checked
  and silently dropped `after`.
- `tryPaginate` runs `getExtensionContext` and the query inside its boundary
  thunk, matching the discipline `query()` already had.
- Type-test gaps closed (`tryUpdate`, `tryDelete`, `tryFindUnique`, `tryCount`,
  the createMany pair), plus a `satisfies` proving
  `fromPromise(p, qualifyPrismaError)` infers `E = PrismaQueryError` with no
  `Defect` leak — verified to actually bite by deliberately breaking it.
- README and Prisma guide rewritten around the new rule; `#36 (#35)` comment
  drift unified; `CLAUDE.md` and `typedoc.json` synced.

## Breaking, shipped as a minor

`qualifyPrismaError` takes the injected `defect` helper as a second argument (it
is a `qualify`, so passing it to a boundary is unchanged — only direct
invocation needs updating), the `DriverError` class is gone, and every error
union changed. Each is a compile error at the call site rather than a silent
behaviour change.

## Verification

`format --check`, `lint`, `typecheck`, `knip`, `test`, `build` and `build:docs`
all green. Coverage stays at 100% statements/branches/functions/lines; the suite
grows from 49 to 62 tests.

One thing deliberately **not** done: the `prisma` catalog pins look one patch
behind (7.8.0 vs 7.9.1), but `pnpm install` refuses the bump — the repo's
`minimumReleaseAge` policy holds 7.9.1 until it matures. They are held on
purpose, not stale.
