### PR TITLE
fix(core): defect an async fn at the sync boundaries, and two diagnostics

### DIFF
--- a/.changeset/tall-spoons-listen.md
+++ b/.changeset/tall-spoons-listen.md
@@ -1,0 +1,63 @@
+---
+"unthrown": minor
+"@unthrown/vitest": minor
+---
+
+Close a boundary hole where an `async` function's rejection escaped
+qualification, stop `toBeErrTagged` counting a message as payload, and name the
+value in `NonExhaustiveError`.
+
+**`fromThrowable` / `fromSafeThrowable` now reject an `async` `fn`.** These wrap a
+**synchronous** function, so they only ever see a synchronous `throw`: an async
+`fn` rejects long after the boundary has returned, and its rejection could never
+reach `qualify`. It used to produce `Ok(<Promise>)` — un-triaged — and the
+rejection then floated as an unhandled rejection, which terminates the process on
+Node by default:
+
+```ts
+const f = fromThrowable(
+  async () => {
+    throw new Error("boom");
+  },
+  (cause, defect) => defect(cause),
+);
+f(); // before: Ok(<Promise>) + an unhandled rejection
+// now:    Defect(TypeError: … `fn` returned a thenable …)
+```
+
+The orphaned rejection is adopted and silenced, so it cannot float. Reach for
+`fromPromise` / `fromSafePromise` for async work.
+
+This is caught at runtime rather than by the type system — the one thenable ban
+in the library that is not a compile error. Putting `NotThenable` on `fn`'s return
+also makes **generic** functions unassignable, so `fromSafeThrowable(structuredClone)`
+would stop compiling with `T` collapsed to `unknown`; the phantom rest-tuple guard
+`fromPromise` uses fares worse. The success type is therefore slightly over-stated
+(`Result<Promise<T>, E>` is spellable but never inhabited) — the mirror of
+`recoverErrCases`'s `never` under-stating the error channel.
+
+**`toBeErrTagged`'s exact-payload form now ignores every reserved key.** The
+documented way to set a `TaggedError`'s message is a subclass field —
+`override message = "…"` — which lands as an own **enumerable** property, so it
+leaked into the payload and failed an exact assertion on the very pattern the
+library prescribes:
+
+```ts
+class HttpError extends TaggedError("HttpError")<{ status: number }> {
+  override message = `http ${this.status}`;
+}
+expect(Err(new HttpError({ status: 500 }))).toBeErrTagged("HttpError", { status: 500 });
+// before: failed — the payload was seen as { status: 500, message: "http 500" }
+// now:    passes
+```
+
+The matcher now skips `_tag`, `name`, `message` and `stack` — exactly the keys
+`TaggedErrorInstance` omits and the constructor types `?: never`, so none of them
+can legitimately be payload. Assertions using `expect.objectContaining` are
+unaffected (they were already tolerant of the extra key).
+
+**`NonExhaustiveError` now names the value it could not match.** `JSON.stringify`
+_returns_ `undefined` — it does not throw — for a function, a symbol, or
+`undefined`, so the `String(input)` fallback never fired and the message read
+"no pattern matched the value undefined" for exactly the rogue inputs this error
+exists to describe. It now falls back correctly (`… the value function rogueFn() {}`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,21 @@ was planned).
   runtime belt-and-braces: a thenable slipped past the types becomes a
   `Defect` and its orphaned rejection is silenced (see Thesis #3). `match`
   handlers are deliberately exempt (edge elimination).
+- **A sync boundary's `fn` is sync too — enforced at RUNTIME, not by the
+  types.** `fromThrowable` / `fromSafeThrowable` wrap a synchronous function, so
+  they only ever see a synchronous `throw`: an `async` `fn` rejects long after
+  the boundary has returned, and its rejection can never reach `qualify`. Left
+  alone that produced `Ok(<Promise>)` — un-triaged — whose rejection then floated
+  as an unhandled rejection (process-fatal on Node by default). Both helpers now
+  probe the return value and mint a **`Defect`** for a thenable, adopting and
+  silencing the orphan — the sibling of `qualifyToResult`'s thenable-`qualify`
+  net. Deliberately **not** a compile error, unlike every other thenable ban:
+  `T & NotThenable<T>` on `fn`'s return makes a _generic_ function unassignable,
+  so `fromSafeThrowable(structuredClone)` would stop compiling with `T` collapsed
+  to `unknown` (the `fromPromise` phantom rest-tuple guard fares worse still).
+  The type therefore over-states the success channel — `Result<Promise<T>, E>` is
+  spellable but never inhabited — the mirror of `recoverErrCases`'s `never`
+  under-stating the error channel. Guarded in `interop.spec.ts`.
 - **Result instances are frozen — and so is the machinery around them.**
   `okRes`/`errRes`/`defectRes` return `Object.freeze`d objects, so a variant
   cannot be forged by mutation; the `readonly` types are real at runtime.
@@ -885,7 +900,12 @@ channel?**
    `toBeErr`, `toBeErrWith` (the error-value mirror of `toBeOkWith` — a deep
    compare of the `Err` value), `toBeErrTagged` (optional second arg also matches
    the tagged error's payload — exact for a plain object, partial for an
-   asymmetric matcher like `expect.objectContaining`), `toBeDefect`, registered
+   asymmetric matcher like `expect.objectContaining`; "payload" excludes
+   **every** key `TaggedError` reserves — `_tag`/`name`/`message`/`stack`, the
+   same list `TaggedErrorInstance` omits — because a subclass's documented
+   `override message = "…"` lands as an own **enumerable** property and would
+   otherwise leak into the exact form, breaking the very pattern Thesis #4
+   prescribes), `toBeDefect`, registered
    via `expect.extend`
    and augmenting Vitest's `Matchers` interface. They detect a thenable
    `AsyncResult` and await internally, so a test reads

