### PR TITLE
feat(vitest): name the call site in forgotten-await failures

### DIFF
--- a/.changeset/forgotten-await-call-site.md
+++ b/.changeset/forgotten-await-call-site.md
@@ -1,0 +1,26 @@
+---
+"@unthrown/vitest": minor
+---
+
+Point forgotten-`await` failures at the line that created the assertion.
+
+The `afterEach` net named the pending matchers but not where they came from, so
+a long spec with several `toBeOk` assertions — or a `test.concurrent` run, where
+the mechanism already disambiguates by test name — left the missing `await` to a
+manual scan.
+
+`settle` now captures an `Error` when it creates the gate, so its stack runs
+through the caller's `expect(...)`. The failure reports the first frame that is
+neither this module nor `node_modules`:
+
+```
+@unthrown/vitest: 1 async assertion(s) (toBeOk) were still pending when the
+test ended — a forgotten `await`. … Created at: loadUser (src/user.spec.ts:42:18).
+```
+
+The location goes in the **message**, since that is the part every reporter
+shows; the full stack is on the error's `cause` for those that render it.
+
+The capture happens only on the **async** path — the one that can be forgotten —
+and V8 formats `.stack` lazily, so a correctly-awaited assertion pays for
+constructing the `Error` and nothing else.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1064,8 +1064,15 @@ channel?**
    `await expect(asyncResult).toBeOk()`. A forgotten `await` is **loud**: the
    matchers track in-flight assertions and a module-registered `afterEach`
    (`failOnForgottenAwait`) fails the test at its end, naming the pending
