### PR TITLE
chore: align the local gate with CI, verify the skill surface, tighten NotThenable

### DIFF
--- a/.changeset/olive-cars-repeat.md
+++ b/.changeset/olive-cars-repeat.md
@@ -1,0 +1,23 @@
+---
+"unthrown": patch
+---
+
+`NotThenable` now rejects a **sometimes**-async callback, not just an always-async
+one.
+
+It was spelled `[R] extends [PromiseLike<unknown>]`, which is false for a partial
+union — so a callback that returns a promise on only one branch compiled on every
+guarded surface:
+
+```ts
+result.tap(() => (flag ? 1 : work())); // used to compile
+```
+
+That is still an unawaited effect whose rejection the pipeline never sees, which
+is exactly what the ban exists to prevent. Spelling it with `Extract` closes it —
+the same reasoning `fromPromise`'s async-qualify guard already used, and which
+this type never picked up.
+
+Affects `map`, `tap`, `let`, `tapDefect`, `tapFailure` and `ensure`'s `onFail`. An
+always-async callback was already rejected and is unchanged; a purely synchronous
+one is unaffected.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,7 +241,13 @@ was planned).
   not ban it. The boundary `qualify` is constrained the same way, with a
   runtime belt-and-braces: a thenable slipped past the types becomes a
   `Defect` and its orphaned rejection is silenced (see Thesis #3). `match`
-  handlers are deliberately exempt (edge elimination).
+  handlers are deliberately exempt (edge elimination). `NotThenable` is spelled
+  `[Extract<R, PromiseLike<unknown>>] extends [never]`, **not** the tuple-wrapped
+  `[R] extends [PromiseLike<…>]`: the latter is false for a PARTIAL union, so a
+  _sometimes_-async callback (`flag ? 1 : work()`) compiled on every guarded
+  surface — still an unawaited effect whose rejection the pipeline never sees.
+  Same reasoning `fromPromise`'s async-qualify guard always used; the type
+  itself only picked it up in 5.1. Guarded in `types.test-d.ts`.
 - **A sync boundary's `fn` is sync too — enforced at RUNTIME, not by the
   types.** `fromThrowable` / `fromSafeThrowable` wrap a synchronous function, so
   they only ever see a synchronous `throw`: an `async` `fn` rejects long after

--- a/packages/boxed/vitest.config.ts
+++ b/packages/boxed/vitest.config.ts
@@ -5,6 +5,11 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.spec.ts"],
     coverage: {
+      // Always on, so a bare `vitest run` enforces the thresholds below.
+      // CI appends `--coverage`; a second CLI flag would crash vitest, so this
+      // lives in the config rather than in the `test` script — and local runs
+      // can no longer pass while the gate fails.
+      enabled: true,
       provider: "v8",
       include: ["src/**"],
       // Every conversion is exercised both directions, including the forced

--- a/packages/core/src/skill-surface.test-d.ts
+++ b/packages/core/src/skill-surface.test-d.ts
@@ -1,0 +1,323 @@
+// A compile-check of the API surface the agent skill (`skills/unthrown/`)
+// documents. The skill is markdown — nothing typechecks it — and it has already
+// shipped a signature that was simply wrong (`fromSchema(schema, input)` for a
+// curried API), which suggests it was written from intent rather than verified.
+//
+// `packages/oxlint/src/skill.test.ts` pins the oxlint rule inventory; this pins
+// the core surface: every export the skill names, spelled the way the skill
+// spells it. A rename, a removed export, or a signature the skill misreports
+// fails `tsc` here.
+//
+// Checked by the package's regular `tsc --noEmit`; no runtime.
+
+import {
+  all,
+  allAsync,
+  allFromDict,
+  allFromDictAsync,
+  type AsyncErrOf,
+  type AsyncOkOf,
+  AsyncResult,
+  Do,
+  DoAsync,
+  Err,
+  ErrAsync,
+  type ErrMatcher,
+  type ErrOf,
+  type FailureView,
+  fromNullable,
+  fromPromise,
+  fromSafePromise,
+  fromSafeThrowable,
+  fromThrowable,
+  GetError,
+  isDefect,
+  isErr,
+  isOk,
+  isResult,
+  match,
+  NonExhaustiveError,
+  type NotThenable,
+  Ok,
+  type OkOf,
+  OkAsync,
+  P,
+  Result,
+  TaggedError,
+  type TaggedErrorConstructor,
+  type TaggedErrorInstance,
+} from "./index.js";
+
+type Equal<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+// --- SKILL.md "Construct and chain" -------------------------------------------
+
+type AgeError = "not_a_number" | "negative";
+declare const input: string;
+
+function parseAge(text: string): Result<number, AgeError> {
+  const n = Number(text);
+  if (Number.isNaN(n)) return Err("not_a_number");
+  if (n < 0) return Err("negative");
+  return Ok(n);
+}
+
+const adult = parseAge(input)
+  .map((n) => n + 1)
+  .flatMap((n) => (n >= 18 ? Ok(n) : Err("underage" as const)));
+
+// `Ok()` with no argument is a `Result<void, never>`, as the skill states.
+const voidOk = Ok();
+
+// --- SKILL.md "Boundaries" ----------------------------------------------------
+
+class NotFoundError extends Error {}
+declare function fetchUser(id: string): Promise<{ id: string }>;
+declare const id: string;
+
+const user = fromPromise(fetchUser(id), (cause, defect) =>
+  cause instanceof NotFoundError ? ("not_found" as const) : defect(cause),
+);
+
+const parse = fromThrowable(
+  (text: string) => JSON.parse(text) as unknown,
+  (cause, defect) => (cause instanceof SyntaxError ? ("invalid_json" as const) : defect(cause)),
+);
+
+declare const schemaParse: (row: unknown) => { ok: true };
+const decode = fromSafeThrowable(schemaParse);
+declare function loadConfig(): Promise<{ port: number }>;
+const cfg = fromSafePromise(loadConfig());
+
+declare const map: Map<string, number>;
+declare const key: string;
+const absent = fromNullable(map.get(key), () => "absent" as const);
+
+// --- SKILL.md "The error channel" --------------------------------------------
+
+class RecordNotFound extends TaggedError("RecordNotFound")<{ id: string }> {}
+class Unavailable extends TaggedError("Unavailable")<{ cause: unknown }> {}
+
+declare const tagged: Result<number, RecordNotFound | Unavailable>;
+
+const mapped = tagged.mapErrCases((matcher, defect) =>
+  matcher
+    .with(P.tag("RecordNotFound"), (e) => e.id)
+    .with(P.tag("Unavailable"), (e) => defect(e.cause)),
+);
+
+// Grouped patterns share one handler, as the skill shows.
+const grouped = tagged.tapErrCases((matcher) =>
+  matcher.with(P.tag("RecordNotFound"), P.tag("Unavailable"), () => undefined),
+);
+
+// The other three error combinators the skill names.
+const flatMapped = tagged.flatMapErrCases((matcher) =>
+  matcher
+    .with(P.tag("RecordNotFound"), () => Ok(0))
+    .with(P.tag("Unavailable"), () => Err("x" as const)),
+);
+const recovered = tagged.recoverErrCases((matcher) =>
+  matcher.with(P.tag("RecordNotFound"), () => 0).with(P.tag("Unavailable"), () => -1),
+);
+const flatTapped = tagged.flatTapErrCases((matcher) =>
+  matcher.with(P.tag("RecordNotFound"), P.tag("Unavailable"), () => Ok(undefined)),
+);
+
+// `returnType<R>()` pins the output, called first.
+const pinned = tagged.mapErrCases((matcher) =>
+  matcher
+    .returnType<string>()
+    .with(P.tag("RecordNotFound"), () => "nf")
+    .with(P.tag("Unavailable"), () => "down"),
+);
+
+// --- SKILL.md "Eliminate at the edge" ----------------------------------------
+
+const folded = parseAge(input).match({
+  ok: (age) => `age is ${age}`,
+  errCases: (matcher) =>
+    matcher.with("negative", () => "must be positive").with("not_a_number", () => "not a number"),
+  defect: () => "something went wrong",
+});
+
+// The extractor family, spelled exactly as the skill lists it.
+declare const total: Result<number, never>;
+declare const failing: Result<number, AgeError>;
+const got: number = total.get();
+const gotErr: AgeError = (Err("negative" as AgeError) as Result<never, AgeError>).getErr();
+const or: number = failing.getOr(0);
+const orElse: number = failing.getOrElse(() => 0);
+const orNull: number | null = failing.getOrNull();
+const orUndef: number | undefined = failing.getOrUndefined();
+const orThrow: number = failing.getOrThrow();
+
+// --- SKILL.md "AsyncResult" ---------------------------------------------------
+
+declare function loadOrders(uid: string): Promise<number[]>;
+
+const lifted = parseAge(input)
+  .toAsync()
+  .flatMap(() => fromPromise(loadOrders(id), (c, d) => d(c)))
+  .map((orders) => orders.length);
+
+const preLifted = [OkAsync(1), ErrAsync("e" as const)] as const;
+
+// --- SKILL.md "TaggedError" ---------------------------------------------------
+
+class NotFound extends TaggedError("NotFound") {}
+class HttpError extends TaggedError("HttpError")<{ status: number }> {
+  override message = `http ${this.status}`;
+}
+class Namespaced extends TaggedError("pkg/NotFound", { name: "NotFound" }) {}
+
+const empty = new NotFound(); // no-arg constructor when the payload is empty
+const withPayload = new HttpError({ status: 500 });
+
+// --- references/api.md: do-notation, aggregates, guards, facades --------------
+
+const doChain = Do()
+  .bind("a", () => Ok(1))
+  .let("b", (scope) => scope.a + 1)
+  .map((scope) => scope.a + scope.b);
+
+const doAsyncChain = DoAsync().bind("a", () => OkAsync(1));
+
+const tuple = all([Ok(1), Ok("a")] as const);
+const dict = allFromDict({ a: Ok(1), b: Ok("x") });
+const tupleAsync = allAsync([OkAsync(1), OkAsync("a")] as const);
+const dictAsync = allFromDictAsync({ a: OkAsync(1), b: OkAsync("x") });
+
+declare const unknownValue: unknown;
+const guarded = isResult(unknownValue);
+const okGuard = isOk(total);
+const errGuard = isErr(failing);
+const defectGuard = isDefect(failing);
+const methodGuard = failing.isOk();
+
+// The facade companions carry the same entry points.
+const viaFacade = [
+  Result.Ok(1),
+  Result.Err("e" as const),
+  Result.Do(),
+  Result.fromNullable(1 as number | null, () => "absent" as const),
+  Result.fromThrowable(
+    () => 1,
+    (c, d) => d(c),
+  ),
+  Result.fromSafeThrowable(() => 1),
+  Result.all([Ok(1)] as const),
+  Result.allFromDict({ a: Ok(1) }),
+] as const;
+const viaAsyncFacade = [
+  AsyncResult.Ok(1),
+  AsyncResult.Err("e" as const),
+  AsyncResult.Do(),
+  AsyncResult.fromPromise(Promise.resolve(1), (c, d) => d(c)),
+  AsyncResult.fromSafePromise(Promise.resolve(1)),
+  AsyncResult.all([OkAsync(1)] as const),
+  AsyncResult.allFromDict({ a: OkAsync(1) }),
+] as const;
+
+// --- references/api.md: the P namespace ---------------------------------------
+
+const patterns = [
+  P._,
+  P.any,
+  P.tag("RecordNotFound"),
+  P.instanceOf(NotFoundError),
+  P.when((x: unknown): x is string => typeof x === "string"),
+  P.union("a", "b"),
+  P.string,
+  P.number,
+] as const;
+
+// `match` over a whole Result, since Result is a discriminated union.
+const overResult = match(total)
+  .with({ tag: "Ok" }, (r) => r.value)
+  .with({ tag: "Err" }, () => 0)
+  .with({ tag: "Defect" }, () => -1)
+  .exhaustive();
+
+// --- references/api.md: the exported utility types -----------------------------
+
+declare function producer(): Result<number, AgeError>;
+declare function asyncProducer(): AsyncResult<number, AgeError>;
+declare const failureView: FailureView<AgeError>;
+declare const errMatcher: ErrMatcher<AgeError>;
+declare const notThenable: NotThenable<number>;
+declare const taggedCtor: TaggedErrorConstructor<"X">;
+declare const taggedInst: TaggedErrorInstance<"X", { a: number }>;
+declare const getError: GetError<AgeError>;
+declare const nonExhaustive: NonExhaustiveError;
+
+export type _SkillSurface = [
+  // the shapes the skill states in prose
+  Expect<Equal<typeof voidOk, Result<void, never>>>,
+  Expect<Equal<OkOf<ReturnType<typeof producer>>, number>>,
+  Expect<Equal<ErrOf<ReturnType<typeof producer>>, AgeError>>,
+  Expect<Equal<AsyncOkOf<ReturnType<typeof asyncProducer>>, number>>,
+  Expect<Equal<AsyncErrOf<ReturnType<typeof asyncProducer>>, AgeError>>,
+  // `flatMap` unions the error channels — SKILL.md says so explicitly
+  Expect<Equal<ErrOf<typeof adult>, AgeError | "underage">>,
+  // a defect branch is subtracted from the outgoing E
+  Expect<Equal<ErrOf<typeof mapped>, string>>,
+  // recoverErrCases empties the error channel
+  Expect<Equal<ErrOf<typeof recovered>, never>>,
+  // fromNullable strips null/undefined from the success type
+  Expect<Equal<OkOf<typeof absent>, number>>,
+  // a defect-only qualify yields E = never
+  Expect<Equal<AsyncErrOf<typeof cfg>, never>>,
+  Expect<Equal<ErrOf<ReturnType<typeof decode>>, never>>,
+  // the do-chain accumulates a readonly object scope
+  Expect<Equal<OkOf<typeof doChain>, number>>,
+  // `all` keeps positional types for a fixed tuple; `allFromDict` keys them
+  // (a readonly tuple in, a mutable positional tuple out — the `AllOk` mapping)
+  Expect<Equal<OkOf<typeof tuple>, [number, string]>>,
+  Expect<Equal<OkOf<typeof dict>, { a: number; b: string }>>,
+  // FailureView's second parameter defaults, so `FailureView<E>` is spellable
+  Expect<Equal<typeof failureView, FailureView<AgeError, never>>>,
+];
+
+// Everything above must be *used* so `noUnusedLocals` stays satisfied.
+export const _skillSurfaceValues = [
+  user,
+  parse,
+  grouped,
+  flatMapped,
+  flatTapped,
+  pinned,
+  folded,
+  got,
+  gotErr,
+  or,
+  orElse,
+  orNull,
+  orUndef,
+  orThrow,
+  lifted,
+  preLifted,
+  empty,
+  withPayload,
+  Namespaced,
+  doAsyncChain,
+  tupleAsync,
+  dictAsync,
+  guarded,
+  okGuard,
+  errGuard,
+  defectGuard,
+  methodGuard,
+  viaFacade,
+  viaAsyncFacade,
+  patterns,
+  overResult,
+  errMatcher,
+  notThenable,
+  taggedCtor,
+  taggedInst,
+  getError,
+  nonExhaustive,
+] as const;

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -516,6 +516,9 @@ class WithMsg extends TaggedError("WithMsg")<{ ticketId: string }> {
 new WithMsg({ ticketId: "t1" });
 
 // ---------------------------------------------------------------------------
+declare const sometimesFlag: boolean;
+declare function sometimesWork(): Promise<number>;
+
 // Thenable callbacks are rejected: an async callback's rejection would bypass
 // qualification and float as an unhandled rejection (Thesis #3).
 // ---------------------------------------------------------------------------
@@ -540,6 +543,22 @@ new WithMsg({ ticketId: "t1" });
   r.flatTapErrCases((matcher) => matcher.with(P._, async () => Ok(1)));
   // @ts-expect-error — an async tapErrCases branch is banned (discarded, would float)
   r.tapErrCases((matcher) => matcher.with(P._, async () => {}));
+  // A SOMETIMES-async callback is banned too. `[R] extends [PromiseLike<…>]`
+  // is false for a partial union, so `sometimesFlag ? 1 : sometimesWork()` used to compile on
+  // every one of these — an unawaited effect whose rejection the pipeline never
+  // sees. `NotThenable` is spelled with `Extract` for exactly this, the same
+  // reasoning `fromPromise`'s async-qualify guard already used.
+  // @ts-expect-error — sometimes-async map callback is banned
+  r.map(() => (sometimesFlag ? 1 : sometimesWork()));
+  // @ts-expect-error — sometimes-async tap callback is banned
+  r.tap(() => (sometimesFlag ? 1 : sometimesWork()));
+  // @ts-expect-error — sometimes-async let callback is banned
+  r.let("k", () => (sometimesFlag ? 1 : sometimesWork()));
+  // @ts-expect-error — sometimes-async tapDefect callback is banned
+  r.tapDefect(() => (sometimesFlag ? 1 : sometimesWork()));
+  // @ts-expect-error — sometimes-async tapFailure callback is banned
+  r.tapFailure(() => (sometimesFlag ? 1 : sometimesWork()));
+
   // @ts-expect-error — async tapDefect callback is banned
   r.tapDefect(async () => {});
   // @ts-expect-error — async tapFailure callback is banned

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -34,12 +34,19 @@ export type Bound<T, K extends string, U> = Prettify<Omit<T, K> & { readonly [P 
  * would escape the pipeline as an unhandled rejection instead of a `Defect`.
  * Lift async work with {@link fromPromise} and compose it with `flatMap`.
  *
+ * Spelled with `Extract`, not `[R] extends [PromiseLike<…>]`, so the ban also
+ * fires when only SOME arms of a union return are thenable — a *sometimes*-async
+ * callback (`flag ? 1 : work()`) is still an unawaited effect whose rejection
+ * the pipeline never sees. The tuple-wrapped form is false for a partial union
+ * and let exactly that through. This is the same reasoning `fromPromise`'s
+ * async-qualify guard already used.
+ *
  * @typeParam R - the callback's inferred return type.
  * @category Types
  */
-export type NotThenable<R> = [R] extends [PromiseLike<unknown>]
-  ? "unthrown: combinator callbacks are synchronous — lift async work with fromPromise and compose with flatMap"
-  : unknown;
+export type NotThenable<R> = [Extract<R, PromiseLike<unknown>>] extends [never]
+  ? unknown
+  : "unthrown: combinator callbacks are synchronous — lift async work with fromPromise and compose with flatMap";
 
 /**
  * The built-in match builder over an error union `E`, as produced by

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -5,6 +5,11 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.spec.ts"],
     coverage: {
+      // Always on, so a bare `vitest run` enforces the thresholds below.
+      // CI appends `--coverage`; a second CLI flag would crash vitest, so this
+      // lives in the config rather than in the `test` script — and local runs
+      // can no longer pass while the gate fails.
+      enabled: true,
       provider: "v8",
       include: ["src/**"],
       // Type-only tests carry no runtime; they're checked by `tsc`, not coverage.

--- a/packages/effect/vitest.config.ts
+++ b/packages/effect/vitest.config.ts
@@ -5,6 +5,11 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.spec.ts"],
     coverage: {
+      // Always on, so a bare `vitest run` enforces the thresholds below.
+      // CI appends `--coverage`; a second CLI flag would crash vitest, so this
+      // lives in the config rather than in the `test` script — and local runs
+      // can no longer pass while the gate fails.
+      enabled: true,
       provider: "v8",
       include: ["src/**"],
       // The interop surface is fully exercised, including every Cause-reduction

--- a/packages/neverthrow/vitest.config.ts
+++ b/packages/neverthrow/vitest.config.ts
@@ -5,6 +5,11 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.spec.ts"],
     coverage: {
+      // Always on, so a bare `vitest run` enforces the thresholds below.
+      // CI appends `--coverage`; a second CLI flag would crash vitest, so this
+      // lives in the config rather than in the `test` script — and local runs
+      // can no longer pass while the gate fails.
+      enabled: true,
       provider: "v8",
       include: ["src/**"],
       // Every conversion is exercised both directions, including the forced

--- a/packages/orpc/vitest.config.ts
+++ b/packages/orpc/vitest.config.ts
@@ -5,6 +5,11 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.spec.ts"],
     coverage: {
+      // Always on, so a bare `vitest run` enforces the thresholds below.
+      // CI appends `--coverage`; a second CLI flag would crash vitest, so this
+      // lives in the config rather than in the `test` script — and local runs
+      // can no longer pass while the gate fails.
+      enabled: true,
       provider: "v8",
       include: ["src/**"],
       exclude: ["src/**/*.test-d.ts", "src/**/*.spec.ts"],

--- a/packages/oxlint/vitest.config.ts
+++ b/packages/oxlint/vitest.config.ts
@@ -5,6 +5,11 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts"],
     coverage: {
+      // Always on, so a bare `vitest run` enforces the thresholds below.
+      // CI appends `--coverage`; a second CLI flag would crash vitest, so this
+      // lives in the config rather than in the `test` script — and local runs
+      // can no longer pass while the gate fails.
+      enabled: true,
       provider: "v8",
       include: ["src/**"],
       exclude: ["src/**/*.test.ts"],

--- a/packages/prisma/vitest.config.ts
+++ b/packages/prisma/vitest.config.ts
@@ -5,6 +5,11 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.spec.ts"],
     coverage: {
+      // Always on, so a bare `vitest run` enforces the thresholds below.
+      // CI appends `--coverage`; a second CLI flag would crash vitest, so this
+      // lives in the config rather than in the `test` script — and local runs
+      // can no longer pass while the gate fails.
+      enabled: true,
       provider: "v8",
       include: ["src/**"],
       // The generated test client is Prisma's output, not ours.

--- a/packages/standard-schema/vitest.config.ts
+++ b/packages/standard-schema/vitest.config.ts
@@ -5,6 +5,11 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.spec.ts"],
     coverage: {
+      // Always on, so a bare `vitest run` enforces the thresholds below.
+      // CI appends `--coverage`; a second CLI flag would crash vitest, so this
+      // lives in the config rather than in the `test` script — and local runs
+      // can no longer pass while the gate fails.
+      enabled: true,
       provider: "v8",
       include: ["src/**"],
       // Both entry points are exercised over valid input, issues, an async

--- a/packages/vitest/vitest.config.ts
+++ b/packages/vitest/vitest.config.ts
@@ -5,6 +5,11 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.spec.ts"],
     coverage: {
+      // Always on, so a bare `vitest run` enforces the thresholds below.
+      // CI appends `--coverage`; a second CLI flag would crash vitest, so this
+      // lives in the config rather than in the `test` script — and local runs
+      // can no longer pass while the gate fails.
+      enabled: true,
       provider: "v8",
       include: ["src/**"],
       // Lock in the matcher suite at full statement/line/function coverage. The


### PR DESCRIPTION
Items 1–3 from the post-audit list, one commit each.

## 1. `pnpm test` now matches CI

Coverage thresholds only fired under `--coverage`, which CI appends and a local
`pnpm test` does not — so a package could pass every test locally and still fail
the gate. That is exactly how #178 went red: one new line in `@unthrown/orpc`
dropped `client.ts` below its 100% threshold, invisible locally.

Fixed in the vitest configs (`coverage.enabled: true`), not the `test` scripts —
CI appends `--coverage`, and **a second CLI `--coverage` crashes vitest**, so the
config is the only spelling that works for both invocations.

Verified by deleting the test #178 added: a bare `pnpm test` now reproduces the
same two threshold errors.

## 2. The agent skill's surface is compile-checked

The skill is markdown, so nothing typechecks it — and it had shipped a signature
that was never right (`fromSchema(schema, input)` for a curried API), which
suggested it was written from intent rather than verified. #178 gated the oxlint
rule inventory; this gates the core surface.

`skill-surface.test-d.ts` exercises every export the skill names, spelled the way
the skill spells it, plus the type shapes it states in prose: `flatMap` unioning
error channels, a defect branch subtracted from the outgoing `E`,
`recoverErrCases` emptying it, a defect-only qualify yielding `E = never`, `all`
keeping positional types, `FailureView`'s defaulted second parameter. A rename, a
removed export or a misreported signature now fails `tsc` (verified by renaming
one import).

**Result: no further defects.** The three fixed in #178 were the real ones. The
one assertion that failed was mine — a spurious `readonly` on `all`'s tuple.

## 3. `NotThenable` rejects a *sometimes*-async callback

Auditing `types.ts` — the last core file I hadn't read directly — turned up a
genuine hole. It was spelled `[R] extends [PromiseLike<unknown>]`, which is
**false for a partial union**, so this compiled on every guarded surface:

```ts
result.tap(() => (flag ? 1 : work())); // an unawaited effect
```

Still an effect whose rejection the pipeline never sees — precisely what the ban
exists to prevent. Affects `map`, `tap`, `let`, `tapDefect`, `tapFailure` and
`ensure`'s `onFail`.

The fix is one line, and the library already knew it: `fromPromise`'s
async-qualify guard uses `Extract` for exactly this reason, with a comment
spelling it out —

> `Extract` (not `[R] extends [PromiseLike<…>]`) so the ban also fires when only
> SOME arms of a union return are thenable — a sometimes-async qualify is still
> an unqualified rejection path

`NotThenable` never picked it up. Now it does, with five `@ts-expect-error`
regression cases.

Runtime impact is limited: #178's `silenceIfThenable` already stops the dropped
promise floating, so this closes the *typing* hole above that net rather than a
live crash.

## Verification

`format --check`, `lint`, `typecheck`, `knip`, `test`, `build` all green; 652
tests; core coverage held at functions 100 / lines 100.

## Note on the release

Release PR #174 is open and current (fixed group → 5.1.0, `@unthrown/prisma` →
0.2.0, `@unthrown/orpc` → 0.1.2). This branch adds a fifth changeset, so #174
will regenerate once this merges — worth merging this first if you want the
`NotThenable` fix in the same release.