--- a/docs/explanation/qualification.md
+++ b/docs/explanation/qualification.md
@@ -83,6 +83,27 @@ otherwise write out — an on-the-record "I decided this is all defects", not a
 convenience that quietly drops the triage. Keep `fromThrowable` / `fromPromise`
 wherever some failures are genuinely anticipated.
 
+## Sync boundaries are sync on both sides
+
+`fromThrowable` / `fromSafeThrowable` wrap a **synchronous** function, and that
+applies to `fn` as much as to `qualify`. A synchronous boundary only ever sees a
+synchronous `throw`, so an `async` `fn` rejects long after the boundary has
+returned — its rejection could never reach `qualify`. Rather than hand back an
+`Ok` wrapping a live promise whose rejection escapes triage (and then floats as an
+unhandled rejection), the boundary produces a **defect**:
+
+```ts
+const bad = fromSafeThrowable(async () => fetchUser(id));
+bad(); // => Defect(TypeError: … `fn` returned a thenable …)
+
+const good = fromSafePromise(() => fetchUser(id)); // AsyncResult<User, never>
+```
+
+Reach for `fromPromise` / `fromSafePromise` for async work. (This one is caught at
+runtime rather than by the type system: banning a thenable return at compile time
+would also reject generic functions, so `fromSafeThrowable(structuredClone)` would
+stop compiling.)
+
 ## The payoff
 
 Because every boundary is qualified and every in-pipeline throw becomes a defect,

--- a/docs/how-to/test-with-vitest.md
+++ b/docs/how-to/test-with-vitest.md
@@ -51,8 +51,9 @@ test("matchers", () => {
 ## Assert on a tagged error's payload
 
 `toBeErrTagged` takes an optional second argument to also assert the tagged error's
-payload — its own fields, minus the `_tag` and `name` that `TaggedError` sets. A
-plain object matches it **exactly**; an asymmetric matcher matches it **partially**:
+payload — its own fields, minus the keys `TaggedError` reserves (`_tag`, `name`,
+`message`, `stack`). A plain object matches it **exactly**; an asymmetric matcher
+matches it **partially**:
 
 ```ts
 import { Err, TaggedError } from "unthrown";
@@ -68,6 +69,19 @@ expect(Err(new NotFound({ id: 1, msg: "nope" }))).toBeErrTagged(
   "NotFound",
   expect.objectContaining({ id: 1 }),
 );
+```
+
+The reserved keys are skipped so the exact form keeps working with the standard way
+of setting a message — `override message = "…"` lands as an own property on the
+instance, but it is `Error`'s human string, not payload:
+
+```ts
+class HttpError extends TaggedError("HttpError")<{ status: number }> {
+  override message = `http ${this.status}`;
+}
+
+// the payload is `{ status }` — the message is not part of it
+expect(Err(new HttpError({ status: 500 }))).toBeErrTagged("HttpError", { status: 500 });
 ```
 
 ## Async results — `await` is required

--- a/packages/core/src/interop.spec.ts
+++ b/packages/core/src/interop.spec.ts
@@ -236,3 +236,87 @@ describe("qualify must be synchronous (runtime belt-and-braces)", () => {
     }
   });
 });
