### PR TITLE
chore(deps): bump @btravstack/theme to 2.0.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ catalogs:
       specifier: 0.2.1
       version: 0.2.1
     '@btravstack/theme':
-      specifier: 1.7.0
-      version: 1.7.0
+      specifier: 2.0.0
+      version: 2.0.0
     '@btravstack/tsconfig':
       specifier: 0.2.0
       version: 0.2.0
@@ -176,7 +176,7 @@ importers:
     devDependencies:
       '@btravstack/theme':
         specifier: 'catalog:'
-        version: 1.7.0(vitepress@1.6.4(@algolia/client-search@5.55.1)(@types/node@26.1.2)(jiti@2.7.0)(postcss@8.5.25)(tsx@4.23.5)(typescript@6.0.3)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+        version: 2.0.0(vitepress@1.6.4(@algolia/client-search@5.55.1)(@types/node@26.1.2)(jiti@2.7.0)(postcss@8.5.25)(tsx@4.23.5)(typescript@6.0.3)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
       '@btravstack/typedoc':
         specifier: 'catalog:'
         version: 0.1.0(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))(typedoc@0.28.20(typescript@6.0.3))
@@ -637,8 +637,8 @@ packages:
     peerDependencies:
       oxlint: '>=1'
 
-  '@btravstack/theme@1.7.0':
-    resolution: {integrity: sha512-EcBvQruZdsiL/zuNsu7Y1r2FeMDv0J5LZJx7ikO6cFvNRzKCc63A7582gVmfJNQlGJIg0cUCjQXB4Tm1YHtyug==}
+  '@btravstack/theme@2.0.0':
+    resolution: {integrity: sha512-tEhaBntwON0PpDWoSsp1cwxmFAXlBk4sLld2U3/MRKWFxAl8/E0ZHtUyy/Bd5rShi7caI7dwq4PzC0mqh7psJA==}
     peerDependencies:
       vitepress: ^1.6.0
       vue: ^3.3.0
@@ -5059,7 +5059,7 @@ snapshots:
     dependencies:
       oxlint: 1.76.0
 
-  '@btravstack/theme@1.7.0(vitepress@1.6.4(@algolia/client-search@5.55.1)(@types/node@26.1.2)(jiti@2.7.0)(postcss@8.5.25)(tsx@4.23.5)(typescript@6.0.3)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))':
+  '@btravstack/theme@2.0.0(vitepress@1.6.4(@algolia/client-search@5.55.1)(@types/node@26.1.2)(jiti@2.7.0)(postcss@8.5.25)(tsx@4.23.5)(typescript@6.0.3)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))':
     dependencies:
       vitepress: 1.6.4(@algolia/client-search@5.55.1)(@types/node@26.1.2)(jiti@2.7.0)(postcss@8.5.25)(tsx@4.23.5)(typescript@6.0.3)(yaml@2.9.0)
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,7 @@ catalog:
   "@btravstack/commitlint": 0.1.0
   "@btravstack/lefthook": 0.1.1
   "@btravstack/oxlint": 0.2.1
-  "@btravstack/theme": 1.7.0
+  "@btravstack/theme": 2.0.0
   "@btravstack/tsconfig": 0.2.0
   "@btravstack/typedoc": 0.1.0
   "@changesets/cli": 2.31.1


### PR DESCRIPTION
Catalog bump only — no source or style change in this repo.

## Why now

`@btravstack/theme@2.0.0` shipped from btravstack/btravstack.github.io#41, releasing three changesets that had queued up: the new `--pkg-di` accent, plus `--pkg-unthrown` teal and `--pkg-entity` amber, which had been merged but unreleased.

## Is the major breaking here?

No. 2.0.0 is major solely because it removes the retired `--pkg-demesne` and `--pkg-start` tokens — `tokens.css` is a published export, so its custom properties are public API even though the projects they named are gone. Grepping this repo returns **zero** references to either.

This site's own `--accent` (teal `#3fb0a5`) is untouched and already matches its token in the theme, so nothing changes visually.

## Verified

`pnpm install` produces a one-line catalog diff plus the lockfile — pnpm added no pinned `minimumReleaseAgeExclude` entry, since the unversioned `@btravstack/theme` exclusion already covers it.

Docs build clean. In the emitted CSS: `--pkg-di: #3E7FD4` present (proving 2.0.0 actually resolved), both retired tokens absent, and `--accent` still `#3fb0a5`.
