### PR TITLE
docs: break collapsed chains in examples with a narrower markdown width

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -6,5 +6,13 @@
     "docs/.vitepress/cache/**",
     "docs/.vitepress/dist/**"
   ],
-  "sortImports": true
+  "sortImports": true,
+  "overrides": [
+    {
+      "files": ["**/*.md"],
+      "options": {
+        "printWidth": 80
+      }
+    }
+  ]
 }

--- a/docs/explanation/exhaustive-error-matching.md
+++ b/docs/explanation/exhaustive-error-matching.md
@@ -140,7 +140,9 @@ matcher exists to eliminate.
 result.match({
   ok: (v) => v,
   errCases: (matcher) =>
-    matcher.with(P.tag("NotFound"), () => 404).with(P.tag("Forbidden"), () => 403),
+    matcher
+      .with(P.tag("NotFound"), () => 404)
+      .with(P.tag("Forbidden"), () => 403),
   defect: (cause) => 500,
 });
 ```
@@ -191,7 +193,9 @@ input. There is no way to widen this hole from user code.
 // ❌ Still won't compile — and shouldn't: tag arms can never be shown to cover
 // an unresolved E. Only the catch-all (or a concrete union) can.
 function partial<T, E>(result: Result<T, E>) {
-  return result.mapErrCases((matcher) => matcher.with(P.tag("NotFound"), () => 404));
+  return result.mapErrCases((matcher) =>
+    matcher.with(P.tag("NotFound"), () => 404),
+  );
 }
 ```
 
@@ -233,7 +237,9 @@ of failing.
 const toApiError = <T, E>(result: Result<T, E>): Result<T, ApiError> =>
   result.mapErrCases((matcher) =>
     // oxlint-disable-next-line unthrown/no-catch-all-pattern -- generic in E
-    matcher.returnType<ApiError>().with(P._, (error) => new ApiError({ status: 500, error })),
+    matcher
+      .returnType<ApiError>()
+      .with(P._, (error) => new ApiError({ status: 500, error })),
   );
 ```
 

--- a/docs/explanation/the-defect-channel.md
+++ b/docs/explanation/the-defect-channel.md
@@ -78,7 +78,9 @@ runtime:
 
 ```ts
 // the "boom" branch is what supplies the `U` in `Result<T | U, never>`
-const recovered = d.recoverErrCases((matcher) => matcher.with("boom", () => 99));
+const recovered = d.recoverErrCases((matcher) =>
+  matcher.with("boom", () => 99),
+);
 // type: Result<number, never>
 recovered.isDefect(); // => true — `never` does NOT mean "total"
 ```
@@ -133,7 +135,9 @@ only combinator that can observe a defect, and it re-enters the modeled world by
 returning a `Result`:
 
 ```ts
-d.recoverDefect((cause) => (cause instanceof RangeError ? Err("out_of_range") : Err("unknown")));
+d.recoverDefect((cause) =>
+  cause instanceof RangeError ? Err("out_of_range") : Err("unknown"),
+);
 ```
 
 Use `tapDefect` to observe a defect's cause (e.g. logging) without changing it.

--- a/docs/how-to/combine-parallel-results.md
+++ b/docs/how-to/combine-parallel-results.md
@@ -45,7 +45,9 @@ import { allAsync } from "unthrown";
 const page = allAsync([loadProfile(id), loadPosts(id), loadFollowers(id)]);
 // AsyncResult<[Profile, Post[], User[]], ProfileError>
 
-page.map(([profile, posts, followers]) => renderPage(profile, posts, followers));
+page.map(([profile, posts, followers]) =>
+  renderPage(profile, posts, followers),
+);
 ```
 
 Use `allFromDictAsync` to key the concurrent results by name instead of position.

--- a/docs/how-to/handle-results-at-the-edge.md
+++ b/docs/how-to/handle-results-at-the-edge.md
@@ -28,12 +28,16 @@ import { fromPromise, Err, P } from "unthrown";
 
 const loadProfile = (id: string) =>
   // A network error (a rejected fetch) is unexpected → defect.