+
+describe("the SYNC boundaries reject an async fn", () => {
+  // A synchronous boundary only ever sees a synchronous `throw`, so an async
+  // `fn` rejects long after it has returned: the rejection can never reach
+  // `qualify`. Left alone it sat inside `Ok(<Promise>)` — un-triaged — and then
+  // floated as an unhandled rejection, which terminates the process on Node by
+  // default. This cannot be banned at compile time without breaking generic
+  // functions (`fromSafeThrowable(structuredClone)`), so it is caught here.
+  const withRejectionProbe = async (body: () => void): Promise<unknown[]> => {
+    const floated: unknown[] = [];
+    const probe = (reason: unknown): void => {
+      floated.push(reason);
+    };
+    process.on("unhandledRejection", probe);
+    try {
+      body();
+      // Two macrotasks: let the orphan settle, then let Node's
+      // unhandled-rejection detection run.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      return floated;
+    } finally {
+      process.off("unhandledRejection", probe);
+    }
+  };
+
+  it("fromThrowable: an async fn is a Defect, never Ok(Promise)", async () => {
+    const floated = await withRejectionProbe(() => {
+      const fn = fromThrowable(
+        async (): Promise<number> => {
+          throw boom;
+        },
+        (cause, defect) => defect(cause),
+      );
+      const r = fn();
+      expect(r.isOk()).toBe(false);
+      expect(r.isDefect()).toBe(true);
+      if (r.isDefect()) {
+        expect(r.cause).toBeInstanceOf(TypeError);
+        expect(String((r.cause as TypeError).message)).toContain("returned a thenable");
+      }
+    });
+    // The orphaned rejection was adopted and silenced, not left to float.
+    expect(floated).toEqual([]);
+  });
+
+  it("fromSafeThrowable: an async fn is a Defect, never Ok(Promise)", async () => {
+    const floated = await withRejectionProbe(() => {
+      const fn = fromSafeThrowable(async (): Promise<number> => {
+        throw boom;
+      });
+      const r = fn();
+      expect(r.isOk()).toBe(false);
+      expect(r.isDefect()).toBe(true);
+    });
+    expect(floated).toEqual([]);
+  });
+
+  it("a RESOLVING async fn is a Defect too — the hazard is the shape, not the outcome", async () => {
+    const fn = fromSafeThrowable(async () => 1);
+    expect(fn().isDefect()).toBe(true);
+  });
+
+  it("a plain (non-promise) thenable is caught the same way", () => {
+    // oxlint-disable-next-line no-thenable -- the point of the test: a hand-rolled thenable must be caught like a Promise
+    const fn = fromSafeThrowable(() => ({ then: () => undefined }));
+    expect(fn().isDefect()).toBe(true);
+  });
+
+  it("a synchronous fn returning an ordinary object is untouched", () => {
+    // `then` is only a thenable marker when it is CALLABLE — a data property
+    // named `then` must still flow through as an ordinary success value.
+    // oxlint-disable-next-line no-thenable -- deliberately NOT a thenable: `then` is a number, which must not trip the guard
+    const fn = fromSafeThrowable(() => ({ then: 1, ok: true }));
+    const r = fn();
+    expect(r.isOk()).toBe(true);
+    // Asserted field-by-field rather than with a `{ then: … }` literal, which
+    // would trip the same `no-thenable` lint the code under test is about.
+    if (r.isOk()) {
+      expect(r.value.then).toBe(1);
+      expect(r.value.ok).toBe(true);
+    }
+  });
+});

