### PR TITLE
test: make the suite self-checking, shared and documented

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -985,6 +985,28 @@ configured outside the repo).
 - **oxlint rules are binding:** no `interface` (use `type`), no `any` (use
   `unknown`). Genuine exceptions (e.g. the `vitest` `Matchers` augmentation, the
   `AsyncRes.then` thenable) carry a targeted `oxlint-disable` with a reason.
+- **Test conventions.** Core's specs share `src/test-helpers.ts` (excluded from
+  coverage): `boom` / `defectOf` fixtures, and `expectOk` / `expectErr` /
+  `expectDefect`, which do the narrowing so a spec reads `expectErr(r, "e")`
+  instead of the two-line `isErr()` dance. Core cannot use `@unthrown/vitest`'s
+  matchers — that package takes core as a **peer**, so importing it would be
+  circular — and these recover most of the readability without the dependency.
+  **No test asserts the absence of a global `unhandledRejection` after a
+  `setTimeout`**: a negative assertion on a timing window cannot distinguish
+  "never fires" from "fires later than we waited", so it can silently stop
+  protecting. Adoption is asserted **positively** instead, via
+  `adoptionProbe()` — `Promise.resolve(x)` calls `x.then(onFulfilled,
+onRejected)`, so the fixture records the handler _and invokes it_, proving both
+  that it was installed and that it swallows the rejection, in one microtask
+  with no timer.
+- **TSDoc `@example` blocks are compiled** (`doc-examples.spec.ts`): every
+  ```ts fence under an `@example` is extracted, given an import preamble of the
+  whole public surface, and typechecked. Examples are the primary teaching
+  surface and they rot silently — the same gap shipped a curried API documented
+  as two-argument in the agent skill. Placeholder names (`findUser`, `id`)
+  surface as TS2304/7006/18046 and are ignored; everything else fails, and a
+  renamed export fails on the _preamble import_ rather than as an ignorable
+  TS2304. `@unthrown/prisma`'s 34 examples are the obvious next application.
 - Tests: Vitest. Every load-bearing invariant above gets an explicit test
   (`invariants.spec.ts` guards them 1:1); core holds 100% line/function coverage,
   enforced by thresholds in its `vitest.config.ts`.

--- a/packages/core/src/aggregate.spec.ts
+++ b/packages/core/src/aggregate.spec.ts
@@ -12,12 +12,7 @@ import {
   Ok,
   type Result,
 } from "./index.js";
-
-const boom = new Error("boom");
-const defectOf = (cause: unknown): Result<number, never> =>
-  Ok(0).map<number>(() => {
-    throw cause;
-  });
+import { boom, defectOf, expectErr, expectOk } from "./test-helpers.js";
 
 describe("all", () => {
   it("collects a tuple of Ok values, preserving positional types", () => {
@@ -35,16 +30,14 @@ describe("all", () => {
 
   it("short-circuits on the first Err", () => {
     const r = all([Ok(1), Err("first"), Err("second")]);
-    expect(r.isErr()).toBe(true);
-    if (r.isErr()) expect(r.error).toBe("first");
+    expectErr(r, "first");
   });
 
   it("lets any Defect dominate, even over an earlier Err", () => {
     const r = all([Ok(1), Err("e"), defectOf(boom)]);
     expect(r.isDefect()).toBe(true);
     const recovered = r.recoverDefect((c) => Ok(c === boom));
-    expect(recovered.isOk()).toBe(true);
-    if (recovered.isOk()) expect(recovered.value).toBe(true);
+    expectOk(recovered, true);
   });
 
   it("keeps the first Defect when several are present", () => {
@@ -57,12 +50,10 @@ describe("all", () => {
     // The array overload: no `as` needed, even in a generic-feeling shape.
     const combine = <T, E>(rs: Result<T, E>[]): Result<T[], E> => all(rs);
     const r = combine([Ok(1), Ok(2), Ok(3)] as Result<number, string>[]);
-    expect(r.isOk()).toBe(true);
-    if (r.isOk()) expect(r.value).toEqual([1, 2, 3]);
+    expectOk(r, [1, 2, 3]);
 
     const e = combine([Ok(1), Err("bad")] as Result<number, string>[]);
-    expect(e.isErr()).toBe(true);
-    if (e.isErr()) expect(e.error).toBe("bad");
+    expectErr(e, "bad");
   });
 
   it("surfaces an out-of-contract non-Result element as a Defect (never throws)", () => {
@@ -83,13 +74,11 @@ describe("allFromDict", () => {
 
   it("short-circuits a record on the first Err and lets a Defect dominate", () => {
     const r = allFromDict({ a: Ok(1), b: Err("bad") });
-    expect(r.isErr()).toBe(true);
-    if (r.isErr()) expect(r.error).toBe("bad");
+    expectErr(r, "bad");
     const d = allFromDict({ a: Ok(1), b: Err("e"), c: defectOf(boom) });
     expect(d.isDefect()).toBe(true);
     const recovered = d.recoverDefect((c) => Ok(c === boom));
-    expect(recovered.isOk()).toBe(true);
-    if (recovered.isOk()) expect(recovered.value).toBe(true);
+    expectOk(recovered, true);
   });
 
   it("returns Ok({}) for an empty record", () => {
@@ -128,8 +117,7 @@ describe("allAsync", () => {
       fromPromise(Promise.reject("first"), (c) => c as string),
       fromPromise(Promise.reject("second"), (c) => c as string),
     ]);
-    expect(r.isErr()).toBe(true);
-    if (r.isErr()) expect(r.error).toBe("first");
+    expectErr(r, "first");
   });
 
   it("lets any Defect dominate, even over an earlier Err", async () => {
@@ -139,8 +127,7 @@ describe("allAsync", () => {
     ]);
     expect(r.isDefect()).toBe(true);
     const recovered = await r.toAsync().recoverDefect((c) => Ok(c === boom));
-    expect(recovered.isOk()).toBe(true);
-    if (recovered.isOk()) expect(recovered.value).toBe(true);
+    expectOk(recovered, true);
   });
 
   it("never rejects — await always yields a Result", async () => {
@@ -191,8 +178,7 @@ describe("allFromDictAsync", () => {
       a: fromSafePromise(Promise.resolve(1)),
       b: fromPromise(Promise.reject("bad"), (c) => c as string),
     });
-    expect(r.isErr()).toBe(true);
-    if (r.isErr()) expect(r.error).toBe("bad");
+    expectErr(r, "bad");
   });
 
   it("lets any Defect dominate over an earlier Err", async () => {

--- a/packages/core/src/async-result.spec.ts
+++ b/packages/core/src/async-result.spec.ts
@@ -11,8 +11,8 @@ import {
   OkAsync,
   type Result,
 } from "./index.js";
+import { boom, expectErr, expectOk } from "./test-helpers.js";
 
-const boom = new Error("boom");
 const asyncOk = <T>(v: T): AsyncResult<T, never> => Ok(v).toAsync();
 const asyncErr = <E>(e: E): AsyncResult<never, E> => Err(e).toAsync();
 const asyncDefect = (): AsyncResult<number, never> =>
@@ -64,15 +64,13 @@ describe("AsyncResult is awaitable and never rejects", () => {
 
   it("fromPromise: a resolved value becomes Ok (promise and thunk forms)", async () => {
     const r1 = await fromPromise(Promise.resolve(5), (c) => c as string);
-    expect(r1.isOk()).toBe(true);
-    if (r1.isOk()) expect(r1.value).toBe(5);
+    expectOk(r1, 5);
 
     const r2 = await fromPromise(
       () => Promise.resolve(6),
       (c) => c as string,
     );
-    expect(r2.isOk()).toBe(true);
-    if (r2.isOk()) expect(r2.value).toBe(6);
+    expectOk(r2, 6);
   });
 });
 
@@ -143,8 +141,7 @@ describe("AsyncResult success channel", () => {
 
   it("flatTap short-circuits to the effect's Err", async () => {
     const r = await asyncOk(5).flatTap(() => Err("denied"));
-    expect(r.isErr()).toBe(true);
-    if (r.isErr()) expect(r.error).toBe("denied");
+    expectErr(r, "denied");
   });
 
   it("flatTap composes an async effect via a qualified boundary, keeping the value", async () => {
@@ -172,8 +169,7 @@ describe("AsyncResult success channel", () => {
       (n) => n > 0,
       (n) => `neg:${n}`,
     );
-    expect(r.isErr()).toBe(true);
-    if (r.isErr()) expect(r.error).toBe("neg:-2");
+    expectErr(r, "neg:-2");
   });
 
   it("ensure refines the success type with a type-guard predicate", async () => {
@@ -222,16 +218,14 @@ describe("AsyncResult success channel", () => {
   it("as replaces the Ok value, and passes Err/Defect through", async () => {
     expect((await asyncOk(1).as("x")).get()).toBe("x");
     const r = await asyncErr("e").as("x");
-    expect(r.isErr()).toBe(true);
-    if (r.isErr()) expect(r.error).toBe("e");
+    expectErr(r, "e");
     expect((await asyncDefect().as("x")).isDefect()).toBe(true);
   });
 
   it("discard drops the Ok value, and passes Err/Defect through", async () => {
     expect((await asyncOk(1).discard()).get()).toBeUndefined();
     const r = await asyncErr("e").discard();
-    expect(r.isErr()).toBe(true);
-    if (r.isErr()) expect(r.error).toBe("e");
+    expectErr(r, "e");
     expect((await asyncDefect().discard()).isDefect()).toBe(true);
   });
 });
@@ -432,11 +426,9 @@ describe("AsyncResult Defect channel", () => {
   it("recoverDefect passes Ok and Err through and does not call the callback", async () => {
     const f = vi.fn();
     const okR = await asyncOk(1).recoverDefect(f);
-    expect(okR.isOk()).toBe(true);
-    if (okR.isOk()) expect(okR.value).toBe(1);
+    expectOk(okR, 1);
     const errR = await asyncErr("e").recoverDefect(f);
-    expect(errR.isErr()).toBe(true);
-    if (errR.isErr()) expect(errR.error).toBe("e");
+    expectErr(errR, "e");
     expect(f).not.toHaveBeenCalled();
   });
 

--- a/packages/core/src/constructors.spec.ts
+++ b/packages/core/src/constructors.spec.ts
@@ -13,12 +13,7 @@ import {
   type Result,
   GetError,
 } from "./index.js";
-
-const boom = new Error("boom");
-const defectOf = (cause: unknown): Result<number, never> =>
-  Ok(0).map<number>(() => {
-    throw cause;
-  });
+import { boom, defectOf } from "./test-helpers.js";
 
 describe("constructors", () => {
   it("Ok wraps a value in the success channel", () => {

--- a/packages/core/src/do.spec.ts
+++ b/packages/core/src/do.spec.ts
@@ -1,12 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { Do, DoAsync, Err, fromSafePromise, Ok, type Result } from "./index.js";
-
-const boom = new Error("boom");
-const defectOf = (cause: unknown): Result<number, never> =>
-  Ok(0).map<number>(() => {
-    throw cause;
-  });
+import { boom, defectOf, expectErr } from "./test-helpers.js";
 
 describe("Do / bind / let", () => {
   it("Do() starts an empty object scope", () => {
@@ -26,8 +21,7 @@ describe("Do / bind / let", () => {
     const r = Do()
       .bind("a", () => Err("denied"))
       .bind("b", later);
-    expect(r.isErr()).toBe(true);
-    if (r.isErr()) expect(r.error).toBe("denied");
+    expectErr(r, "denied");
     expect(later).not.toHaveBeenCalled();
   });
 
@@ -35,8 +29,7 @@ describe("Do / bind / let", () => {
     const a: Result<{ x: number }, "e1"> = Do().bind("x", () => Err<"e1">("e1"));
     const b = a.bind("y", () => Err<"e2">("e2"));
     // `b` is Result<{ x; y }, "e1" | "e2"> — exercised at runtime here:
-    expect(b.isErr()).toBe(true);
-    if (b.isErr()) expect(b.error).toBe("e1");
+    expectErr(b, "e1");
   });
 
   it("propagates a Defect and does not run later steps", () => {
@@ -116,8 +109,7 @@ describe("Do / bind / let — async", () => {
       .toAsync()
       .bind("a", () => Err("denied"))
       .bind("b", () => Ok(1));
-    expect(r.isErr()).toBe(true);
-    if (r.isErr()) expect(r.error).toBe("denied");
+    expectErr(r, "denied");
   });
 
   it("turns a throw in an async bind or let into a Defect and never rejects", async () => {
@@ -178,7 +170,6 @@ describe("DoAsync — the pre-lifted async Do", () => {
     const r = await DoAsync()
       .bind("a", () => Err("denied"))
       .bind("b", () => Ok(1));
-    expect(r.isErr()).toBe(true);
-    if (r.isErr()) expect(r.error).toBe("denied");
+    expectErr(r, "denied");
   });
 });

--- a/packages/core/src/doc-examples.spec.ts
+++ b/packages/core/src/doc-examples.spec.ts
@@ -1,0 +1,126 @@
+// The `@example` blocks in this package's TSDoc are the library's primary
+// teaching surface — they land in the generated API reference and are the first
+// thing most people copy. Nothing compiled them.
+//
+// That is the same gap that let the agent skill ship `fromSchema(schema, input)`
+// for a curried API, and let its Prisma section describe a class that had been
+// deleted. Prose rots silently; `tsc` does not.
+//
+// Every ```ts block under an `@example` tag is extracted, given an import
+// preamble covering the whole public surface, and typechecked. A renamed export,
+// a removed one, or a wrong signature fails here.
+//
+// Examples legitimately use undeclared placeholders (`findUser`, `id`, `Row`) —
+// spelling every one out would make them worse documentation. Those surface as
+// TS2304 / TS7006 / TS18046 and are ignored. Nothing else is: because the
+// preamble imports the real surface, a renamed export fails on the *import*
+// (TS2305/TS2724), not as an ignorable TS2304 in the body.
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterAll, expect, it } from "vitest";
+
+const SRC = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(SRC, "..", "..", "..");
+
+/** Placeholder-name artifacts of extracting a snippet out of its prose. */
+const PLACEHOLDER_CODES = ["TS2304", "TS7006", "TS18046"];
+
+const publicExports = (): string[] => {
+  const index = readFileSync(join(SRC, "index.ts"), "utf8");
+  const names = new Set<string>();
+  for (const block of index.matchAll(/export\s+(?:type\s+)?\{([^}]*)\}/g)) {
+    for (const raw of (block[1] ?? "").split(",")) {
+      const name = raw
+        .trim()
+        .replace(/^type\s+/, "")
+        .split(/\s+as\s+/)
+        .pop()
+        ?.trim();
+      if (name) names.add(name);
+    }
+  }
+  return [...names].sort();
+};
+
+const extract = (): { file: string; code: string }[] => {
+  const found: { file: string; code: string }[] = [];
+  for (const entry of readdirSync(SRC)) {
+    if (!entry.endsWith(".ts") || entry.includes(".spec.") || entry.includes(".test-d.")) continue;
+    const src = readFileSync(join(SRC, entry), "utf8");
+    for (const example of src.matchAll(/@example\s*\n((?:\s*\*.*\n)+?)\s*\*\//g)) {
+      const body = (example[1] ?? "")
+        .split("\n")
+        .map((line) => line.replace(/^\s*\*\s?/, ""))
+        .join("\n");
+      for (const fence of body.matchAll(/```ts\n([\s\S]*?)```/g)) {
+        found.push({ file: entry, code: fence[1] ?? "" });
+      }
+    }
+  }
+  return found;
+};
+
+const workdir = mkdtempSync(join(tmpdir(), "unthrown-doc-examples-"));
+afterAll(() => {
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+it("every TSDoc @example in this package typechecks", () => {
+  const examples = extract();
+  // A guard on the guard: if the extraction regex ever stops matching, this
+  // test would pass vacuously.
+  expect(examples.length).toBeGreaterThan(20);
+
+  // Imports resolve to `src`, not `dist`, so the check needs no build step.
+  const preamble = `import { ${publicExports().join(", ")} } from "${join(SRC, "index.js")}";\n`;
+  examples.forEach(({ file, code }, i) => {
+    // The example's own import line is dropped — the preamble supersedes it.
+    const body = code.replace(/^\s*import .*from "unthrown";\s*$/gm, "");
+    // `.mts` so a top-level `await` in an example is legal.
+    writeFileSync(
+      join(workdir, `ex${String(i).padStart(2, "0")}_${file.replace(".ts", "")}.mts`),
+      preamble + body,
+    );
+  });
+  writeFileSync(
+    join(workdir, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: {
+        strict: true,
+        exactOptionalPropertyTypes: true,
+        noUncheckedIndexedAccess: true,
+        module: "NodeNext",
+        moduleResolution: "NodeNext",
+        target: "ES2022",
+        noEmit: true,
+        skipLibCheck: true,
+        noUnusedLocals: false,
+        lib: ["ES2022", "DOM"],
+      },
+      include: ["*.mts"],
+    }),
+  );
+
+  let output = "";
+  try {
+    execFileSync(join(REPO_ROOT, "node_modules", ".bin", "tsc"), ["-p", "tsconfig.json"], {
+      cwd: workdir,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (error) {
+    output = String((error as { stdout?: string }).stdout ?? "");
+  }
+
+  const real = output
+    .split("\n")
+    .filter((line) => /error TS\d+:/.test(line))
+    .filter((line) => !PLACEHOLDER_CODES.some((code) => line.includes(`error ${code}:`)));
+
+  expect(real, `\n${real.join("\n")}\n`).toEqual([]);
+}, 60_000);

--- a/packages/core/src/doc-examples.spec.ts
+++ b/packages/core/src/doc-examples.spec.ts
@@ -18,6 +18,7 @@
 
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -25,7 +26,11 @@ import { fileURLToPath } from "node:url";
 import { afterAll, expect, it } from "vitest";
 
 const SRC = dirname(fileURLToPath(import.meta.url));
-const REPO_ROOT = join(SRC, "..", "..", "..");
+
+// Resolve the compiler's own JS entry and run it under `process.execPath`,
+// rather than the `node_modules/.bin/tsc` shim: that shim is `tsc.cmd` on
+// Windows, so spawning the extensionless path only works on POSIX.
+const TSC = createRequire(import.meta.url).resolve("typescript/bin/tsc");
 
 /** Placeholder-name artifacts of extracting a snippet out of its prose. */
 const PLACEHOLDER_CODES = ["TS2304", "TS7006", "TS18046"];
@@ -108,7 +113,7 @@ it("every TSDoc @example in this package typechecks", () => {
 
   let output = "";
   try {
-    execFileSync(join(REPO_ROOT, "node_modules", ".bin", "tsc"), ["-p", "tsconfig.json"], {
+    execFileSync(process.execPath, [TSC, "-p", "tsconfig.json"], {
       cwd: workdir,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],

--- a/packages/core/src/facade.spec.ts
+++ b/packages/core/src/facade.spec.ts
@@ -21,8 +21,7 @@ import {
   Ok,
   Result,
 } from "./index.js";
-
-const boom = new Error("boom");
+import { boom } from "./test-helpers.js";
 
 describe("Result facade mirrors the free functions", () => {
   it("exposes the same constructors", () => {

--- a/packages/core/src/interop.spec.ts
+++ b/packages/core/src/interop.spec.ts
@@ -10,8 +10,14 @@ import {
   Ok,
   type Result,
 } from "./index.js";
-
-const boom = new Error("boom");
+import {
+  adoptionProbe,
+  boom,
+  expectDefect,
+  expectErr,
+  expectOk,
+  flushMicrotasks,
+} from "./test-helpers.js";
 
 describe("fromNullable", () => {
   it("turns null/undefined into a modeled Err", () => {
@@ -21,20 +27,16 @@ describe("fromNullable", () => {
 
   it("keeps a present value as Ok (and treats falsy non-null as present)", () => {
     const r1 = fromNullable(5, () => "absent");
-    expect(r1.isOk()).toBe(true);
-    if (r1.isOk()) expect(r1.value).toBe(5);
+    expectOk(r1, 5);
 
     const r2 = fromNullable(0, () => "absent");
-    expect(r2.isOk()).toBe(true);
-    if (r2.isOk()) expect(r2.value).toBe(0);
+    expectOk(r2, 0);
 
     const r3 = fromNullable("", () => "absent");
-    expect(r3.isOk()).toBe(true);
-    if (r3.isOk()) expect(r3.value).toBe("");
+    expectOk(r3, "");
 
     const r4 = fromNullable(false, () => "absent");
-    expect(r4.isOk()).toBe(true);
-    if (r4.isOk()) expect(r4.value).toBe(false);
+    expectOk(r4, false);
   });
 });
 
@@ -45,8 +47,7 @@ describe("fromThrowable", () => {
       () => "qualified",
     );
     const r = add(2, 3);
-    expect(r.isOk()).toBe(true);
-    if (r.isOk()) expect(r.value).toBe(5);
+    expectOk(r, 5);
   });
 
   it("triages a thrown cause into Err when qualify returns E", () => {
@@ -55,12 +56,10 @@ describe("fromThrowable", () => {
       () => "invalid-json",
     );
     const err = parse("{not json}");
-    expect(err.isErr()).toBe(true);
-    if (err.isErr()) expect(err.error).toBe("invalid-json");
+    expectErr(err, "invalid-json");
 
     const ok = parse('{"a":1}');
-    expect(ok.isOk()).toBe(true);
-    if (ok.isOk()) expect(ok.value).toEqual({ a: 1 });
+    expectOk(ok, { a: 1 });
   });
 
   it("triages a thrown cause into a Defect when qualify returns the injected defect marker", () => {
@@ -114,8 +113,7 @@ describe("fromThrowable", () => {
       (c, defect) => (c === boom ? ("known" as const) : defect(c)),
     );
     const r: Result<number, "known"> = fn();
-    expect(r.isOk()).toBe(true);
-    if (r.isOk()) expect(r.value).toBe(1);
+    expectOk(r, 1);
   });
 });
 
@@ -123,8 +121,7 @@ describe("fromSafeThrowable", () => {
   it("wraps a successful call as Ok and forwards arguments", () => {
     const add = fromSafeThrowable((a: number, b: number) => a + b);
     const r = add(2, 3);
-    expect(r.isOk()).toBe(true);
-    if (r.isOk()) expect(r.value).toBe(5);
+    expectOk(r, 5);
   });
 
   it("turns every throw into a Defect with the original cause — never an Err", () => {
@@ -150,8 +147,7 @@ describe("fromSafeThrowable", () => {
       throw "nope";
     });
     const r = fn();
-    expect(r.isDefect()).toBe(true);
-    if (r.isDefect()) expect(r.cause).toBe("nope");
+    expectDefect(r, "nope");
   });
 });
 
@@ -214,26 +210,19 @@ describe("qualify must be synchronous (runtime belt-and-braces)", () => {
     if (r.isDefect()) expect(r.cause).toBeInstanceOf(TypeError);
   });
 
-  it("an async-THROWING qualify still yields a Defect and its rejection never floats", async () => {
-    const floated: unknown[] = [];
-    const probe = (reason: unknown): void => {
-      floated.push(reason);
-    };
-    process.on("unhandledRejection", probe);
-    try {
-      const r = await fromPromise(Promise.reject(boom), (async () => {
-        throw new Error("late rejection");
-      }) as never);
-      expect(r.isDefect()).toBe(true);
-      // Give the orphaned promise time to settle and Node's unhandled-rejection
-      // detection a macrotask to fire — the adopt-and-silence handler must have
-      // claimed the rejection.
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      expect(floated).toEqual([]);
-    } finally {
-      process.off("unhandledRejection", probe);
-    }
+  it("an async qualify's orphaned thenable is ADOPTED, not left to float", async () => {
+    // Positive and deterministic: `Promise.resolve(x)` calls
+    // `x.then(onFulfilled, onRejected)`, so an `onRejected` reaching the fixture
+    // proves the orphan was adopted. The previous shape asserted the *absence*
+    // of a global `unhandledRejection` after two `setTimeout(0)`s — a negative
+    // assertion on a timing window, which cannot distinguish "never fires" from
+    // "fires later than we waited".
+    const { thenable, adoptions } = adoptionProbe();
+    const r = await fromPromise(Promise.reject(boom), (() => thenable) as never);
+    expect(r.isDefect()).toBe(true);
+    await flushMicrotasks();
+    expect(adoptions).toHaveLength(1);
+    expect(typeof adoptions[0]?.onRejected).toBe("function");
   });
 });
 
@@ -244,54 +233,45 @@ describe("the SYNC boundaries reject an async fn", () => {
   // floated as an unhandled rejection, which terminates the process on Node by
   // default. This cannot be banned at compile time without breaking generic
   // functions (`fromSafeThrowable(structuredClone)`), so it is caught here.
-  const withRejectionProbe = async (body: () => void): Promise<unknown[]> => {
-    const floated: unknown[] = [];
-    const probe = (reason: unknown): void => {
-      floated.push(reason);
-    };
-    process.on("unhandledRejection", probe);
-    try {
-      body();
-      // Two macrotasks: let the orphan settle, then let Node's
-      // unhandled-rejection detection run.
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      return floated;
-    } finally {
-      process.off("unhandledRejection", probe);
+  it("fromThrowable: an async fn is a Defect, never Ok(Promise)", () => {
+    const fn = fromThrowable(
+      async (): Promise<number> => {
+        throw boom;
+      },
+      (cause, defect) => defect(cause),
+    );
+    const r = fn();
+    expect(r.isOk()).toBe(false);
+    expect(r.isDefect()).toBe(true);
+    if (r.isDefect()) {
+      expect(r.cause).toBeInstanceOf(TypeError);
+      expect(String((r.cause as TypeError).message)).toContain("returned a thenable");
     }
-  };
-
-  it("fromThrowable: an async fn is a Defect, never Ok(Promise)", async () => {
-    const floated = await withRejectionProbe(() => {
-      const fn = fromThrowable(
-        async (): Promise<number> => {
-          throw boom;
-        },
-        (cause, defect) => defect(cause),
-      );
-      const r = fn();
-      expect(r.isOk()).toBe(false);
-      expect(r.isDefect()).toBe(true);
-      if (r.isDefect()) {
-        expect(r.cause).toBeInstanceOf(TypeError);
-        expect(String((r.cause as TypeError).message)).toContain("returned a thenable");
-      }
-    });
-    // The orphaned rejection was adopted and silenced, not left to float.
-    expect(floated).toEqual([]);
   });
 
-  it("fromSafeThrowable: an async fn is a Defect, never Ok(Promise)", async () => {
-    const floated = await withRejectionProbe(() => {
-      const fn = fromSafeThrowable(async (): Promise<number> => {
-        throw boom;
-      });
-      const r = fn();
-      expect(r.isOk()).toBe(false);
-      expect(r.isDefect()).toBe(true);
+  it("fromSafeThrowable: an async fn is a Defect, never Ok(Promise)", () => {
+    const fn = fromSafeThrowable(async (): Promise<number> => {
+      throw boom;
     });
-    expect(floated).toEqual([]);
+    expect(fn().isDefect()).toBe(true);
+  });
+
+  it.each([
+    [
+      "fromThrowable",
+      (t: PromiseLike<never>) =>
+        fromThrowable(
+          () => t,
+          (cause, defect) => defect(cause),
+        )(),
+    ],
+    ["fromSafeThrowable", (t: PromiseLike<never>) => fromSafeThrowable(() => t)()],
+  ])("%s ADOPTS the orphaned thenable rather than dropping it", async (_label, run) => {
+    const { thenable, adoptions } = adoptionProbe();
+    run(thenable);
+    await flushMicrotasks();
+    expect(adoptions).toHaveLength(1);
+    expect(typeof adoptions[0]?.onRejected).toBe("function");
   });
 
   it("a RESOLVING async fn is a Defect too — the hazard is the shape, not the outcome", async () => {

--- a/packages/core/src/invariants.spec.ts
+++ b/packages/core/src/invariants.spec.ts
@@ -6,12 +6,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { Do, Err, fromSafePromise, Ok, P, type Result, GetError } from "./index.js";
-
-const boom = new Error("boom");
-const defectOf = (cause: unknown): Result<number, never> =>
-  Ok(0).map<number>(() => {
-    throw cause;
-  });
+import { adoptionProbe, boom, defectOf, flushMicrotasks } from "./test-helpers.js";
 
 describe("Invariant 1: throw inside any combinator becomes a Defect", () => {
   it("every catching combinator converts a thrown callback into a Defect", () => {
@@ -291,72 +286,81 @@ describe("Invariant 6: a DISCARDED thenable is adopted, so its rejection never f
   // mid-flight — and an unhandled rejection is process-fatal on Node by
   // default. Worse for an observer: its whole job is to surface a failure, and
   // this is the one path where the failure would be invisible.
-  const rejecting = () => Promise.reject(new Error("floated"));
-
-  const withRejectionProbe = async (body: () => void): Promise<unknown[]> => {
-    const floated: unknown[] = [];
-    const probe = (reason: unknown): void => {
-      floated.push(reason);
-    };
-    process.on("unhandledRejection", probe);
-    try {
-      body();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      return floated;
-    } finally {
-      process.off("unhandledRejection", probe);
-    }
+  //
+  // Asserted POSITIVELY, via `adoptionProbe`: `Promise.resolve(x)` calls
+  // `x.then(onFulfilled, onRejected)`, so an `onRejected` function arriving at
+  // the fixture is proof the value was adopted. The earlier shape asserted the
+  // *absence* of a global `unhandledRejection` after two `setTimeout(0)`s —
+  // a negative assertion on a timing heuristic, which cannot tell "never fires"
+  // from "fires later than the window", so it could have silently stopped
+  // protecting. This settles in one microtask and depends on no timer.
+  const expectAdopted = async (run: (thenable: PromiseLike<never>) => unknown): Promise<void> => {
+    const { thenable, adoptions } = adoptionProbe();
+    // Awaiting settles an AsyncResult's pipeline (a sync Result is not thenable,
+    // so this is just a microtask turn); the extra flush lets
+    // `Promise.resolve(thenable)` reach the fixture's `then`.
+    await run(thenable);
+    await flushMicrotasks();
+    expect(adoptions).toHaveLength(1);
+    expect(typeof adoptions[0]?.onRejected).toBe("function");
   };
 
   it.each([
-    ["tap", () => Ok(1).tap(rejecting as never)],
-    ["tapDefect", () => defectOf(boom).tapDefect(rejecting as never)],
-    ["tapFailure", () => Err("e" as const).tapFailure(rejecting as never)],
+    ["tap", (t: PromiseLike<never>) => Ok(1).tap((() => t) as never)],
+    ["tapDefect", (t: PromiseLike<never>) => defectOf(boom).tapDefect((() => t) as never)],
+    ["tapFailure", (t: PromiseLike<never>) => Err("e" as const).tapFailure((() => t) as never)],
     [
       "tapErrCases",
-      () =>
+      (t: PromiseLike<never>) =>
         Err("e" as const).tapErrCases(
           // oxlint-disable-next-line unthrown/no-catch-all-pattern -- `E` here is a single type, not a union of cases
-          (m) => m.with(P._, rejecting) as never,
+          (m) => m.with(P._, () => t) as never,
         ),
     ],
-    ["flatMap", () => Ok(1).flatMap(rejecting as never)],
-    ["flatTap", () => Ok(1).flatTap(rejecting as never)],
-    ["bind", () => Do().bind("a", rejecting as never)],
-  ])("%s discards a smuggled thenable without letting it float", async (_label, run) => {
-    const floated = await withRejectionProbe(() => {
-      run();
-    });
-    expect(floated).toEqual([]);
+    ["flatMap", (t: PromiseLike<never>) => Ok(1).flatMap((() => t) as never)],
+    ["flatTap", (t: PromiseLike<never>) => Ok(1).flatTap((() => t) as never)],
+    ["bind", (t: PromiseLike<never>) => Do().bind("a", (() => t) as never)],
+  ])("%s adopts a smuggled thenable rather than dropping it", async (_label, run) => {
+    await expectAdopted(run);
   });
 
   it("the async surface adopts it too", async () => {
-    const floated = await withRejectionProbe(() => {
-      void Ok(1)
+    await expectAdopted((t) =>
+      Ok(1)
         .toAsync()
-        .tap(rejecting as never);
-      void defectOf(boom)
+        .tap((() => t) as never),
+    );
+    await expectAdopted((t) =>
+      defectOf(boom)
         .toAsync()
-        .tapDefect(rejecting as never);
-      void Err("e" as const)
+        .tapDefect((() => t) as never),
+    );
+    await expectAdopted((t) =>
+      Err("e" as const)
         .toAsync()
-        .tapFailure(rejecting as never);
-    });
-    expect(floated).toEqual([]);
+        .tapFailure((() => t) as never),
+    );
   });
 
   it("the observer still passes the original result through unchanged", () => {
     // Silencing must not change the outcome: `tap` observes, it does not decide.
+    const { thenable } = adoptionProbe();
     expect(
       Ok(1)
-        .tap(rejecting as never)
+        .tap((() => thenable) as never)
         .getOr(0),
     ).toBe(1);
     expect(
       Err("e" as const)
-        .tapFailure(rejecting as never)
+        .tapFailure((() => thenable) as never)
         .getOr("fallback"),
     ).toBe("fallback");
+  });
+
+  it("an ordinary, non-thenable return is left alone", () => {
+    // The guard must not adopt everything — only what looks thenable.
+    const { adoptions } = adoptionProbe();
+    Ok(1).tap(() => 42);
+    expect(adoptions).toHaveLength(0);
   });
 });

--- a/packages/core/src/result.spec.ts
+++ b/packages/core/src/result.spec.ts
@@ -1,12 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { Err, Ok, P, type Result } from "./index.js";
-
-const boom = new Error("boom");
-const defectOf = (cause: unknown): Result<number, never> =>
-  Ok(0).map<number>(() => {
-    throw cause;
-  });
+import { boom, defectOf, expectDefect, expectErr, expectOk } from "./test-helpers.js";
 
 describe("Ok() with no argument", () => {
   it("constructs a void success", () => {
@@ -28,8 +23,7 @@ describe("Result.map", () => {
     const f = vi.fn();
     const r = Err<string>("e").map(f);
     expect(f).not.toHaveBeenCalled();
-    expect(r.isErr()).toBe(true);
-    if (r.isErr()) expect(r.error).toBe("e");
+    expectErr(r, "e");
   });
 
   it("passes a Defect through untouched without calling the callback", () => {
@@ -68,8 +62,7 @@ describe("Result.flatMap", () => {
   it("passes Err through and does not call the callback", () => {
     const f = vi.fn();
     const r = Err<string>("e").flatMap(f);
-    expect(r.isErr()).toBe(true);
-    if (r.isErr()) expect(r.error).toBe("e");
+    expectErr(r, "e");
     expect(f).not.toHaveBeenCalled();
   });
 
@@ -129,8 +122,7 @@ describe("Result.flatTap", () => {
 
   it("short-circuits to the effect's Err", () => {
     const r = Ok(5).flatTap(() => Err("denied"));
-    expect(r.isErr()).toBe(true);
-    if (r.isErr()) expect(r.error).toBe("denied");
+    expectErr(r, "denied");
   });
 
   it("propagates a Defect from the effect", () => {
@@ -172,8 +164,7 @@ describe("Result.ensure", () => {
       (n) => n > 0,
       (n) => `neg:${n}`,
     );
-    expect(r.isErr()).toBe(true);
-    if (r.isErr()) expect(r.error).toBe("neg:-2");
+    expectErr(r, "neg:-2");
   });
 
   it("refines the success type with a type-guard predicate", () => {
@@ -189,8 +180,7 @@ describe("Result.ensure", () => {
     const p = vi.fn(() => true);
     const f = vi.fn(() => "e2");
     const e = Err("e").ensure(p, f);
-    expect(e.isErr()).toBe(true);
-    if (e.isErr()) expect(e.error).toBe("e");
+    expectErr(e, "e");
     expect(defectOf(boom).ensure(p, f).isDefect()).toBe(true);
     expect(p).not.toHaveBeenCalled();
     expect(f).not.toHaveBeenCalled();
@@ -227,8 +217,7 @@ describe("Result.as", () => {
 
   it("passes Err and Defect through", () => {
     const r = Err("e").as("x");
-    expect(r.isErr()).toBe(true);
-    if (r.isErr()) expect(r.error).toBe("e");
+    expectErr(r, "e");
     expect(defectOf(boom).as("x").isDefect()).toBe(true);
   });
 });
@@ -240,8 +229,7 @@ describe("Result.discard", () => {
 
   it("passes Err and Defect through", () => {
     const r = Err("e").discard();
-    expect(r.isErr()).toBe(true);
-    if (r.isErr()) expect(r.error).toBe("e");
+    expectErr(r, "e");
     expect(defectOf(boom).discard().isDefect()).toBe(true);
   });
 });
@@ -288,8 +276,7 @@ describe("Result.mapErrCases (matcher)", () => {
     const d = errB("x").mapErrCases((matcher, defect) =>
       matcher.with(P.tag("A"), (e) => e.a).with(P.tag("B"), (_e) => defect(boom)),
     );
-    expect(d.isDefect()).toBe(true);
-    if (d.isDefect()) expect(d.cause).toBe(boom);
+    expectDefect(d, boom);
   });
 
   it("throws NonExhaustiveError → Defect when a value slips past the types", () => {
@@ -301,8 +288,7 @@ describe("Result.mapErrCases (matcher)", () => {
   it("passes Ok through and does not run the matcher", () => {
     const f = vi.fn();
     const r = Ok(1).mapErrCases((matcher) => matcher.with(P._, f));
-    expect(r.isOk()).toBe(true);
-    if (r.isOk()) expect(r.value).toBe(1);
+    expectOk(r, 1);
     expect(f).not.toHaveBeenCalled();
   });
 
@@ -347,8 +333,7 @@ describe("Result.flatMapErrCases (matcher)", () => {
 
   it("a branch may return defect(cause)", () => {
     const d = Err("e").flatMapErrCases((matcher, defect) => matcher.with(P._, (e) => defect(e)));
-    expect(d.isDefect()).toBe(true);
-    if (d.isDefect()) expect(d.cause).toBe("e");
+    expectDefect(d, "e");
   });
 
   it("passes Ok and Defect through without running the matcher", () => {
@@ -417,8 +402,7 @@ describe("Result.recoverErrCases (matcher)", () => {
 
   it("a branch returning defect(cause) stays a Defect (not a recovery)", () => {
     const d = Err("e").recoverErrCases((matcher, defect) => matcher.with(P._, (e) => defect(e)));
-    expect(d.isDefect()).toBe(true);
-    if (d.isDefect()) expect(d.cause).toBe("e");
+    expectDefect(d, "e");
   });
 
   it("converts a throw into a Defect", () => {
@@ -570,18 +554,15 @@ describe("Result.recoverDefect (the only door to a Defect)", () => {
 
   it("replaces a Defect with an Err", () => {
     const r = defectOf(boom).recoverDefect(() => Err("modeled now"));
-    expect(r.isErr()).toBe(true);
-    if (r.isErr()) expect(r.error).toBe("modeled now");
+    expectErr(r, "modeled now");
   });
 
   it("passes Ok and Err through and does not call the callback", () => {
     const f = vi.fn();
     const okR = Ok(1).recoverDefect(f);
-    expect(okR.isOk()).toBe(true);
-    if (okR.isOk()) expect(okR.value).toBe(1);
+    expectOk(okR, 1);
     const errR = Err("e").recoverDefect(f);
-    expect(errR.isErr()).toBe(true);
-    if (errR.isErr()) expect(errR.error).toBe("e");
+    expectErr(errR, "e");
     expect(f).not.toHaveBeenCalled();
   });
 

--- a/packages/core/src/test-helpers.ts
+++ b/packages/core/src/test-helpers.ts
@@ -31,22 +31,40 @@ export const defectOf = (cause: unknown = boom): Result<number, never> =>
     throw cause;
   });
 
-/** Assert `Ok`, and its value, doing the narrowing for you. */
+/**
+ * Assert `Ok`, and its value, doing the narrowing for you. Structural
+ * (`toEqual`), matching `@unthrown/vitest`'s `toBeOkWith` — a success value is
+ * compared by what it is, not by reference. For identity, see
+ * {@link expectDefect}.
+ */
 export function expectOk<T, E>(result: Result<T, E>, value: T): void {
   expect(result.isOk()).toBe(true);
   if (result.isOk()) expect(result.value).toEqual(value);
 }
 
-/** Assert `Err`, and its error, doing the narrowing for you. */
+/**
+ * Assert `Err`, and its error, doing the narrowing for you. Structural
+ * (`toEqual`), matching `@unthrown/vitest`'s `toBeErrWith`.
+ */
 export function expectErr<T, E>(result: Result<T, E>, error: E): void {
   expect(result.isErr()).toBe(true);
   if (result.isErr()) expect(result.error).toEqual(error);
 }
 
-/** Assert a `Defect`, and its cause, doing the narrowing for you. */
+/**
+ * Assert a `Defect`, and its cause, doing the narrowing for you.
+ *
+ * @remarks
+ * Compares by **identity** (`toBe`), unlike {@link expectOk} / {@link expectErr}.
+ * That asymmetry is the point: the ok/err channels carry a *value*, so a
+ * structural compare is the right claim, but the defect channel's contract is
+ * that the ORIGINAL cause survives untouched — `get()` rethrows it with its
+ * original stack. `toEqual` would accept a freshly-built `Error` with the same
+ * message and quietly stop guarding that.
+ */
 export function expectDefect<T, E>(result: Result<T, E>, cause: unknown = boom): void {
   expect(result.isDefect()).toBe(true);
-  if (result.isDefect()) expect(result.cause).toEqual(cause);
+  if (result.isDefect()) expect(result.cause).toBe(cause);
 }
 
 /**

--- a/packages/core/src/test-helpers.ts
+++ b/packages/core/src/test-helpers.ts
@@ -1,0 +1,84 @@
+// Shared fixtures and assertions for core's OWN specs.
+//
+// Core cannot use `@unthrown/vitest` — that package takes core as a peer, so
+// importing it here would be circular. The satellites get to write
+// `expect(r).toBeErrWith("e")`; core had to spell the narrowing dance out by
+// hand at every site:
+//
+//   expect(r.isErr()).toBe(true);
+//   if (r.isErr()) expect(r.error).toBe("e");
+//
+// `expectErr` / `expectOk` / `expectDefect` recover most of that readability
+// without the dependency, and `boom` / `defectOf` stop nine spec files
+// re-declaring the same two fixtures.
+//
+// Not library code: excluded from coverage in `vitest.config.ts`.
+
+import { expect } from "vitest";
+
+import { Ok, type Result } from "./index.js";
+
+/** The stock thrown cause, so specs don't each mint their own. */
+export const boom = new Error("boom");
+
+/**
+ * A Defect-state `Result` carrying `cause`. Going through `map` is deliberate:
+ * a defect has no public constructor, so a throw inside a combinator is the
+ * only way to mint one — which is itself part of what the specs document.
+ */
+export const defectOf = (cause: unknown = boom): Result<number, never> =>
+  Ok(0).map<number>(() => {
+    throw cause;
+  });
+
+/** Assert `Ok`, and its value, doing the narrowing for you. */
+export function expectOk<T, E>(result: Result<T, E>, value: T): void {
+  expect(result.isOk()).toBe(true);
+  if (result.isOk()) expect(result.value).toEqual(value);
+}
+
+/** Assert `Err`, and its error, doing the narrowing for you. */
+export function expectErr<T, E>(result: Result<T, E>, error: E): void {
+  expect(result.isErr()).toBe(true);
+  if (result.isErr()) expect(result.error).toEqual(error);
+}
+
+/** Assert a `Defect`, and its cause, doing the narrowing for you. */
+export function expectDefect<T, E>(result: Result<T, E>, cause: unknown = boom): void {
+  expect(result.isDefect()).toBe(true);
+  if (result.isDefect()) expect(result.cause).toEqual(cause);
+}
+
+/**
+ * A thenable that records how it was adopted, for the "a discarded thenable is
+ * adopted" invariant.
+ *
+ * @remarks
+ * `Promise.resolve(x)` calls `x.then(onFulfilled, onRejected)` — so an
+ * `onRejected` function arriving here is **positive, deterministic proof** that
+ * the value was adopted rather than dropped. It replaces the previous shape,
+ * which asserted the *absence* of a global `unhandledRejection` after two
+ * `setTimeout(0)`s: a negative assertion on a timing heuristic can silently stop
+ * protecting, because a rejection firing later than the window looks identical
+ * to one that never fires. This settles in a single microtask instead.
+ */
+export function adoptionProbe(): {
+  thenable: PromiseLike<never>;
+  adoptions: readonly { onRejected: unknown }[];
+} {
+  const adoptions: { onRejected: unknown }[] = [];
+  const thenable = {
+    // oxlint-disable-next-line no-thenable -- the point of the fixture: it must look thenable to be adopted
+    then(_onFulfilled: unknown, onRejected: unknown) {
+      adoptions.push({ onRejected });
+      // Drive the adopted rejection immediately. Recording alone would only
+      // prove the handler was INSTALLED; invoking it proves it actually
+      // swallows the rejection — still with no timer and no global listener.
+      if (typeof onRejected === "function") (onRejected as (cause: unknown) => void)(boom);
+    },
+  };
+  return { thenable: thenable as unknown as PromiseLike<never>, adoptions };
+}
+
+/** Flush the microtask queue — enough for `Promise.resolve(thenable)` to adopt. */
+export const flushMicrotasks = (): Promise<void> => Promise.resolve();

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -12,8 +12,9 @@ export default defineConfig({
       enabled: true,
       provider: "v8",
       include: ["src/**"],
-      // Type-only tests carry no runtime; they're checked by `tsc`, not coverage.
-      exclude: ["src/**/*.test-d.ts"],
+      // Type-only tests carry no runtime (they are checked by `tsc`), and
+      // `test-helpers.ts` is spec scaffolding, not library code.
+      exclude: ["src/**/*.test-d.ts", "src/test-helpers.ts"],
       // Lock in the full-coverage suite. Branches sit below 100 only because of
       // the deliberately-unreachable defensive `then` rejection path.
       thresholds: {


### PR DESCRIPTION
The four items from the test-quality audit.

> **Process note:** this content was briefly pushed straight to `main`
> (`e960723`) — my mistake, I forgot to branch. CI passed on it, but it bypassed
> review, so `74ca7ff` reverts it on main and this branch re-lands it as a normal
> PR. Nothing else changed between the two.

Context worth keeping: **the suite was already strong** — names describe
behaviour, `vi.fn()` proves callbacks *didn't* run, `invariants.spec.ts` maps 1:1
onto CLAUDE.md, no tautologies. These changes target the parts that could stop
protecting without saying so.

## 1. TSDoc `@example` blocks are compiled

35 in core, and nothing checked any of them. I extracted and typechecked all 35
first: **they all pass today.** The problem is that nothing kept them that way —
and this is the same gap that let the agent skill ship `fromSchema(schema, input)`
for a curried API and describe a Prisma class that had been deleted.

`doc-examples.spec.ts` extracts every ```ts fence under an `@example`, gives it an
import preamble of the whole public surface, and runs `tsc`. Imports resolve to
`src`, so no build step is needed.

Placeholder names (`findUser`, `id`, `Row`) are good documentation, not defects —
they surface as TS2304/7006/18046 and are ignored. Nothing else is, and because
the preamble imports the real surface a **renamed export fails on the import**
rather than as an ignorable TS2304 in the body. There is a guard-on-the-guard
too: if the extraction regex ever stops matching, the count assertion fails
rather than the test passing vacuously.

Verified by breaking a real example — `fromNullable(0)`, dropping the required
`onAbsent` — and watching it fail with `TS2554: Expected 2 arguments, but got 1`.

`@unthrown/prisma`'s 34 examples are the obvious next application.

## 2. The unhandled-rejection probes are gone

Six assertions did `expect(floated).toEqual([])` after two `setTimeout(0)`s. That
is a **negative assertion on a timing window**: it cannot distinguish "never
fires" from "fires later than we waited", so it could have silently stopped
protecting. It also leaned on process-global `process.on("unhandledRejection")`
while vitest runs files in parallel worker threads.

Replaced with `adoptionProbe()`. `Promise.resolve(x)` calls
`x.then(onFulfilled, onRejected)`, so a recording thenable is **positive,
deterministic** proof of adoption — one microtask, no timer, no global listener.

Worth flagging: recording the handler alone made **functions coverage drop**,
because it proved the handler was *installed* but never *ran* it. That is a real
weakening, so the fixture now invokes `onRejected` as well — proving both that it
is installed and that it swallows the rejection. Coverage back to 100% functions,
and the assertion ends up strictly stronger than the timing version it replaced.

All 8 still bite (verified by neutering `silenceIfThenable`), now in 0–2ms.

## 3 + 4. Shared fixtures and a narrowing helper

`boom` was declared in **nine** core spec files and `defectOf` in **five**; both
now come from `src/test-helpers.ts` (excluded from coverage — scaffolding, not
library code).

And 45 sites of

```ts
expect(r.isErr()).toBe(true);
if (r.isErr()) expect(r.error).toBe("e");
```

are now `expectErr(r, "e")`. Core can't use `@unthrown/vitest`'s matchers — that
package takes core as a **peer**, so the import would be circular — so this
recovers most of what the satellites get from `toBeErrWith`. Two sites are
deliberately left alone: they assert something other than plain payload equality.

## Verification

`format --check`, `lint`, `typecheck`, `knip`, `test`, `build` all green. 309
core tests (was 305); core coverage back at functions 100 / lines 100.

CLAUDE.md gains a "Test conventions" entry recording the helper file, the ban on
timing-based absence assertions, and the example gate — so the next change
follows the same shape rather than reintroducing a `setTimeout` probe.