-  fromPromise(fetch(`/api/users/${id}`), (c, defect) => defect(c)).flatMap((res) => {
-    if (res.status === 404) return Err(new NotFound({ id }));
-    if (res.status === 403) return Err(new Forbidden());
-    if (!res.ok) throw new Error(`unexpected status ${res.status}`); // → Defect
-    return fromPromise(res.json() as Promise<Profile>, (c, defect) => defect(c)); // malformed JSON → Defect
-  });
+  fromPromise(fetch(`/api/users/${id}`), (c, defect) => defect(c)).flatMap(
+    (res) => {
+      if (res.status === 404) return Err(new NotFound({ id }));
+      if (res.status === 403) return Err(new Forbidden());
+      if (!res.ok) throw new Error(`unexpected status ${res.status}`); // → Defect
+      return fromPromise(res.json() as Promise<Profile>, (c, defect) =>
+        defect(c),
+      ); // malformed JSON → Defect
+    },
+  );
 // AsyncResult<Profile, NotFound | Forbidden>
 
 async function handler(id: string): Promise<HttpResponse> {
@@ -97,7 +101,9 @@ app.get("/users/:id", (c) => {
     errCases: (matcher) =>
       matcher
         .with(P.tag("InvalidId"), () => c.json({ error: "invalid id" }, 400))
-        .with(P.tag("NotFound"), (e) => c.json({ error: `no user ${e.id}` }, 404)),
+        .with(P.tag("NotFound"), (e) =>
+          c.json({ error: `no user ${e.id}` }, 404),
+        ),
     defect: (cause) => {
       logger.error(cause);
       return c.json({ error: "Internal Error" }, 500);

--- a/docs/how-to/interoperate-with-libraries.md
+++ b/docs/how-to/interoperate-with-libraries.md
@@ -58,7 +58,9 @@ declare const loadUser: Effect.Effect<User, NotFound | Timeout>;
 await fromEffect(loadUser).match({
   ok: (user) => user.name,
   errCases: (matcher) =>
-    matcher.with(P.tag("NotFound"), () => "missing").with(P.tag("Timeout"), () => "timed out"),
+    matcher
+      .with(P.tag("NotFound"), () => "missing")
+      .with(P.tag("Timeout"), () => "timed out"),
   defect: String,
 });
 ```

--- a/docs/how-to/lint-your-codebase.md
+++ b/docs/how-to/lint-your-codebase.md
@@ -71,12 +71,22 @@ pin — but **only where the pin declares the error channel**, which is inside a
 
 ```ts
 // result: Result<User, NotFound>
-result.mapErrCases((m) => m.returnType<unknown>().with(P.tag("NotFound"), (e) => e)); // ✗ flagged — this is E
-result.mapErrCases((m) => m.returnType<ApiError>().with(P.tag("NotFound"), () => new ApiError())); // ✓
+result.mapErrCases((m) =>
+  m.returnType<unknown>().with(P.tag("NotFound"), (e) => e),
+); // ✗ flagged — this is E
+result.mapErrCases((m) =>
+  m.returnType<ApiError>().with(P.tag("NotFound"), () => new ApiError()),
+); // ✓
 
-result.recoverErrCases((m) => m.returnType<unknown>().with(P.tag("NotFound"), (e) => e)); // ✓ — the SUCCESS type
+result.recoverErrCases((m) =>
+  m.returnType<unknown>().with(P.tag("NotFound"), (e) => e),
+); // ✓ — the SUCCESS type
 result.tapErrCases((m) => m.returnType<void>().with(P.tag("NotFound"), log)); // ✓ — discarded
-result.match({ ok, defect, errCases: (m) => m.returnType<unknown>().with(P.tag("NotFound"), id) }); // ✓ — a folded value
+result.match({
+  ok,
+  defect,
+  errCases: (m) => m.returnType<unknown>().with(P.tag("NotFound"), id),
+}); // ✓ — a folded value
 ```
 
 `flatMapErrCases` / `flatTapErrCases` need no separate check: their builder output
@@ -240,7 +250,9 @@ compiling as `E` grows and silently absorbs each new case.
 ```ts
 result.mapErrCases((m) => m.with(P._, (e) => e)); // ✗ — the catch-all
 // ✓ — enumerate every case; group cases that share a handler
-result.mapErrCases((m) => m.with(P.tag("NotFound"), P.tag("Forbidden"), (e) => e));
+result.mapErrCases((m) =>
+  m.with(P.tag("NotFound"), P.tag("Forbidden"), (e) => e),
+);
 ```
 
 Because a matched builder must still be exhaustive, removing `P._` makes the

--- a/docs/how-to/migrate-from-boxed.md
+++ b/docs/how-to/migrate-from-boxed.md
@@ -97,7 +97,9 @@ Two honest options:
 ```ts
 // Model it yourself — a small discriminated union, matchable natively
 type ItemState =
-  { tag: "NotAsked" } | { tag: "Loading" } | { tag: "Done"; result: Result<Item, FetchFailed> };
+  | { tag: "NotAsked" }
+  | { tag: "Loading" }
+  | { tag: "Done"; result: Result<Item, FetchFailed> };
 ```
 
 or keep using Boxed's `AsyncData` for view state while the data layer speaks

--- a/docs/how-to/migrate-from-neverthrow.md
+++ b/docs/how-to/migrate-from-neverthrow.md
@@ -72,8 +72,12 @@ app.get("/users/:id", async (req, res) => {
     ok: (view) => res.status(200).json(view),
     errCases: (matcher) =>
       matcher
-        .with(P.tag("NotFound"), () => res.status(404).json({ error: "not found" }))
-        .with(P.tag("Forbidden"), () => res.status(403).json({ error: "forbidden" })),
+        .with(P.tag("NotFound"), () =>
+          res.status(404).json({ error: "not found" }),
+        )
+        .with(P.tag("Forbidden"), () =>
+          res.status(403).json({ error: "forbidden" }),
+        ),
     defect: (cause) => {
       console.error(cause); // everything the pipeline caught lands here
       res.status(500).json({ error: "internal error" });

--- a/docs/how-to/migrate-from-try-catch.md
+++ b/docs/how-to/migrate-from-try-catch.md
@@ -30,7 +30,8 @@ import { fromThrowable } from "unthrown";
 
 const parseConfig = fromThrowable(
   (text: string) => JSON.parse(text) as Config,
-  (cause, defect) => (cause instanceof SyntaxError ? ("invalid_json" as const) : defect(cause)),
+  (cause, defect) =>
+    cause instanceof SyntaxError ? ("invalid_json" as const) : defect(cause),
 );
 // (text: string) => Result<Config, "invalid_json">
 ```
@@ -56,7 +57,8 @@ function getUser(id: string) {
       if (!res.ok) throw new NotFoundError(id);
       return res.json() as Promise<User>;
     }),
-    (cause, defect) => (cause instanceof NotFoundError ? ("not_found" as const) : defect(cause)),
+    (cause, defect) =>
+      cause instanceof NotFoundError ? ("not_found" as const) : defect(cause),
   ); // AsyncResult<User, "not_found">
 }
 ```
@@ -113,7 +115,9 @@ so that is what the arms spell out:
 ```ts
 // before: throw new ConfigError(cause)
 // after:  ConfigError becomes a modeled Err, not a throw
-parseConfig(text).mapErrCases((matcher) => matcher.with("invalid_json", (e) => new ConfigError(e)));
+parseConfig(text).mapErrCases((matcher) =>
+  matcher.with("invalid_json", (e) => new ConfigError(e)),
+);
 ```
 
 `catch-log-rethrow` — log, keep the original error, still propagate as an `Err`:

--- a/docs/how-to/model-errors.md
+++ b/docs/how-to/model-errors.md
@@ -38,7 +38,9 @@ it's reserved (a payload `message` is a compile error, like `name` and `stack`).
 Set it the standard way, **once per subclass**, with `override message`:
 
 ```ts
-class TicketNotFound extends TaggedError("TicketNotFound")<{ ticketId: string }> {
+class TicketNotFound extends TaggedError("TicketNotFound")<{
+  ticketId: string;
+}> {
   override message = "ticket not found";
 }
 
@@ -49,7 +51,10 @@ The field may interpolate the payload via `this` — the base populates the payl
 fields before the subclass field initialiser runs:
 
 ```ts
-class InvalidState extends TaggedError("InvalidState")<{ got: string; want: string }> {
+class InvalidState extends TaggedError("InvalidState")<{
+  got: string;
+  want: string;
+}> {
   override message = `expected ${this.want}, got ${this.got}`;
 }
 ```

--- a/docs/how-to/qualify-a-boundary.md
+++ b/docs/how-to/qualify-a-boundary.md
@@ -104,7 +104,8 @@ import { fromNullable, TaggedError } from "unthrown";
 
 class NotFound extends TaggedError("NotFound")<{ id: string }> {}
 
-const fromCache = (id: string) => fromNullable(cache.get(id), () => new NotFound({ id }));
+const fromCache = (id: string) =>
+  fromNullable(cache.get(id), () => new NotFound({ id }));
 
 fromCache("u_1").map((p) => p.name); // Result<string, NotFound>
 ```
@@ -122,7 +123,9 @@ class InvalidProfile extends TaggedError("InvalidProfile")<{ field: string }> {}
 const parseProfile = fromThrowable(
   (raw: string) => JSON.parse(raw) as Profile,
   (cause, defect) =>
-    cause instanceof SyntaxError ? new InvalidProfile({ field: "json" }) : defect(cause),
+    cause instanceof SyntaxError
+      ? new InvalidProfile({ field: "json" })
+      : defect(cause),
 );
 
 parseProfile('{"name":"Ada"}'); // Result<Profile, InvalidProfile>

--- a/docs/how-to/sequence-dependent-steps.md
+++ b/docs/how-to/sequence-dependent-steps.md
@@ -71,7 +71,9 @@ const profile = await Do()
       c instanceof MissingRowError ? new UserNotFound() : defect(c),
     ),
   )
-  .bind("posts", ({ user }) => fromPromise(fetchPosts(user.id), (c, defect) => defect(c)))
+  .bind("posts", ({ user }) =>
+    fromPromise(fetchPosts(user.id), (c, defect) => defect(c)),
+  )
   .let("count", ({ posts }) => posts.length)
   .match({
     ok: (s) => s,

--- a/docs/how-to/test-with-vitest.md
+++ b/docs/how-to/test-with-vitest.md
@@ -62,7 +62,10 @@ import { expect } from "vitest";
 class NotFound extends TaggedError("NotFound")<{ id: number; msg: string }> {}
 
 // exact — every payload field must match
-expect(Err(new NotFound({ id: 1, msg: "nope" }))).toBeErrTagged("NotFound", { id: 1, msg: "nope" });
+expect(Err(new NotFound({ id: 1, msg: "nope" }))).toBeErrTagged("NotFound", {
+  id: 1,
+  msg: "nope",
+});
 
 // partial — only the listed fields are checked
 expect(Err(new NotFound({ id: 1, msg: "nope" }))).toBeErrTagged(
@@ -81,7 +84,9 @@ class HttpError extends TaggedError("HttpError")<{ status: number }> {
 }
 
 // the payload is `{ status }` — the message is not part of it
-expect(Err(new HttpError({ status: 500 }))).toBeErrTagged("HttpError", { status: 500 });
+expect(Err(new HttpError({ status: 500 }))).toBeErrTagged("HttpError", {
+  status: 500,
+});
 ```
 
 ## Async results — `await` is required

--- a/docs/how-to/use-with-orpc.md
+++ b/docs/how-to/use-with-orpc.md
@@ -197,7 +197,9 @@ const createUser = os
         .tryCreate({ data: input })
         .mapErrCases((matcher) =>
           matcher
-            .with(P.tag("UniqueConstraintViolation"), () => errors.EMAIL_TAKEN())
+            .with(P.tag("UniqueConstraintViolation"), () =>
+              errors.EMAIL_TAKEN(),
+            )
             .with(
               P.tag("ForeignKeyViolation"),
               P.tag("Unavailable"),

--- a/docs/how-to/use-with-prisma.md
+++ b/docs/how-to/use-with-prisma.md
@@ -165,9 +165,15 @@ transaction client `tx`:
 ```ts
 const moved = db.$tryTransaction((tx) =>
   tx.account
-    .tryUpdate({ where: { id: from }, data: { balance: { decrement: amount } } })
+    .tryUpdate({
+      where: { id: from },
+      data: { balance: { decrement: amount } },
+    })
     .flatMap(() =>
-      tx.account.tryUpdate({ where: { id: to }, data: { balance: { increment: amount } } }),
+      tx.account.tryUpdate({
+        where: { id: to },
+        data: { balance: { increment: amount } },
+      }),
     ),
 );
 //    ^? AsyncResult<Account, RecordNotFound | UniqueConstraintViolation | ForeignKeyViolation>
@@ -197,8 +203,10 @@ const page = await db.user
 //    ^? Result<[User[], CursorPaginationMeta], InvalidCursor>
 
 page.match({
-  ok: ([users, meta]) => json({ users, nextCursor: meta.endCursor, hasMore: meta.hasNextPage }),
-  errCases: (matcher) => matcher.with(P.tag("InvalidCursor"), () => badRequest("bad cursor")),
+  ok: ([users, meta]) =>
+    json({ users, nextCursor: meta.endCursor, hasMore: meta.hasNextPage }),
+  errCases: (matcher) =>
+    matcher.with(P.tag("InvalidCursor"), () => badRequest("bad cursor")),
   defect: serverError,
 });
 ```

--- a/docs/how-to/validate-with-standard-schema.md
+++ b/docs/how-to/validate-with-standard-schema.md
@@ -70,11 +70,14 @@ function validateSignup(input: unknown): ValidationResult {
       // oxlint-disable-next-line unthrown/no-catch-all-pattern -- E is a single issues array, not a union
       matcher.with(P._, (issues) => ({
         ok: false as const,
-        fieldErrors: issues.reduce<Record<string, string[]>>((byField, issue) => {
-          const field = fieldOf(issue);
-          (byField[field] ??= []).push(issue.message);
-          return byField;
-        }, {}),
+        fieldErrors: issues.reduce<Record<string, string[]>>(
+          (byField, issue) => {
+            const field = fieldOf(issue);
+            (byField[field] ??= []).push(issue.message);
+            return byField;
+          },
+          {},
+        ),
       })),
     defect: (cause) => {
       logger.error(cause); // the validator itself threw — a real bug, not a bad form

--- a/docs/reference/combinators.md
+++ b/docs/reference/combinators.md
@@ -160,7 +160,12 @@ import { P } from "unthrown";
 
 // log whatever the error is, then let it flow through unchanged
 loadUser(id).tapErrCases((matcher) =>
-  matcher.with(P.tag("NotFound"), P.tag("Forbidden"), P.tag("Unavailable"), (e) => logger.error(e)),
+  matcher.with(
+    P.tag("NotFound"),
+    P.tag("Forbidden"),
+    P.tag("Unavailable"),
+    (e) => logger.error(e),
+  ),
 );
 ```
 
@@ -233,13 +238,17 @@ Use this table to move between the two:
 const status = await findUser(id) // Result<User, NotFound>  (sync)
   .toAsync() // AsyncResult<User, NotFound>
   // the boundary's qualify decides what it adds to E — here, LoadFailed
-  .flatMap((user) => fromPromise(loadOrders(user.id), () => ({ _tag: "LoadFailed" as const })))
+  .flatMap((user) =>
+    fromPromise(loadOrders(user.id), () => ({ _tag: "LoadFailed" as const })),
+  )
   .map((orders) => orders.length) // sync callback, still AsyncResult
   .match({
     ok: (n) => n,
     // the boundary widened E, so both cases are named here
     errCases: (matcher) =>
-      matcher.with(P.tag("NotFound"), () => 0).with(P.tag("LoadFailed"), () => -2),
+      matcher
+        .with(P.tag("NotFound"), () => 0)
+        .with(P.tag("LoadFailed"), () => -2),
     defect: () => -1,
   }); // await collapses it
 ```

--- a/docs/reference/result-surface.md
+++ b/docs/reference/result-surface.md
@@ -120,7 +120,10 @@ Result.all([Result.Ok(1), Result.Ok(2)]);
 
 // AsyncResult.* — everything that yields an AsyncResult
 await AsyncResult.fromPromise(fetchUser(id), (c, defect) => defect(c));
-await AsyncResult.all([AsyncResult.fromSafePromise(loadA()), AsyncResult.fromSafePromise(loadB())]);
+await AsyncResult.all([
+  AsyncResult.fromSafePromise(loadA()),
+  AsyncResult.fromSafePromise(loadB()),
+]);
 ```
 
 The free functions remain the primary, tree-shakeable API; the companions are an
@@ -152,7 +155,9 @@ rules, inputs resolved concurrently (order preserved), and (like every
 ```ts
 import { allAsync, fromSafePromise } from "unthrown";
 
-const [a, b] = (await allAsync([fromSafePromise(loadA()), fromSafePromise(loadB())])).get();
+const [a, b] = (
+  await allAsync([fromSafePromise(loadA()), fromSafePromise(loadB())])
+).get();
 ```
 
 ## Interop constructors

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -97,7 +97,9 @@ const message = parseAge("-3").match({
   // `errCases` receives an exhaustive matcher — one branch per error. It
   // matches plain strings too (no tag required), and a missing case won't compile.
   errCases: (matcher) =>
-    matcher.with("negative", () => "must be positive").with("not_a_number", () => "not a number"),
+    matcher
+      .with("negative", () => "must be positive")
+      .with("not_a_number", () => "not a number"),
   defect: (cause) => {
     console.error(cause); // a bug slipped through — log it, don't leak it
     return "something went wrong";

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -433,7 +433,9 @@
   const toApiError = <T, E>(result: Result<T, E>): Result<T, ApiError> =>
     result.mapErrCases((matcher) =>
       // oxlint-disable-next-line unthrown/no-catch-all-pattern -- generic in `E`: no arm list can prove exhaustiveness
-      matcher.returnType<ApiError>().with(P._, (error) => new ApiError({ status: 500, error })),
+      matcher
+        .returnType<ApiError>()
+        .with(P._, (error) => new ApiError({ status: 500, error })),
     );
   ```
 
@@ -621,7 +623,9 @@ type 'never'`. The `never` receiver now carries a message, so the diagnostic
   ```ts
   const toApiError = <T, E>(result: Result<T, E>): Result<T, ApiError> =>
     result.mapErrCases((matcher) =>
-      matcher.returnType<ApiError>().with(P._, (error) => new ApiError({ status: 500, error })),
+      matcher
+        .returnType<ApiError>()
+        .with(P._, (error) => new ApiError({ status: 500, error })),
     );
   ```
 
@@ -943,7 +947,9 @@ type 'never'`. The `never` receiver now carries a message, so the diagnostic
     ok: (n) => `got ${n}`,
     defect: (cause) => `bug: ${String(cause)}`,
     err: (matcher) =>
-      matcher.with(tag("NotFound"), () => "404").with(tag("Forbidden"), (e) => `403 for ${e.user}`),
+      matcher
+        .with(tag("NotFound"), () => "404")
+        .with(tag("Forbidden"), (e) => `403 for ${e.user}`),
   });
   ```
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -484,7 +484,11 @@ export function defectRes<T, E>(cause: unknown): Result<T, E> {
  *   // `E` is `unknown` here — an untyped boundary has no cases to enumerate,
  *   // so the `P._` escape hatch is the only arm that can terminate the match:
  *   // oxlint-disable-next-line unthrown/no-catch-all-pattern -- untyped boundary: `E` is `unknown`
- *   x.match({ ok: () => 1, errCases: (m) => m.with(P._, () => 0), defect: () => -1 });
+ *   x.match({
+ *     ok: () => 1,
+ *     errCases: (m) => m.with(P._, () => 0),
+ *     defect: () => -1,
+ *   });
  * ```
  *
  * @category Guards

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -104,7 +104,10 @@ export type Result<T, E> = ResultType<T, E>;
  * @example
  * ```ts
  * import { AsyncResult } from "unthrown";
- * const user = await AsyncResult.fromPromise(fetchUser(id), (c, defect) => defect(c));
+ * const user = await AsyncResult.fromPromise(
+ *   fetchUser(id),
+ *   (c, defect) => defect(c),
+ * );
  * user.get(); // => the fetched user (on success)
  * ```
  */

--- a/packages/core/src/interop.ts
+++ b/packages/core/src/interop.ts
@@ -514,7 +514,10 @@ export function allFromDict<R extends ResultRecord>(
  * ```ts
  * import { allAsync, fromSafePromise } from "unthrown";
  *
- * const both = allAsync([fromSafePromise(Promise.resolve(1)), fromSafePromise(Promise.resolve(2))]);
+ * const both = allAsync([
+ *   fromSafePromise(Promise.resolve(1)),
+ *   fromSafePromise(Promise.resolve(2)),
+ * ]);
  * (await both).get(); // => [1, 2]
  * ```
  */

--- a/packages/orpc/README.md
+++ b/packages/orpc/README.md
@@ -39,7 +39,9 @@ const find = os
     handlerResult(({ input, errors }) =>
       repo
         .findPlanet(input.id)
-        .mapErrCases((matcher) => matcher.with(P.tag("NotFound"), () => errors.NOT_FOUND())),
+        .mapErrCases((matcher) =>
+          matcher.with(P.tag("NotFound"), () => errors.NOT_FOUND()),
+        ),
     ),
   );
 ```
@@ -59,7 +61,9 @@ const find = os
   .result(({ input, errors }) =>
     repo
       .findPlanet(input.id)
-      .mapErrCases((matcher) => matcher.with(P.tag("NotFound"), () => errors.NOT_FOUND())),
+      .mapErrCases((matcher) =>
+        matcher.with(P.tag("NotFound"), () => errors.NOT_FOUND()),
+      ),
   );
 ```
 

--- a/packages/orpc/src/server.ts
+++ b/packages/orpc/src/server.ts
@@ -77,7 +77,9 @@ export type ResultHandler<
  *     handlerResult(({ input, errors }) =>
  *       repo
  *         .findPlanet(input.id)
- *         .mapErrCases((matcher) => matcher.with(P.tag("NotFound"), () => errors.NOT_FOUND())),
+ *         .mapErrCases((matcher) =>
+ *           matcher.with(P.tag("NotFound"), () => errors.NOT_FOUND()),
+ *         ),
  *     ),
  *   );
  * ```

--- a/packages/oxlint/CHANGELOG.md
+++ b/packages/oxlint/CHANGELOG.md
@@ -100,7 +100,9 @@
   const toApiError = <T, E>(result: Result<T, E>): Result<T, ApiError> =>
     result.mapErrCases((matcher) =>
       // oxlint-disable-next-line unthrown/no-catch-all-pattern -- generic in `E`: no arm list can prove exhaustiveness
-      matcher.returnType<ApiError>().with(P._, (error) => new ApiError({ status: 500, error })),
+      matcher
+        .returnType<ApiError>()
+        .with(P._, (error) => new ApiError({ status: 500, error })),
     );
   ```
 
@@ -300,7 +302,11 @@
   result.mapErrCases((matcher) =>
     matcher
       .with(tag("NotFound"), () => new ApiError({ status: 404 }))
-      .with(tag("Conflict"), tag("DriverError"), (e) => new ApiError({ status: 500, error: e })),
+      .with(
+        tag("Conflict"),
+        tag("DriverError"),
+        (e) => new ApiError({ status: 500, error: e }),
+      ),
   );
   ```
 
@@ -315,7 +321,9 @@
   const toApiError = <T, E>(result: Result<T, E>): Result<T, ApiError> =>
     result.mapErrCases((matcher) =>
       // oxlint-disable-next-line unthrown/no-catch-all-pattern -- generic in `E`: no arm list can prove exhaustiveness
-      matcher.returnType<ApiError>().with(P._, (error) => new ApiError({ status: 500, error })),
+      matcher
+        .returnType<ApiError>()
+        .with(P._, (error) => new ApiError({ status: 500, error })),
     );
   ```
 

--- a/packages/oxlint/README.md
+++ b/packages/oxlint/README.md
@@ -78,7 +78,9 @@ import { P, type Result } from "unthrown";
 const toApiError = <T, E>(result: Result<T, E>): Result<T, ApiError> =>
   result.mapErrCases((matcher) =>
     // oxlint-disable-next-line unthrown/no-catch-all-pattern -- generic in `E`: no arm list can prove exhaustiveness
-    matcher.returnType<ApiError>().with(P._, (error) => new ApiError({ status: 500, error })),
+    matcher
+      .returnType<ApiError>()
+      .with(P._, (error) => new ApiError({ status: 500, error })),
   );
 ```
 
@@ -92,7 +94,11 @@ import { P } from "unthrown";
 result.mapErrCases((matcher) =>
   matcher
     .with(P.tag("NotFound"), () => new ApiError({ status: 404 }))
-    .with(P.tag("Conflict"), P.tag("DriverError"), (e) => new ApiError({ status: 500, error: e })),
+    .with(
+      P.tag("Conflict"),
+      P.tag("DriverError"),
+      (e) => new ApiError({ status: 500, error: e }),
+    ),
 );
 ```
 

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -80,9 +80,15 @@ await db.user.tryCreate({ data }).match({
 ```ts
 const moved = db.$tryTransaction((tx) =>
   tx.account
-    .tryUpdate({ where: { id: from }, data: { balance: { decrement: amount } } })
+    .tryUpdate({
+      where: { id: from },
+      data: { balance: { decrement: amount } },
+    })
     .flatMap(() =>
-      tx.account.tryUpdate({ where: { id: to }, data: { balance: { increment: amount } } }),
+      tx.account.tryUpdate({
+        where: { id: to },
+        data: { balance: { increment: amount } },
+      }),
     ),
 );
 // Err anywhere → both updates rolled back, and the Err is in `moved`.
@@ -106,14 +112,18 @@ const page = await db.user
 // a compile error.
 
 // Custom serialization (composite keys, non-id cursors):
-const liked = await db.like.tryPaginate({ orderBy: { postId: "asc" } }).withCursor({
-  limit: 20,
-  getCursor: ({ postId, userId }) => `${postId}:${userId}`,
-  parseCursor: (cursor) => {
-    const [postId, userId] = cursor.split(":");
-    return { userId_postId: { postId: Number(postId), userId: Number(userId) } };
-  },
-});
+const liked = await db.like
+  .tryPaginate({ orderBy: { postId: "asc" } })
+  .withCursor({
+    limit: 20,
+    getCursor: ({ postId, userId }) => `${postId}:${userId}`,
+    parseCursor: (cursor) => {
+      const [postId, userId] = cursor.split(":");
+      return {
+        userId_postId: { postId: Number(postId), userId: Number(userId) },
+      };
+    },
+  });
 ```
 
 The raw promise methods stay available on purpose: they are the escape hatch for

--- a/packages/prisma/src/index.ts
+++ b/packages/prisma/src/index.ts
@@ -618,9 +618,13 @@ export const unthrownPrisma = Prisma.defineExtension({
      * @example
      * ```ts
      * const moved = db.$tryTransaction((tx) =>
-     *   tx.account.tryUpdate({ where: { id: from }, data: { balance: { decrement: amount } } })
+     *   tx.account
+     *     .tryUpdate({ where: { id: from }, data: { balance: { decrement: amount } } })
      *     .flatMap(() =>
-     *       tx.account.tryUpdate({ where: { id: to }, data: { balance: { increment: amount } } }),
+     *       tx.account.tryUpdate({
+     *         where: { id: to },
+     *         data: { balance: { increment: amount } },
+     *       }),
      *     ),
      * );
      * // Err anywhere → both updates rolled back, and the Err is in `moved`.

--- a/skills/unthrown/SKILL.md
+++ b/skills/unthrown/SKILL.md
@@ -86,7 +86,8 @@ const user = fromPromise(fetchUser(id), (cause, defect) =>
 // Throwing fn → wrapped fn returning Result (wraps the FUNCTION, not a call)
 const parse = fromThrowable(
   (text: string) => JSON.parse(text) as unknown,
-  (cause, defect) => (cause instanceof SyntaxError ? ("invalid_json" as const) : defect(cause)),
+  (cause, defect) =>
+    cause instanceof SyntaxError ? ("invalid_json" as const) : defect(cause),
 );
 parse("nope"); // => Err("invalid_json")
 
@@ -153,7 +154,9 @@ surrounding `try/catch`:
 const message = result.match({
   ok: (age) => `age is ${age}`,
   errCases: (matcher) =>
-    matcher.with("negative", () => "must be positive").with("not_a_number", () => "not a number"),
+    matcher
+      .with("negative", () => "must be positive")
+      .with("not_a_number", () => "not a number"),
   defect: (cause) => {
     logger.error(cause);
     return "something went wrong";

--- a/skills/unthrown/references/api.md
+++ b/skills/unthrown/references/api.md
@@ -111,8 +111,16 @@ parameter — return it **un-terminated**. Standalone (e.g. matching a whole
   `defect(…)` branch in `flatTapErrCases`.
 - Deliberately unsupported: deep structural inversion, `P.select`, array
   patterns.
-- Matching a whole `Result` works natively:
-  `match(r).with({ tag: "Ok" }, ({ value }) => …).with({ tag: "Err" }, …).with({ tag: "Defect" }, …).exhaustive()`.
+- Matching a whole `Result` works natively — it is a discriminated union:
+
+  ```ts
+  match(r)
+    .with({ tag: "Ok" }, ({ value }) => value)
+    .with({ tag: "Err" }, ({ error }) => fallback(error))
+    .with({ tag: "Defect" }, ({ cause }) => report(cause))
+    .exhaustive();
+  ```
+
 - `NonExhaustiveError` (exported) is thrown when a rogue value slips past the
   types with no matching arm; inside combinators the throw-to-defect net turns
   it into a `Defect`, in `match` it throws.


### PR DESCRIPTION
Matcher chains in the docs were rendering on one line, e.g. in
[Getting started, Step 4](https://btravstack.github.io/unthrown/tutorial/getting-started#step-4-%E2%80%94-handle-every-outcome-with-match):

```ts
errCases: (matcher) =>
  matcher.with("negative", () => "must be positive").with("not_a_number", () => "not a number"),
```

which hides the shape of the very API the example teaches, and overflows the
VitePress content column.

## The cause was the formatter, not the author

oxfmt formats TypeScript **inside markdown fences**, and at the default width
these chains fit on one line. I confirmed it by hand-breaking one and running
`pnpm format` — it collapsed straight back. So this could not be fixed by editing
the examples; it needed a config change.

## Two options, and why this one

| | Effect |
|---|---|
| `embeddedLanguageFormatting: "off"` for `**/*.md` | Hand-formatting sticks — but doc examples stop being formatted **at all**, freezing whatever is there and letting future ones drift |
| **`printWidth: 80` for `**/*.md`** ← chosen | Examples stay auto-formatted, and the broken-out form falls out mechanically, everywhere, for free |

80 also suits the docs' content column better than the 100 used for source, so
examples are less likely to need horizontal scrolling.

Result:

```ts
errCases: (matcher) =>
  matcher
    .with("negative", () => "must be positive")
    .with("not_a_number", () => "not a number"),
```

Grouped patterns benefit too — `matcher.with(P.tag("A"), P.tag("B"), P.tag("C"), handler)`
now puts each pattern on its own line, so the shared handler is visually distinct
from the patterns sharing it.

## Scope

**26 markdown files** reformat — docs site, all package READMEs, the root README,
and the agent skill. I verified only code blocks move: prose and tables are
untouched, since `proseWrap` stays `preserve`.

**TSDoc `@example` blocks are not affected by any of this** — they live inside
comments, and oxfmt leaves them alone (verified). They render into the API
reference on the same site, so I rewrapped the six genuinely over-long *code*
lines there by hand, across core, orpc and prisma.

Lines that are long only because of a trailing `// =>` annotation are
deliberately left alone — wrapping the annotation away from the expression it
annotates makes the example worse, not better. Same reasoning for the two
remaining one-line chains in the docs: both are inline code inside a sentence,
where a line break isn't possible and compactness is the point.

One 110-character inline chain in the skill's API reference became a fenced block
instead, where it can breathe.

## Verification

`format --check`, `lint`, `typecheck`, `knip`, `test`, `build` all green — including
the `doc-examples.spec.ts` gate from #180, which recompiles every TSDoc example, so
the hand-rewrapped ones are proven still valid TypeScript rather than just
plausible-looking.