--- a/packages/core/src/interop.ts
+++ b/packages/core/src/interop.ts
@@ -60,6 +60,11 @@ export function fromNullable<T, E>(
  * — and a thenable slipped past the types at runtime becomes a `Defect` (never
  * an `Err(Promise)`), its orphaned rejection silenced.
  *
+ * `fn` is **synchronous** too. An `async` `fn` rejects *after* this boundary has
+ * already returned, so its rejection could never reach `qualify`: it becomes a
+ * `Defect` (never `Ok(<Promise>)`) and the orphaned rejection is silenced rather
+ * than left to float. Reach for {@link fromPromise} to wrap async work.
+ *
  * The modeled error type is `Exclude<R, Defect>` — the `Defect` arm of
  * `qualify`'s return is **subtracted** from `E`, never inferred into it. So a
  * `qualify` that returns *only* `defect(cause)` yields `E = never` (a Defect is
@@ -100,7 +105,8 @@ export function fromThrowable<A extends unknown[], T, R>(
   const triage = qualify as (cause: unknown, defect: (cause: unknown) => Defect) => E | Defect;
   return (...args: A): Result<T, E> => {
     try {
-      return Ok(fn(...args)) as Result<T, E>;
+      const value = fn(...args);
+      return isThenable(value) ? thenableReturnDefect<T, E>(value) : (Ok(value) as Result<T, E>);
     } catch (cause) {
       return qualifyToResult<T, E>(cause, triage);
     }
@@ -117,6 +123,10 @@ export function fromThrowable<A extends unknown[], T, R>(
  * error channel is `never`, so there is nothing to triage; there is no
  * `qualify`. When some throws *are* anticipated, reach for
  * {@link fromThrowable} and triage them.
+ *
+ * `fn` is **synchronous**: an `async` `fn` becomes a `Defect` (never
+ * `Ok(<Promise>)`), with its orphaned rejection silenced rather than left to
+ * float. Reach for {@link fromSafePromise} to wrap async work.
  *
  * @typeParam A - the wrapped function's argument tuple.
  * @typeParam T - the wrapped function's return type.
@@ -141,7 +151,8 @@ export function fromSafeThrowable<A extends unknown[], T>(
 ): (...args: A) => Result<T, never> {
   return (...args: A): Result<T, never> => {
     try {
-      return Ok(fn(...args));
+      const value = fn(...args);
+      return isThenable(value) ? thenableReturnDefect<T, never>(value) : Ok(value);
     } catch (cause) {
       return defectRes<T, never>(cause);
     }
@@ -292,7 +303,38 @@ function qualifyToResult<T, E>(
 }
 
 /**
- * Runtime thenable probe for the belt-and-braces guard above. Called inside the
+ * The Defect minted when a **synchronous** boundary's `fn` returns a thenable —
+ * i.e. an `async` function was handed to {@link fromThrowable} /
+ * {@link fromSafeThrowable}.
+ *
+ * @remarks
+ * This is the sibling of the thenable-`qualify` net in {@link qualifyToResult},
+ * and it closes a strictly worse hole. A synchronous boundary only ever sees a
+ * synchronous `throw`, so an async `fn`'s rejection never reaches `qualify` at
+ * all: it would sit inside `Ok(<Promise>)`, un-triaged, and then float as an
+ * unhandled rejection — which terminates the process on Node by default.
+ *
+ * Unlike the combinator callbacks, this cannot be banned at compile time
+ * without collateral damage: `T & NotThenable<T>` on `fn`'s return makes a
+ * **generic** function unassignable, so `fromSafeThrowable(structuredClone)`
+ * stops compiling and `T` collapses to `unknown`. (The phantom rest-tuple guard
+ * `fromPromise` uses fares worse.) So the ban is enforced here, at runtime,
+ * where it costs nothing: a Defect, plus adopt-and-silence so the orphaned
+ * rejection cannot float.
+ *
+ * @internal
+ */
+function thenableReturnDefect<T, E>(value: unknown): Result<T, E> {
+  void Promise.resolve(value).then(undefined, () => undefined);
+  return defectRes<T, E>(
+    new TypeError(
+      "unthrown: fromThrowable/fromSafeThrowable wrap a SYNCHRONOUS function, but `fn` returned a thenable — its rejection would escape qualification. Use fromPromise/fromSafePromise instead.",
+    ),
+  );
+}
+
+/**
+ * Runtime thenable probe for the belt-and-braces guards above. Called inside the
  * caller's `try`, so even a hostile `.then` getter lands on the Defect path.
  *
  * @internal

--- a/packages/core/src/matcher.spec.ts
+++ b/packages/core/src/matcher.spec.ts
@@ -152,6 +152,27 @@ describe("the built-in matcher engine", () => {
     }
   });
 
+  // `JSON.stringify` RETURNS undefined for these (it does not throw), so the
+  // `catch` never fires — without the `?? String(input)` fallback the message
+  // read "the value undefined" for exactly the rogue inputs this error describes.
+  it.each([
+    ["a function", function rogueFn() {}, "rogueFn"],
+    ["a symbol", Symbol("rogueSym"), "Symbol(rogueSym)"],
+  ])("NonExhaustiveError names %s instead of printing `undefined`", (_label, input, expected) => {
+    const builder = match(input as unknown as "a").with("a", () => 1);
+    try {
+      builder.run();
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(NonExhaustiveError);
+      expect((error as NonExhaustiveError).message).toContain(expected);
+      // The regression: `JSON.stringify` returns undefined for these, so without
+      // the `?? String(input)` fallback every one of them printed as `undefined`.
+      expect((error as NonExhaustiveError).message).not.toContain("the value undefined");
+      expect((error as NonExhaustiveError).input).toBe(input);
+    }
+  });
+
   it("a non-plain object pattern never matches structurally — identity only", () => {
     // A keyless class instance (Date, Error) or a foreign symbol-keyed pattern
     // object (e.g. a real ts-pattern matcher) must NOT vacuously match every

--- a/packages/core/src/matcher.ts
+++ b/packages/core/src/matcher.ts
@@ -242,9 +242,14 @@ export class NonExhaustiveError extends Error {
   /** The value no arm matched. */
   readonly input: unknown;
   constructor(input: unknown) {
-    let printed: string;
+    let printed: string | undefined;
     try {
-      printed = JSON.stringify(input);
+      // `JSON.stringify` RETURNS undefined (it does not throw) for a function, a
+      // symbol, or `undefined` — so `?? String(input)` is load-bearing, not
+      // belt-and-braces: without it the message reads "the value undefined" for
+      // exactly the rogue inputs this error exists to describe. The `catch` is
+      // for the inputs that genuinely throw (a bigint, a circular object).
+      printed = JSON.stringify(input) ?? String(input);
     } catch {
       printed = String(input);
     }

--- a/packages/standard-schema/src/index.ts
+++ b/packages/standard-schema/src/index.ts
@@ -14,7 +14,7 @@
 //   parseUser(input); // Result<{ id: string }, readonly StandardSchemaV1.Issue[]>
 
 import type { StandardSchemaV1 } from "@standard-schema/spec";
-import { Err, fromSafePromise, fromThrowable, Ok } from "unthrown";
+import { Err, fromSafePromise, fromSafeThrowable, Ok } from "unthrown";
 import type { AsyncResult, Result } from "unthrown";
 
 /** The error channel both entry points produce: a schema's validation issues. */
@@ -65,25 +65,34 @@ export function fromSchema<S extends StandardSchemaV1>(
 ): (input: unknown) => Result<StandardSchemaV1.InferOutput<S>, SchemaIssues> {
   type Output = StandardSchemaV1.InferOutput<S>;
   // Run `validate` at a boundary so a *throwing* validator lands in the Defect
-  // channel instead of escaping; `qualify` only ever mints a Defect, so E = never.
-  const validate = fromThrowable(
-    (input: unknown) => schema["~standard"].validate(input),
-    (cause, defect) => defect(cause),
-  );
+  // channel instead of escaping.
+  //
+  // The return is BOXED deliberately. A Standard Schema may legitimately
+  // validate asynchronously, and `fromSafeThrowable` (rightly) turns a thenable
+  // return into a Defect — a synchronous boundary cannot qualify a rejection.
+  // But here an async schema is a *usage* error with its own actionable message,
+  // not an anonymous defect, so the thenable has to reach the check below rather
+  // than being swallowed. Wrapping it in an object keeps the boundary's value
+  // non-thenable while still catching a throwing validator.
+  const validate = fromSafeThrowable((input: unknown) => ({
+    returned: schema["~standard"].validate(input) as
+      | StandardSchemaV1.Result<Output>
+      | PromiseLike<StandardSchemaV1.Result<Output>>,
+  }));
   return (input) => {
     const settled = validate(input);
     // An async schema can't be represented synchronously — fail loud and early.
-    if (settled.isOk() && isThenable(settled.value)) {
+    if (settled.isOk() && isThenable(settled.value.returned)) {
       // The in-flight validation promise is deliberately dropped — adopt its
       // eventual rejection (if any) so a validator that later fails cannot
       // fire as an unhandled rejection after this throw.
-      Promise.resolve(settled.value).then(undefined, () => {});
+      Promise.resolve(settled.value.returned).then(undefined, () => {});
       throw new TypeError(
         "@unthrown/standard-schema: this schema validates asynchronously — use fromSchemaAsync instead.",
       );
     }
-    return settled.flatMap((result) => {
-      const sync = result as StandardSchemaV1.Result<Output>;
+    return settled.flatMap((box) => {
+      const sync = box.returned as StandardSchemaV1.Result<Output>;
       return sync.issues ? Err(sync.issues) : Ok(sync.value);
     });
   };

--- a/packages/vitest/src/index.spec.ts
+++ b/packages/vitest/src/index.spec.ts
@@ -48,6 +48,40 @@ describe("toBeErr / toBeErrTagged", () => {
     expect(r).not.toBeErrTagged("MyError", { code: 42, extra: true });
   });
 
+  // The regression: `override message = "…"` is the documented way to set a
+  // TaggedError's message, and it lands as an OWN ENUMERABLE property — so it
+  // used to leak into the payload and break the exact-match form on the very
+  // pattern the library prescribes. `_tag` / `name` / `message` / `stack` are all
+  // reserved by TaggedError, so none of them is payload.
+  it("toBeErrTagged ignores the reserved keys — an `override message` is not payload", () => {
+    class HttpError extends TaggedError("HttpError")<{ status: number }> {
+      override message = `http ${this.status}`;
+    }
+    const error = new HttpError({ status: 500 });
+    const r: Result<number, HttpError> = Err(error);
+    // the message is really set (we are not just deleting it), and it really is
+    // an own enumerable property — which is why it used to leak into the payload
+    expect(error.message).toBe("http 500");
+    expect(Object.keys(error)).toContain("message");
+    expect(r).toBeErrTagged("HttpError", { status: 500 });
+    expect(r).not.toBeErrTagged("HttpError", { status: 404 });
+    // still exact: an extra field fails, and the reserved keys cannot be asserted
+    expect(r).not.toBeErrTagged("HttpError", { status: 500, extra: true });
+    expect(r).not.toBeErrTagged("HttpError", { status: 500, message: "http 500" });
+  });
+
+  it("toBeErrTagged ignores a namespaced tag's decoupled `name` too", () => {
+    class Retryable extends TaggedError("@lib/Retryable", { name: "Retryable" })<{
+      tries: number;
+    }> {
+      override message = "safe to retry";
+    }
+    const error = new Retryable({ tries: 3 });
+    const r: Result<number, Retryable> = Err(error);
+    expect(error.name).toBe("Retryable");
+    expect(r).toBeErrTagged("@lib/Retryable", { tries: 3 });
+  });
+
   it("toBeErrTagged matches the payload partially with an asymmetric matcher", () => {
     class Multi extends TaggedError("Multi")<{ id: number; msg: string }> {}
     const r: Result<number, Multi> = Err(new Multi({ id: 1, msg: "boom" }));

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -39,15 +39,30 @@ function render(result: SomeResult, stringify: Stringify): string {
   /* v8 ignore stop */
 }
 
-// The "payload" of a TaggedError: its own enumerable properties minus the
-// `_tag` discriminant and the `name` (both set by TaggedError itself, not by
-// you). This is the data you passed to the constructor, so `toBeErrTagged`'s
-// optional second argument matches it: a plain object asserts it exactly, and an
-// asymmetric matcher (e.g. `expect.objectContaining(...)`) asserts it partially.
+// The keys `TaggedError` RESERVES — never payload, so never part of what
+// `toBeErrTagged`'s second argument asserts. This mirrors the reservation
+// exactly: `TaggedErrorInstance` is `Omit<A, "name" | "message" | "stack">` and
+// the constructor types all three `?: never`, so none of them can legitimately
+// be payload.
+//
+// `message` is the one that bites. The documented way to set it is a subclass
+// field — `override message = "…"` — which lands as an OWN ENUMERABLE property,
+// so `Object.keys` sees it and an exact payload assertion
+// (`toBeErrTagged("HttpError", { status: 500 })`) would fail on the very pattern
+// the library prescribes. (`stack` is already invisible here — the constructor
+// re-defines it non-enumerable — but it is listed so this set is the
+// reservation list, not a subset that happens to work.)
+const RESERVED_KEYS: ReadonlySet<string> = new Set(["_tag", "name", "message", "stack"]);
+
+// The "payload" of a TaggedError: its own enumerable properties minus the keys
+// TaggedError owns. This is the data you passed to the constructor, so
+// `toBeErrTagged`'s optional second argument matches it: a plain object asserts
+// it exactly, and an asymmetric matcher (e.g. `expect.objectContaining(...)`)
+// asserts it partially.
 function payloadOf(error: object): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const key of Object.keys(error)) {
-    if (key !== "_tag" && key !== "name") out[key] = (error as Record<string, unknown>)[key];
+    if (!RESERVED_KEYS.has(key)) out[key] = (error as Record<string, unknown>)[key];
   }
   return out;
 }
@@ -367,8 +382,10 @@ export type UnthrownMatchers<R = unknown> = {
   toBeErr: () => R;
   /**
    * Assert an `Err` whose error has `_tag === tag`. Optionally pass `expected`
-   * to also match the error's payload (its own props minus `_tag`/`name`): a
-   * plain object matches exactly, an asymmetric matcher (e.g.
+   * to also match the error's payload — its own props minus the keys
+   * `TaggedError` reserves (`_tag`, `name`, `message`, `stack`), so a subclass's
+   * `override message = "…"` does not leak into an exact assertion. A plain
+   * object matches exactly, an asymmetric matcher (e.g.
    * `expect.objectContaining(...)`) matches partially. An explicitly-passed
    * `undefined` asserts the payload equals `undefined` (it does not degrade
    * to tag-only).


### PR DESCRIPTION
The three actionable findings from the full-library audit, in one pass.

## 1. An `async` fn at a sync boundary escaped qualification and floated

`fromThrowable` / `fromSafeThrowable` wrap a **synchronous** function, so they
only ever see a synchronous `throw`. An `async` `fn` rejects long after the
boundary has returned — its rejection can never reach `qualify`:

```ts
const f = fromThrowable(async () => { throw new Error("boom") }, (c, d) => d(c));
f();  // Ok(<Promise>) — un-triaged — plus an unhandled rejection
```

Verified against `process.on("unhandledRejection")`: both helpers produced
`Ok(<Promise>)` and **two unhandled rejections** reached the handler. On Node ≥15
an unhandled rejection terminates the process by default. This was the one hole
in the library's otherwise-complete "no unqualified rejection" discipline — every
combinator callback is `NotThenable`-guarded, and `fromPromise`'s `qualify` has
*both* a compile-time phantom guard and a runtime adopt-and-silence net, but `fn`
— the actual boundary — had neither.

Both helpers now probe the return value, mint a `Defect`, and adopt-and-silence
the orphan so it cannot float.

**Why runtime and not a compile error.** I tested both compile-time variants:

| | rejects async `fn` | concrete inference | generic `fn` |
|---|---|---|---|
| `T & NotThenable<T>` on `fn`'s return | ✅ | ✅ | ❌ |
| phantom rest-tuple guard (`fromPromise`'s) | ✅ | ✅ | ❌ + `T` → `unknown` |

Both reject a *generic* function — a generic fn can't satisfy a conditional over
its own type parameter. That isn't hypothetical: `fromSafeThrowable(structuredClone)`
stops compiling with `T` collapsed to `unknown`. So the ban lives at runtime,
where it costs nothing. The success type therefore over-states the channel
(`Result<Promise<T>, E>` is spellable but never inhabited) — the mirror of
`recoverErrCases`'s `never` under-stating the error channel.

**One in-repo consumer depended on the old behaviour**, and the suite caught it:
`@unthrown/standard-schema`'s `fromSchema` used `Ok(<Promise>)` to detect an
async schema and throw its own actionable "use `fromSchemaAsync`" message. It now
boxes the validator's return so the thenable still reaches that check — an async
schema is a *usage error with a dedicated message*, not an anonymous defect. Its
boundary also drops from `fromThrowable` with a defect-only qualify to
`fromSafeThrowable`, which is the named form of exactly that.

## 2. `toBeErrTagged`'s exact-payload form broke on the documented `TaggedError` pattern

`CLAUDE.md` prescribes `override message = "…"` as *the* way to set a message.
That lands as an own **enumerable** property, so it leaked into the payload:

```
own enumerable keys, with the override: [ '_tag', 'status', 'name', 'message' ]
own enumerable keys, without:           [ '_tag', 'status', 'name' ]
```

`payloadOf` stripped `_tag` and `name` but not `message`, so
`toBeErrTagged("HttpError", { status: 500 })` failed on the very pattern the
library recommends. It now skips `_tag` / `name` / `message` / `stack` — exactly
the keys `TaggedErrorInstance` omits and the constructor types `?: never`, so
none of them can legitimately be payload.

The existing suite missed it because every exact-payload test used a payload-less
error or `expect.objectContaining` (partial, so the extra key was tolerated).
`objectContaining` assertions are unaffected by this change.

## 3. `NonExhaustiveError` printed `undefined` for exactly the values it describes

```
new NonExhaustiveError(() => 1)      // "…the value undefined"
new NonExhaustiveError(Symbol("s"))  // "…the value undefined"
new NonExhaustiveError(1n)           // "…the value 1"   ← worked
```

`JSON.stringify` *returns* `undefined` for a function/symbol/`undefined` rather
than throwing, so the `catch → String(input)` fallback never fired — only the
bigint path, which genuinely throws, reached it. This error is only reachable
when a rogue value has slipped past the types, so the printed value *is* the
whole diagnostic. Now `JSON.stringify(input) ?? String(input)`.

## Verification

`format --check`, `lint`, `typecheck`, `knip`, `test`, `build`, `build:docs` all
green. 639 tests (was 630). Core coverage held at functions 100 / lines 100.

Docs updated: a new "Sync boundaries are sync on both sides" section in the
qualification guide, the reserved-key note in the testing guide, and `CLAUDE.md`
gains the new runtime invariant (including why it is *not* type-enforced).

## Not in this PR

The other two audit findings, both judgement calls rather than defects:

- **The library doesn't dogfood `@unthrown/oxlint`** — 7 rules, 4 in
  `recommended`, encoding Theses #1 and #5, never run against the monorepo's own
  source. The library is currently compliant (no `P._` in any non-test library
  source; the generic-`E` sites use the guards), so enabling it should be close
  to a no-op — which is the best time to do it.
- **Observer combinators have no runtime net for a smuggled thenable**, unlike
  `qualifyToResult`. Cast-only path, so low severity; the point is the asymmetry.

Happy to take either as a follow-up.