-   matchers — the abandoned assertion is reported exactly once, correctly
-   attributed, and can never late-fire as an unhandled rejection.
+   matchers **and the call site that created them** — the abandoned assertion is
+   reported exactly once, correctly attributed, and can never late-fire as an
+   unhandled rejection. The call site comes from an `Error` captured in `settle`
+   on the **async path only** (the one that can be forgotten), whose stack is
+   walked past `node_modules` and this module to the first user frame; it lands
+   in the **message**, since that is the part every reporter shows, with the
+   full stack on the error's `cause`. Deliberately not filtered on a `/vitest/`
+   path segment — this package's own sources live under `packages/vitest/`, so
+   that rule would discard the very frame being looked for.
 4. ✅ **The built-in matcher** — Done. `matcher.ts` powers the exhaustive error
    matchers (Thesis #5), exporting `match`/`P`/`NonExhaustiveError` — `P`
    carrying every pattern constructor, `P.tag(t)` (the `{ _tag: t }` pattern)

--- a/docs/how-to/test-with-vitest.md
+++ b/docs/how-to/test-with-vitest.md
@@ -104,8 +104,15 @@ await expect(fromSafePromise(Promise.reject(boom))).toBeDefect();
 ::: danger Don't forget the await
 Always `await expect(asyncResult)…`. As a safety net, importing the package also
 registers an `afterEach` hook: a test that ends with async assertions still pending
-**fails** with an explicit message naming the un-awaited matchers, instead of
-passing silently.
+**fails** with an explicit message naming the un-awaited matchers **and the line
+that created them**, instead of passing silently.
+
+```
+@unthrown/vitest: 1 async assertion(s) (toBeOk) were still pending when the
+test ended — a forgotten `await`. … Created at: loadUser (src/user.spec.ts:42:18).
+```
+
+The full stack is on the error's `cause`, for reporters that render it.
 :::
 
 ## Where to go next

--- a/packages/vitest/src/index.spec.ts
+++ b/packages/vitest/src/index.spec.ts
@@ -156,6 +156,32 @@ describe("forgotten await detection", () => {
     expect(() => failOnForgottenAwait()).not.toThrow();
   });
 
+  it("names the call site of the forgotten assertion, not a library frame", () => {
+    void expect(fromSafePromise(new Promise<number>(() => {}))).toBeOk();
+    let message = "";
+    try {
+      failOnForgottenAwait();
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    // The user's `expect(...)` line — this spec file, with a line number.
+    expect(message).toMatch(/index\.spec\.ts:\d+:\d+/);
+    // …and NOT the matcher machinery that created the gate.
+    expect(message).not.toMatch(/src[/\\]index\.ts:/);
+  });
+
+  it("attaches the assertion-time stack as the error's cause", () => {
+    void expect(fromSafePromise(new Promise<number>(() => {}))).toBeErr();
+    let cause: unknown;
+    try {
+      failOnForgottenAwait();
+    } catch (e) {
+      cause = (e as Error).cause;
+    }
+    expect(cause).toBeInstanceOf(Error);
+    expect((cause as Error).stack).toMatch(/index\.spec\.ts:\d+:\d+/);
+  });
+
   it("names every pending matcher, negated assertions included", () => {
     void expect(fromSafePromise(new Promise<number>(() => {}))).toBeErr();
     void expect(fromSafePromise(new Promise<number>(() => {}))).not.toBeOk();

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -73,8 +73,58 @@ function payloadOf(error: object): Record<string, unknown> {
 // survives a test is a forgotten `await`, which `failOnForgottenAwait` (the
 // `afterEach` hook registered below) turns into a loud, correctly-attributed
 // test failure.
-type InFlight = { matcherName: string; testName: string | undefined; abandon: () => void };
+type InFlight = {
+  matcherName: string;
+  testName: string | undefined;
+  abandon: () => void;
+  // Captured where the gate is created, so its stack runs through the user's
+  // `expect(...)` call. Only ever constructed on the ASYNC path — the one that
+  // can be forgotten — and V8 formats `.stack` lazily, so a correctly-awaited
+  // assertion pays for the capture and nothing more.
+  callSite: Error;
+};
 const inFlight = new Map<Promise<Outcome>, InFlight>();
+
+// The first stack frame that belongs to the user rather than to this matcher
+// module or to the test runner. `expect(...)` reaches `settle` through vitest's
+// chai wrappers, so the frame directly above us is machinery, not the call
+// site; skipping `node_modules` (which is where the runner and chai live) and
+// this module itself lands on the spec file.
+//
+// Deliberately NOT filtering on a `/vitest/` path segment: this package's own
+// sources sit under `packages/vitest/`, so such a rule would discard the very
+// frame we are looking for whenever the caller is a test in this repo.
+//
+// Returns undefined when nothing qualifies (a bundled runner, an exotic stack
+// format), in which case the caller omits the location rather than guessing.
+function callSiteFrame(error: Error): string | undefined {
+  // `?? ""` rather than an early return: `stack` is always populated on V8, so
+  // a guard clause would be an unreachable statement, and an empty string
+  // reaches the same answer (`find` over no frames yields undefined).
+  const stack = error.stack ?? "";
+  // `slice(1)` drops the message line; we construct the Error ourselves with a
+  // single-line message, so every remaining line is a frame.
+  //
+  // `find` rather than a loop with a fallback `return undefined`: in a normal
+  // V8 run the caller's own frame always qualifies, so an explicit fallback
+  // would be an unreachable statement. This way the undefined case falls out of
+  // `find`'s own contract, and an exotic stack format still degrades to
+  // omitting the location rather than naming a library frame as the call site.
+  const frame = stack
+    .split("\n")
+    .slice(1)
+    .map((raw) => raw.trim())
+    .find(
+      (line) =>
+        // The runner and chai live in node_modules; `node:` covers internals.
+        !/node_modules|node:/.test(line) &&
+        // This module — `src/index.ts` from source, `dist/index.[cm]js`
+        // published. `index.spec.ts` does not match: `\.` must be followed by
+        // the extension.
+        !/[/\\](?:src|dist)[/\\]index\.[cm]?[jt]s(?::|$)/.test(line),
+    );
+  return frame?.replace(/^at\s+/, "");
+}
 
 // The slice of vitest's `TestContext` the hook needs: enough of the task tree
 // to rebuild the full test name (`"outer suite > inner suite > test"` — the
@@ -126,6 +176,7 @@ function settle(
     // Which test created the assertion — lets the afterEach hook claim only
     // its own test's forgotten awaits under `test.concurrent`.
     testName: state.currentTestName,
+    callSite: new Error(`@unthrown/vitest: ${matcherName} assertion created here`),
     abandon: () =>
       deliver({
         pass: !state.isNot,
@@ -204,8 +255,29 @@ export function failOnForgottenAwait(context?: HookContext): void {
     entry.abandon();
   }
   const names = claimed.map(([, entry]) => entry.matcherName).join(", ");
+  // Report the call sites in the MESSAGE, not only via `cause`: the message is
+  // the one part every reporter shows, and "you forgot an await" is of little
+  // use without the line. `cause` carries the full stack for anything that
+  // renders it.
+  const sites = [
+    ...new Set(
+      claimed
+        .map(([, entry]) => callSiteFrame(entry.callSite))
+        .filter((site): site is string => site !== undefined),
+    ),
+  ];
+  // `sites` is empty only when no frame qualified — see `callSiteFrame`.
+  /* v8 ignore next */
+  const where = sites.length === 0 ? "" : ` Created at: ${sites.join("; ")}.`;
   throw new Error(
-    `@unthrown/vitest: ${claimed.length} async assertion(s) (${names}) were still pending when the test ended — a forgotten \`await\`. For an AsyncResult the matcher is asynchronous: write \`await expect(asyncResult).toBeOk()\`.`,
+    `@unthrown/vitest: ${claimed.length} async assertion(s) (${names}) were still pending when the test ended — a forgotten \`await\`. For an AsyncResult the matcher is asynchronous: write \`await expect(asyncResult).toBeOk()\`.${where}`,
+    // The first claimed assertion's capture: with several forgotten awaits the
+    // message lists every site, while `cause` gives one full stack to walk.
+    // The `?.` is unreachable — `claimed.length === 0` returned above — and is
+    // here only because `noUncheckedIndexedAccess` types the access as
+    // possibly-undefined.
+    /* v8 ignore next */
+    { cause: claimed[0]?.[1].callSite },
   );
 }
 

--- a/skills/unthrown/references/ecosystem.md
+++ b/skills/unthrown/references/ecosystem.md
@@ -29,7 +29,8 @@ await expect(asyncResult).toBeErrTagged("NotFound", { id: "42" });
 ```
 
 A forgotten `await` on an async assertion fails the test at its end
-(`failOnForgottenAwait`, auto-registered), naming the pending matchers. Manual
+(`failOnForgottenAwait`, auto-registered), naming the pending matchers and the
+call site that created them (full stack on the error's `cause`). Manual
 wiring exports: the seven raw matcher functions, `failOnForgottenAwait`, and the
 `UnthrownMatchers` type.
 


### PR DESCRIPTION
## What & why

Closes #192.

> **Stacked on #213** (`feat/to-be-defect-with`) — both touch `packages/vitest/src/index.ts`. Merge that one first, or retarget this to `main` after it lands.

The forgotten-`await` net named the pending matchers but not where they came from. In a long spec with several `toBeOk` assertions — or under `test.concurrent`, where the mechanism already has to disambiguate by test name — finding the one missing `await` was a manual scan.

`settle` now captures an `Error` where it creates the gate, so its stack runs through the caller's `expect(...)`:

```
@unthrown/vitest: 1 async assertion(s) (toBeOk) were still pending when the
test ended — a forgotten `await`. … Created at: loadUser (src/user.spec.ts:42:18).
```

### The two questions the issue left open

**`cause` vs. inlining a frame — both.** The location goes in the **message**, because that is the one part every reporter shows and "you forgot an await" is of little use without the line. The full `Error` also goes on `cause`, for reporters that render it. Neither alone is right: `cause` gets buried, and a single inlined frame throws away the rest of the stack.

**Trimming library frames — yes.** The reported frame is the first that is neither `node_modules`/`node:` nor this module, so it is the user's `expect(...)` rather than `settle`.

One trap worth recording, which the test caught: the filter deliberately does **not** key on a `/vitest/` path segment. This package's own sources live under `packages/vitest/`, so that rule discards the very frame being looked for whenever the caller is a test in this repo. The `node_modules` check already covers the real runner. The test asserts both directions — the message matches `index.spec.ts:<line>:<col>` and does *not* match `src/index.ts`.

### Cost

The capture happens only on the **async** path — the one that can be forgotten — and V8 formats `.stack` lazily, so a correctly-awaited assertion pays for constructing the `Error` and nothing more.

### Notes

Built test-first; both tests were watched failing (`expected '@unthrown/vitest: 1 async assertion(s…' to match /index\.spec\.ts:\d+:\d+/` and `expected undefined to be an instance of Error`).

Keeping the package's 100% statement/line/function coverage shaped the implementation rather than being patched over with ignores: `callSiteFrame` uses `find` instead of a loop with a fallback `return undefined`, and reads `error.stack ?? ""` instead of an early-return guard — in both cases because on V8 the other path is unreachable, and an unreachable statement is better removed than excused.

## Checklist

- [x] The full gate passes locally: `pnpm format --check && pnpm lint && pnpm typecheck && pnpm knip && pnpm test && pnpm build`
- [x] Added/updated tests (and invariant guards / type-level tests if behaviour changed)
- [x] Added a changeset (`pnpm changeset`) for any user-facing change
- [x] Updated TSDoc and `CLAUDE.md` if the public surface or a design rule changed
- [x] Commits follow Conventional Commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
