### PR TITLE
feat(examples): add runnable example packages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1207,10 +1207,15 @@ onRejected)`, so the fixture records the handler _and invokes it_, proving both
   everything else fails, and a renamed export fails on the _preamble import_ as
   TS2305/TS2724, which is never ignored.
   This extractor stays **core-only** — rolling it out to the satellites is not
-  the direction taken; `@unthrown/prisma` alone carries 81 `@example` blocks,
-  and the runnable `examples/` packages are the repo's actual answer to prose
-  rot for satellite documentation. Those satellite `@example` blocks remain
-  unguarded. `@unthrown/drizzle` takes the same idea from the other end:
+  the direction taken (#191); the runnable `examples/` packages are the repo's
+  answer to prose rot outside core, and the satellites' `@example` blocks
+  remain unguarded. Beware the count that motivated that issue: a naive
+  `grep -c @example packages/prisma/src` reports **81**, but 47 of those are in
+  Prisma's own **generated** client and 30 more are in `index.spec.ts` /
+  `types.test-d.ts`, which the extractor skips by name. The public API surface
+  the extractor would actually see is `index.ts` alone — **4** blocks. The
+  earlier figures in this file (34) and on #191 (~80) were both artefacts of
+  counting generated and test files. `@unthrown/drizzle` takes the same idea from the other end:
   `src/docs-examples.test-d.ts` is a type-level file holding every sample its
   README, its guide page and its `@example` blocks ship, so a sample that stops
   compiling fails the gate. (It caught two live defects when it was written — a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -985,8 +985,27 @@ code: "NOT_FOUND" }, …))`); non-inferable →
   typedoc bases come from the catalog dependencies `@btravstack/tsconfig` and
   `@btravstack/typedoc` (alongside `@btravstack/oxlint`, `@btravstack/commitlint`,
   `@btravstack/lefthook` and the docs' `@btravstack/theme`). There is no
-  `tools/` directory — `pnpm-workspace.yaml` declares only `packages/*` and
-  `docs`.
+  `tools/` directory — `pnpm-workspace.yaml` declares `packages/*`, `examples/*`
+  and `docs`.
+- `examples/*` are **private, runnable examples**, not published packages —
+  `@unthrown/example-checkout-domain`, `@unthrown/example-checkout-persistence`,
+  `@unthrown/example-checkout-api`, modelling one checkout between them so each
+  package can show a different job the library does (the error union and `Do`
+  sequencing; `@unthrown/prisma`'s read/write error shapes; the oRPC edge with
+  no `try`/`catch`). Every guide snippet is hand-written prose, checked by
+  review and nothing else, so it drifts silently; these are workspace packages
+  instead — real imports of `unthrown` and its satellites through their
+  published entry points, typechecked and tested in CI, so a breaking change
+  turns one red rather than leaving a stale snippet uncaught. Each is
+  `private: true` with **no `build` script** — they are consumed as source,
+  never published, so there is nothing to build and no changeset to add.
+  `typecheck` runs on all three; `test` runs where no external infrastructure
+  is required (`checkout-domain` and `checkout-api` are pure; `checkout-persistence`
+  runs against Prisma's in-memory SQLite, the same pattern `@unthrown/prisma`'s
+  own suite uses). Each has an annotated walkthrough in `docs/examples/`, linked
+  from `examples/README.md`. They double as a **conformance fixture** for the
+  dogfooded oxlint preset — `no-catch-all-pattern` included, so none of the
+  three's error matches reaches for `P._`.
 - `docs` → `@unthrown/docs`, the VitePress site (guide + TypeDoc-generated API
   reference). **TypeDoc runs from here, not from the packages** — it needs its
   own TypeScript (see the toolchain section). One `typedoc.<name>.json` per
@@ -1187,8 +1206,11 @@ onRejected)`, so the fixture records the handler _and invokes it_, proving both
   spelling suggestion, which TypeScript 7 adds where a similar name exists);
   everything else fails, and a renamed export fails on the _preamble import_ as
   TS2305/TS2724, which is never ignored.
-  `@unthrown/prisma`'s 34 examples are the obvious next application.
-  `@unthrown/drizzle` takes the same idea from the other end:
+  This extractor stays **core-only** — rolling it out to the satellites is not
+  the direction taken; `@unthrown/prisma` alone carries 81 `@example` blocks,
+  and the runnable `examples/` packages are the repo's actual answer to prose
+  rot for satellite documentation. Those satellite `@example` blocks remain
+  unguarded. `@unthrown/drizzle` takes the same idea from the other end:
   `src/docs-examples.test-d.ts` is a type-level file holding every sample its
   README, its guide page and its `@example` blocks ship, so a sample that stops
   compiling fails the gate. (It caught two live defects when it was written — a

--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ defect, so the edge of your program needs a single `match` and no `try`/`catch`.
 | [`@unthrown/standard-schema`](./packages/standard-schema) | `fromSchema` / `fromSchemaAsync`: any Standard Schema validator into a `Result`.                                                                                  |
 | [`@unthrown/oxlint`](./packages/oxlint)                   | oxlint plugin: `no-ambiguous-error-type`, `no-catch-all-pattern`, `no-unhandled-result`, `no-unused-matcher`, `prefer-async-result`, `no-throw`, `prefer-ensure`. |
 
+## Examples
+
+Three small runnable packages under [`./examples`](./examples) model one
+checkout end to end — the domain, `@unthrown/prisma` persistence, and an oRPC
+edge — each compiled and covered by tests, unlike the snippets above. See the
+[annotated walkthroughs](https://btravstack.github.io/unthrown/examples/).
+
 ## Contributing
 
 This is a pnpm + turbo monorepo. Common tasks:

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -162,6 +162,7 @@ export default defineConfig({
         ],
       },
       { text: "API", link: "/api/" },
+      { text: "Examples", link: "/examples/" },
       {
         text: "Changelog",
         link: "https://github.com/btravstack/unthrown/releases",
@@ -195,6 +196,17 @@ export default defineConfig({
             { text: "@unthrown/prisma", link: "/api/prisma/" },
             { text: "@unthrown/drizzle", link: "/api/drizzle/" },
             { text: "@unthrown/orpc", link: "/api/orpc/" },
+          ],
+        },
+      ],
+      "/examples/": [
+        {
+          text: "Examples",
+          items: [
+            { text: "Overview", link: "/examples/" },
+            { text: "Checkout domain", link: "/examples/checkout-domain" },
+            { text: "Checkout persistence", link: "/examples/checkout-persistence" },
+            { text: "Checkout API", link: "/examples/checkout-api" },
           ],
         },
       ],

--- a/docs/examples/checkout-api.md
+++ b/docs/examples/checkout-api.md
@@ -93,13 +93,34 @@ exception. `createCaller` deliberately routes every call through a real
 `RPCHandler`/`RPCLink` loop (in-memory, no socket) rather than oRPC's
 in-process shortcut, because that collapse only happens once a call crosses a
 genuine transport boundary — the same reason
-[`@unthrown/orpc`'s own suite](https://github.com/btravstack/unthrown/tree/main/packages/orpc/src/index.spec.ts)
+[`@unthrown/orpc`'s own suite](https://github.com/btravstack/unthrown/blob/main/packages/orpc/src/index.spec.ts)
 tests it that way. The payoff: an unmodelled failure still cannot escape as an
 unhandled rejection — it always arrives as a typed, catchable error, just not
 one you were meant to handle in `mapErrCases`.
 
 See [the oRPC guide](../how-to/use-with-orpc) for the full server/client
 bridge.
+
+## A fifth outcome, that is not a domain case at all
+
+`router.ts` also declares `input(z.object({ cartId: z.string().min(1) }))`.
+An empty `cartId` never reaches `placeOrder` — oRPC rejects it during its own
+input validation, before the handler runs at all. The rejection happens to
+carry the same `BAD_REQUEST` code as `CartEmpty` (both were declared in the
+same `.errors({...})` call), but it is not one of `E`'s four cases and no arm
+in `mapErrCases` produced it:
+
+```ts
+await expect(caller.placeOrder({ cartId: "" })).rejects.toMatchObject({
+  code: "BAD_REQUEST",
+  message: "Input validation failed",
+});
+```
+
+The message is the tell — `"Input validation failed"`, not `"cart … has no
+lines"`. A domain's `E` and a transport's input contract are two different
+things that can coincidentally share a status code; only `E` is the one
+`unthrown` makes exhaustive.
 
 ## Where to go next
 

--- a/docs/examples/checkout-api.md
+++ b/docs/examples/checkout-api.md
@@ -10,7 +10,7 @@ description: Serving placeOrder over oRPC with @unthrown/orpc — an exhaustive 
 over oRPC with `@unthrown/orpc`, tested through a real request/response cycle.
 
 ```sh
-pnpm --filter @unthrown/example-checkout-api test
+pnpm turbo run test --filter=@unthrown/example-checkout-api
 ```
 
 ## No `try`/`catch`

--- a/docs/examples/checkout-api.md
+++ b/docs/examples/checkout-api.md
@@ -1,0 +1,104 @@
+---
+title: Checkout API example
+description: Serving placeOrder over oRPC with @unthrown/orpc — an exhaustive mapErrCases at the edge, no try/catch, and a provider outage that collapses to INTERNAL_SERVER_ERROR instead of an unhandled rejection.
+---
+
+# Checkout API
+
+[`examples/checkout-api`](https://github.com/btravstack/unthrown/tree/main/examples/checkout-api)
+— the edge half: [Checkout domain](./checkout-domain)'s `placeOrder` served
+over oRPC with `@unthrown/orpc`, tested through a real request/response cycle.
+
+```sh
+pnpm --filter @unthrown/example-checkout-api test
+```
+
+## No `try`/`catch`
+
+The handler is one `mapErrCases` call — nothing else:
+
+```ts
+handlerResult(({ input, errors }) =>
+  placeOrder(deps, input.cartId).mapErrCases((matcher) =>
+    matcher
+      .with(P.tag("CartNotFound"), (e) =>
+        errors.NOT_FOUND({ message: e.message }),
+      )
+      .with(P.tag("CartEmpty"), (e) =>
+        errors.BAD_REQUEST({ message: e.message }),
+      )
+      .with(P.tag("OutOfStock"), (e) => errors.CONFLICT({ message: e.message }))
+      .with(P.tag("PaymentDeclined"), (e) =>
+        errors.PAYMENT_REQUIRED({ message: e.message }),
+      ),
+  ),
+);
+```
+
+That is safe with no surrounding guard because two things already happened
+upstream. First, `placeOrder`'s own pipeline never lets a thrown callback
+escape — the throw→defect net converts it to a `Defect` before it reaches this
+handler. Second, [`handlerResult`](../how-to/use-with-orpc) is the elimination
+edge: `Ok` becomes the response, a returned `ORPCError` is served as a typed,
+inferable error, and a `Defect` is rethrown onto oRPC's own defect path. There
+is nothing left for a `try`/`catch` to do here.
+
+## Every domain case is named
+
+`placeOrder`'s error channel is `CartNotFound | CartEmpty | OutOfStock |
+PaymentDeclined` — four cases, each with its own `.with(P.tag(...), ...)` arm
+mapping it to a distinct declared `ORPCError`. `P._` is banned by the
+dogfooded `no-catch-all-pattern` lint rule, so there is no wildcard to quietly
+absorb a case that was never handled. Add a fifth error to
+`CheckoutError` and this `mapErrCases` stops compiling — every call site,
+this one included, must add its own arm before the build is green again. The
+tests pin three of the four outcomes as distinctly observable:
+
+```ts
+await expect(caller.placeOrder({ cartId: "nope" })).rejects.toMatchObject({
+  code: "NOT_FOUND",
+});
+await expect(caller.placeOrder({ cartId: "cart_1" })).rejects.toMatchObject({
+  code: "PAYMENT_REQUIRED",
+});
+```
+
+## The defect arm: an outage, not a 500 with a leaked stack trace
+
+The fourth outcome the suite pins is not a domain case at all — it is what
+happens when the payment provider throws instead of returning a
+`PaymentDeclined`:
+
+```ts
+const caller = createCaller(
+  deps({
+    charge: () => {
+      throw new Error("connect ETIMEDOUT");
+    },
+  }),
+);
+await expect(caller.placeOrder({ cartId: "cart_1" })).rejects.toMatchObject({
+  code: "INTERNAL_SERVER_ERROR",
+});
+```
+
+Nothing in `router.ts` names this case, because it is not a business outcome —
+nobody writes domain logic for a severed connection. The throw becomes a
+`Defect` inside `placeOrder`, `handlerResult` rethrows its cause, and oRPC
+collapses it to a generic `INTERNAL_SERVER_ERROR` rather than leaking the raw
+exception. `createCaller` deliberately routes every call through a real
+`RPCHandler`/`RPCLink` loop (in-memory, no socket) rather than oRPC's
+in-process shortcut, because that collapse only happens once a call crosses a
+genuine transport boundary — the same reason
+[`@unthrown/orpc`'s own suite](https://github.com/btravstack/unthrown/tree/main/packages/orpc/src/index.spec.ts)
+tests it that way. The payoff: an unmodelled failure still cannot escape as an
+unhandled rejection — it always arrives as a typed, catchable error, just not
+one you were meant to handle in `mapErrCases`.
+
+See [the oRPC guide](../how-to/use-with-orpc) for the full server/client
+bridge.
+
+## Where to go next
+
+- The modelling half: [Checkout domain](./checkout-domain).
+- The persistence half: [Checkout persistence](./checkout-persistence).

--- a/docs/examples/checkout-api.md
+++ b/docs/examples/checkout-api.md
@@ -52,7 +52,10 @@ dogfooded `no-catch-all-pattern` lint rule, so there is no wildcard to quietly
 absorb a case that was never handled. Add a fifth error to
 `CheckoutError` and this `mapErrCases` stops compiling — every call site,
 this one included, must add its own arm before the build is green again. The
-tests pin three of the four outcomes as distinctly observable:
+tests exercise two of the four domain cases end to end — `CartNotFound` and
+`PaymentDeclined` — each landing on its own distinct `ORPCError` code
+(`CartEmpty` and `OutOfStock` follow the identical pattern and are covered at
+the domain layer already; see [Checkout domain](./checkout-domain)):
 
 ```ts
 await expect(caller.placeOrder({ cartId: "nope" })).rejects.toMatchObject({

--- a/docs/examples/checkout-domain.md
+++ b/docs/examples/checkout-domain.md
@@ -56,6 +56,48 @@ partial fulfilment — and the human string is defined once on the class rather
 than built at each throw site. See
 [Model errors](../how-to/model-errors).
 
+## The trap `reserveAll` avoids
+
+Reserving every line looks like a job for a loop:
+
+```ts
+// ✗ WRONG — silently destroys the defect channel
+for (const line of lines) {
+  const reserved = deps.reserve(line);
+  if (reserved.isErr()) return Err(reserved.error);
+}
+return Ok(lines);
+```
+
+`isErr()` is **false for a `Defect`**. A `Result<void, OutOfStock>` can be in the
+defect state at runtime — the defect variant is never part of `E` — so a
+reservation that blew up on its own account falls straight through this loop and
+gets reported as `Ok`. The failure vanishes.
+
+Folding with `flatMap` is both shorter and correct:
+
+```ts
+lines
+  .reduce<Result<void, OutOfStock>>(
+    (acc, line) => acc.flatMap(() => deps.reserve(line)),
+    Ok(),
+  )
+  .map(() => lines);
+```
+
+`flatMap` short-circuits on `Err` **and** passes a `Defect` through untouched,
+which is the whole reason to reach for the combinator instead of branching by
+hand. It stays lazy too: after a failure the callback is simply not invoked, so
+later lines are never reserved — which
+[`all`](../reference/combinators) could not do, since it takes an
+already-materialised array.
+
+A test pins it:
+
+```ts
+await expect(result).toBeDefectWith(boom);
+```
+
 ## Where to go next
 
 - Store and read it back: [Checkout persistence](./checkout-persistence).

--- a/docs/examples/checkout-domain.md
+++ b/docs/examples/checkout-domain.md
@@ -1,0 +1,60 @@
+---
+title: Checkout domain example
+description: Errors as values in a small checkout domain — a TaggedError union, Do/bind sequencing, and the defect channel, in a package that compiles and is tested.
+---
+
+# Checkout domain
+
+[`examples/checkout-domain`](https://github.com/btravstack/unthrown/tree/main/examples/checkout-domain)
+— the modelling half: the error union, the domain function, and the tests that
+pin both.
+
+```sh
+pnpm --filter @unthrown/example-checkout-domain test
+```
+
+## The signature is the documentation
+
+```ts
+placeOrder(deps, cartId): AsyncResult<Order, CartNotFound | CartEmpty | OutOfStock | PaymentDeclined>;
+```
+
+Four business outcomes, named. A caller can see every way this fails without
+reading the body, and the compiler will not let them forget one.
+
+## What is deliberately _not_ in `E`
+
+The payment provider timing out. It throws, the pipeline catches it, and it
+arrives as a `Defect` — never as an `Err` a caller might mistake for a domain
+outcome. The test pins it:
+
+```ts
+await expect(result).toBeDefect();
+expect(result.isDefect() ? result.cause : undefined).toBe(boom);
+```
+
+The rule is "would you branch on it?" Nobody writes business logic for a severed
+connection; they log it and return 500. Modelling it would force an arm at every
+call site duplicating that same decision.
+
+## Why `OutOfStock` carries fields, not a string
+
+```ts
+export class OutOfStock extends TaggedError("OutOfStock")<{
+  sku: string;
+  requested: number;
+  available: number;
+}> {
+  override message = `${this.requested} × ${this.sku} requested, ${this.available} available`;
+}
+```
+
+The payload is structured so a caller can _use_ it — render `available`, offer a
+partial fulfilment — and the human string is defined once on the class rather
+than built at each throw site. See
+[Model errors](../how-to/model-errors).
+
+## Where to go next
+
+- Store and read it back: [Checkout persistence](./checkout-persistence).
+- Serve it: [Checkout API](./checkout-api).

--- a/docs/examples/checkout-domain.md
+++ b/docs/examples/checkout-domain.md
@@ -10,7 +10,7 @@ description: Errors as values in a small checkout domain — a TaggedError union
 pin both.
 
 ```sh
-pnpm --filter @unthrown/example-checkout-domain test
+pnpm turbo run test --filter=@unthrown/example-checkout-domain
 ```
 
 ## The signature is the documentation

--- a/docs/examples/checkout-domain.md
+++ b/docs/examples/checkout-domain.md
@@ -29,9 +29,11 @@ arrives as a `Defect` — never as an `Err` a caller might mistake for a domain
 outcome. The test pins it:
 
 ```ts
-await expect(result).toBeDefect();
-expect(result.isDefect() ? result.cause : undefined).toBe(boom);
+await expect(result).toBeDefectWith(boom);
 ```
+
+The cause is the original throw, not a wrapper — `bind` is a plain combinator,
+so it mints a `Defect` carrying the thrown value as-is.
 
 The rule is "would you branch on it?" Nobody writes business logic for a severed
 connection; they log it and return 500. Modelling it would force an arm at every

--- a/docs/examples/checkout-persistence.md
+++ b/docs/examples/checkout-persistence.md
@@ -11,7 +11,7 @@ reading the cart from [Checkout domain](./checkout-domain) against a real
 (in-memory) database.
 
 ```sh
-pnpm --filter @unthrown/example-checkout-persistence test
+pnpm turbo run test --filter=@unthrown/example-checkout-persistence
 ```
 
 ## A read infers `E = never`

--- a/docs/examples/checkout-persistence.md
+++ b/docs/examples/checkout-persistence.md
@@ -1,0 +1,71 @@
+---
+title: Checkout persistence example
+description: Storing and reading a checkout with @unthrown/prisma — a read that infers E = never, and a write that carries only the P-codes a caller would branch on.
+---
+
+# Checkout persistence
+
+[`examples/checkout-persistence`](https://github.com/btravstack/unthrown/tree/main/examples/checkout-persistence)
+— the persistence half: a repository built on `@unthrown/prisma`, storing and
+reading the cart from [Checkout domain](./checkout-domain) against a real
+(in-memory) database.
+
+```sh
+pnpm --filter @unthrown/example-checkout-persistence test
+```
+
+## A read infers `E = never`
+
+```ts
+findCart: (cartId: string): AsyncResult<Cart, CartNotFound> =>
+  db.cart
+    .tryFindUnique({ where: { id: cartId }, include: { lines: true } })
+    .flatMap((row) =>
+      row === null ? Err(new CartNotFound({ cartId })) : Ok(/* … */),
+    );
+```
+
+`tryFindUnique` itself is `AsyncResult<Row | null, never>` — a database that
+will not answer at all is a `Defect`, not a domain outcome, so there is no
+error case to name for the query. Absence is `null`. `CartNotFound` is not
+something Prisma raises; it is something _this repository_ introduces by
+turning that `null` into the modeled error `findCart` promises its caller
+(matching `CheckoutDeps["findCart"]` from the domain package). The test pins
+the distinction:
+
+```ts
+await expect(repo.findCart("nope")).toBeErrTagged("CartNotFound", {
+  cartId: "nope",
+});
+```
+
+## A write carries only the P-codes you would branch on
+
+```ts
+saveOrder: (order: { id: string; total: number; cartId: string }) =>
+  db.order.tryCreate({ data: order });
+```
+
+`saveOrder`'s error channel is exactly `UniqueConstraintViolation |
+ForeignKeyViolation | RecordNotFound` — the P-codes a `create` can actually
+raise. The schema's `Order.cartId @unique` makes "one order per cart" a real
+constraint, so a second `saveOrder` for the same cart comes back as a modeled
+`Err`, not a thrown driver exception:
+
+```ts
+await expect(repo.saveOrder({ id: "o1", total: 100, cartId: "c1" })).toBeOk();
+await expect(
+  repo.saveOrder({ id: "o2", total: 100, cartId: "c1" }),
+).toBeErrTagged("UniqueConstraintViolation");
+```
+
+Everything infrastructural — a dropped connection, a pool timeout, a
+deadlock — is deliberately _not_ in either channel. Nobody writes domain logic
+for those; they are a `Defect`, folded once at the edge. See
+[the Prisma guide](../how-to/use-with-prisma) for the full per-operation error
+table.
+
+## Where to go next
+
+- The modelling half: [Checkout domain](./checkout-domain).
+- Serve it: [Checkout API](./checkout-api).

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -17,8 +17,8 @@ covered by tests.** There is no database and no server to start:
 git clone https://github.com/btravstack/unthrown.git
 cd unthrown
 pnpm install
-pnpm --filter "@unthrown/example-*" test
-pnpm --filter "@unthrown/example-*" typecheck
+pnpm turbo run test --filter="@unthrown/example-*"
+pnpm turbo run typecheck --filter="@unthrown/example-*"
 ```
 
 ## [Checkout domain](/examples/checkout-domain)

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -14,9 +14,11 @@ model one small checkout between them, each showing a different job
 covered by tests.** There is no database and no server to start:
 
 ```sh
+git clone https://github.com/btravstack/unthrown.git
+cd unthrown
 pnpm install
-pnpm test
-pnpm typecheck
+pnpm --filter "@unthrown/example-*" test
+pnpm --filter "@unthrown/example-*" typecheck
 ```
 
 ## [Checkout domain](/examples/checkout-domain)
@@ -34,8 +36,9 @@ only the P-codes a caller would actually branch on.
 ## [Checkout API](/examples/checkout-api)
 
 The edge: `placeOrder` served over oRPC with `@unthrown/orpc` — one exhaustive
-`mapErrCases`, a handler with no `try`/`catch`, and a provider outage that
-collapses to `INTERNAL_SERVER_ERROR` instead of an unhandled rejection.
+`mapErrCases`, a handler with no `try`/`catch`, a provider outage that
+collapses to `INTERNAL_SERVER_ERROR` instead of an unhandled rejection, and
+why oRPC's own input validation is a separate concern from `E`.
 
 ## Why these exist as packages rather than snippets
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,49 @@
+---
+title: Examples
+description: Three small packages modelling one checkout — code that compiles and is covered by tests, unlike the snippets in the guide.
+---
+
+# Examples
+
+Annotated tours of the runnable packages under
+[`examples/`](https://github.com/btravstack/unthrown/tree/main/examples). They
+model one small checkout between them, each showing a different job
+`unthrown` does.
+
+**Unlike the snippets elsewhere in this guide, this code compiles and is
+covered by tests.** There is no database and no server to start:
+
+```sh
+pnpm install
+pnpm test
+pnpm typecheck
+```
+
+## [Checkout domain](/examples/checkout-domain)
+
+The error union, `Do`/`bind` sequencing, exhaustive matching, and the defect
+channel — a thrown payment-provider outage becomes a `Defect`, never an `Err`
+a caller might mistake for a modelled outcome.
+
+## [Checkout persistence](/examples/checkout-persistence)
+
+`@unthrown/prisma` on in-memory SQLite: why a read infers `E = never` (absence
+is `null`; a database that will not answer is a defect) and a write carries
+only the P-codes a caller would actually branch on.
+
+## [Checkout API](/examples/checkout-api)
+
+The edge: `placeOrder` served over oRPC with `@unthrown/orpc` — one exhaustive
+`mapErrCases`, a handler with no `try`/`catch`, and a provider outage that
+collapses to `INTERNAL_SERVER_ERROR` instead of an unhandled rejection.
+
+## Why these exist as packages rather than snippets
+
+Every fenced block in the rest of this guide is written by hand. It is
+checked by review and nothing else, so it can drift from the library without
+any build noticing.
+
+These three cannot. They are workspace packages: they typecheck, their specs
+run in CI, and they consume `unthrown` and its satellites through their real
+published entry points rather than a path alias. If the library changes
+underneath them, something goes red.

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,6 +16,6 @@ tests**. There is no database and no server to start:
 
 ```sh
 pnpm install
-pnpm --filter "@unthrown/example-*" test
-pnpm --filter "@unthrown/example-*" typecheck
+pnpm turbo run test --filter="@unthrown/example-*"
+pnpm turbo run typecheck --filter="@unthrown/example-*"
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,21 @@
+# Examples
+
+Three small packages modelling one checkout between them, each showing a
+different job `unthrown` does.
+
+📖 **[Annotated walkthroughs →](https://btravstack.github.io/unthrown/examples/)**
+
+| Package                                          | Shows                                                                                                     |
+| ------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| [`checkout-domain`](./checkout-domain)           | The error union, `Do`/`bind` sequencing, exhaustive matching, and the defect channel.                     |
+| [`checkout-persistence`](./checkout-persistence) | `@unthrown/prisma`: why a read infers `E = never` and a write carries only the codes you branch on.       |
+| [`checkout-api`](./checkout-api)                 | The edge: oRPC's own input validation, one exhaustive `mapErrCases`, and a handler with no `try`/`catch`. |
+
+Unlike the snippets in the guide, **this code compiles and is covered by
+tests**. There is no database and no server to start:
+
+```sh
+pnpm install
+pnpm test
+pnpm typecheck
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,6 +16,6 @@ tests**. There is no database and no server to start:
 
 ```sh
 pnpm install
-pnpm test
-pnpm typecheck
+pnpm --filter "@unthrown/example-*" test
+pnpm --filter "@unthrown/example-*" typecheck
 ```

--- a/examples/checkout-api/package.json
+++ b/examples/checkout-api/package.json
@@ -24,7 +24,6 @@
   "devDependencies": {
     "@btravstack/tsconfig": "catalog:",
     "@types/node": "catalog:",
-    "@unthrown/vitest": "workspace:*",
     "typescript": "catalog:",
     "vitest": "catalog:"
   }

--- a/examples/checkout-api/package.json
+++ b/examples/checkout-api/package.json
@@ -18,7 +18,6 @@
     "@orpc/server": "catalog:",
     "@unthrown/example-checkout-domain": "workspace:*",
     "@unthrown/orpc": "workspace:*",
-    "@unthrown/standard-schema": "workspace:*",
     "unthrown": "workspace:^",
     "zod": "catalog:"
   },

--- a/examples/checkout-api/package.json
+++ b/examples/checkout-api/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@unthrown/example-checkout-api",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Errors as values at the HTTP edge — an oRPC handler with no try/catch",
+  "license": "MIT",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@orpc/client": "catalog:",
+    "@orpc/server": "catalog:",
+    "@unthrown/example-checkout-domain": "workspace:*",
+    "@unthrown/orpc": "workspace:*",
+    "@unthrown/standard-schema": "workspace:*",
+    "unthrown": "workspace:^",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@btravstack/tsconfig": "catalog:",
+    "@types/node": "catalog:",
+    "@unthrown/vitest": "workspace:*",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/examples/checkout-api/src/index.spec.ts
+++ b/examples/checkout-api/src/index.spec.ts
@@ -1,0 +1,57 @@
+import {
+  CartNotFound,
+  PaymentDeclined,
+  type CheckoutDeps,
+} from "@unthrown/example-checkout-domain";
+import { Err, Ok } from "unthrown";
+import { expect, test } from "vitest";
+
+import { createCaller } from "./index.js";
+
+const LINE = { sku: "COFFEE-1KG", quantity: 2, unitPrice: 12_00 };
+
+const deps = (over: Partial<CheckoutDeps> = {}): CheckoutDeps => ({
+  findCart: (id) => Ok({ id, lines: [LINE] }).toAsync(),
+  reserve: () => Ok(undefined),
+  charge: () => Ok({ reference: "pay_123" }).toAsync(),
+  ...over,
+});
+
+test("a placed order comes back as the procedure's output", async () => {
+  const caller = createCaller(deps());
+  const order = await caller.placeOrder({ cartId: "cart_1" });
+  expect(order.total).toBe(24_00);
+});
+
+test("a modelled failure arrives as a typed, inferable ORPCError", async () => {
+  const caller = createCaller(
+    deps({ findCart: (id) => Err(new CartNotFound({ cartId: id })).toAsync() }),
+  );
+  await expect(caller.placeOrder({ cartId: "nope" })).rejects.toMatchObject({
+    code: "NOT_FOUND",
+  });
+});
+
+test("a declined payment maps to its own status, not a generic 500", async () => {
+  const caller = createCaller(
+    deps({ charge: () => Err(new PaymentDeclined({ code: "card_expired" })).toAsync() }),
+  );
+  await expect(caller.placeOrder({ cartId: "cart_1" })).rejects.toMatchObject({
+    code: "PAYMENT_REQUIRED",
+  });
+});
+
+// The payoff: the handler has no try/catch, and an unmodelled failure still
+// cannot escape as an unhandled rejection — it collapses to INTERNAL_SERVER_ERROR.
+test("a provider outage collapses to INTERNAL_SERVER_ERROR", async () => {
+  const caller = createCaller(
+    deps({
+      charge: () => {
+        throw new Error("connect ETIMEDOUT");
+      },
+    }),
+  );
+  await expect(caller.placeOrder({ cartId: "cart_1" })).rejects.toMatchObject({
+    code: "INTERNAL_SERVER_ERROR",
+  });
+});

--- a/examples/checkout-api/src/index.spec.ts
+++ b/examples/checkout-api/src/index.spec.ts
@@ -12,7 +12,7 @@ const LINE = { sku: "COFFEE-1KG", quantity: 2, unitPrice: 12_00 };
 
 const deps = (over: Partial<CheckoutDeps> = {}): CheckoutDeps => ({
   findCart: (id) => Ok({ id, lines: [LINE] }).toAsync(),
-  reserve: () => Ok(undefined),
+  reserve: () => Ok(),
   charge: () => Ok({ reference: "pay_123" }).toAsync(),
   ...over,
 });
@@ -53,5 +53,19 @@ test("a provider outage collapses to INTERNAL_SERVER_ERROR", async () => {
   );
   await expect(caller.placeOrder({ cartId: "cart_1" })).rejects.toMatchObject({
     code: "INTERNAL_SERVER_ERROR",
+    message: "Internal Server Error",
+  });
+});
+
+// oRPC's own input validation is a SEPARATE concern from `E`: `cartId` never
+// even reaches `placeOrder`, so this is not one of the four domain cases —
+// `.errors({ BAD_REQUEST: {} })` happens to share a code with `CartEmpty`,
+// but the message ("Input validation failed", not "cart … has no lines")
+// shows it is oRPC's own contract check, not a returned domain error.
+test("an empty cartId fails oRPC's own input validation, not a domain case", async () => {
+  const caller = createCaller(deps());
+  await expect(caller.placeOrder({ cartId: "" })).rejects.toMatchObject({
+    code: "BAD_REQUEST",
+    message: "Input validation failed",
   });
 });

--- a/examples/checkout-api/src/index.ts
+++ b/examples/checkout-api/src/index.ts
@@ -1,0 +1,47 @@
+// `createCaller` wires the router behind a REAL oRPC request/response cycle —
+// an `RPCHandler` looped straight back into an `RPCLink` via a custom `fetch`,
+// exactly the pattern `packages/orpc/src/index.spec.ts`'s
+// "through a real serialization round-trip" block drives. That is deliberate,
+// not incidental: oRPC only collapses an arbitrary thrown cause into a typed
+// `INTERNAL_SERVER_ERROR` `ORPCError` when a call crosses this transport
+// boundary. `createRouterClient`'s in-process shortcut (used inside
+// `@unthrown/orpc`'s own suite for the `Ok`/`Err` mappings) skips that
+// wrapping and rethrows the raw cause instead — which would leave a payment
+// provider's exception looking like an uncaught `Error` to a caller instead of
+// a `code`-bearing `ORPCError`. Routing every call through the same
+// serialization boundary a real HTTP deployment uses is what makes the
+// "outage collapses to INTERNAL_SERVER_ERROR, never an unhandled rejection"
+// guarantee genuine here rather than an artifact of skipping the wire.
+
+import { createORPCClient } from "@orpc/client";
+import { RPCLink } from "@orpc/client/fetch";
+import type { RouterClient } from "@orpc/server";
+import { RPCHandler } from "@orpc/server/fetch";
+import type { CheckoutDeps } from "@unthrown/example-checkout-domain";
+
+import { createRouter } from "./router.js";
+
+export { createRouter } from "./router.js";
+
+/**
+ * Build a caller for the router, in-memory: a real `RPCHandler` looped back
+ * into an `RPCLink` client with no socket opened. A modelled failure arrives
+ * as a rejected promise carrying the declared `ORPCError` (read `.code`); an
+ * unmodelled one (a thrown exception anywhere in the pipeline) still arrives
+ * as a rejection — never an unhandled rejection — but collapsed to a generic
+ * `INTERNAL_SERVER_ERROR`, its original cause deliberately not leaked over
+ * the wire.
+ */
+export const createCaller = (deps: CheckoutDeps) => {
+  const router = createRouter(deps);
+  const handler = new RPCHandler(router);
+  const link = new RPCLink({
+    url: "/rpc",
+    fetch: async (url, init) => {
+      const request = new Request(new URL(url, "http://in-memory.test"), init);
+      const { response } = await handler.handle(request, { prefix: "/rpc" });
+      return response ?? new Response("no procedure matched", { status: 404 });
+    },
+  });
+  return createORPCClient<RouterClient<typeof router>>(link);
+};

--- a/examples/checkout-api/src/router.ts
+++ b/examples/checkout-api/src/router.ts
@@ -1,0 +1,45 @@
+// The HTTP edge: `placeOrder` served over oRPC via `@unthrown/orpc`'s
+// `handlerResult`. This file is the point of the example — read the handler
+// body first.
+//
+// The load-bearing shape: ONE exhaustive `mapErrCases`, naming every domain
+// case by tag, with no `try`/`catch` anywhere. `handlerResult` already routes
+// `Ok` to the procedure's output and rethrows a `Defect`'s cause onto oRPC's
+// own defect path (which collapses it to `INTERNAL_SERVER_ERROR`), so the
+// handler itself never needs to guard against an unmodelled failure — the
+// throw→defect net upstream in `placeOrder`'s pipeline already turned the
+// payment provider's exception into a `Defect` before it ever reached here.
+//
+// `P._` is banned by the dogfooded oxlint preset (`no-catch-all-pattern`), so
+// every one of the four `CheckoutError` cases must be named. Add a fifth error
+// to the domain's union and this `mapErrCases` stops compiling until it is
+// handled too — that is the payoff of matching exhaustively instead of
+// blanket-handling.
+
+import { os } from "@orpc/server";
+import { placeOrder, type CheckoutDeps } from "@unthrown/example-checkout-domain";
+import { handlerResult } from "@unthrown/orpc/server";
+import { P } from "unthrown";
+import { z } from "zod";
+
+export const createRouter = (deps: CheckoutDeps) => ({
+  placeOrder: os
+    .input(z.object({ cartId: z.string().min(1) }))
+    .errors({
+      NOT_FOUND: {},
+      BAD_REQUEST: {},
+      CONFLICT: {},
+      PAYMENT_REQUIRED: {},
+    })
+    .handler(
+      handlerResult(({ input, errors }) =>
+        placeOrder(deps, input.cartId).mapErrCases((matcher) =>
+          matcher
+            .with(P.tag("CartNotFound"), (e) => errors.NOT_FOUND({ message: e.message }))
+            .with(P.tag("CartEmpty"), (e) => errors.BAD_REQUEST({ message: e.message }))
+            .with(P.tag("OutOfStock"), (e) => errors.CONFLICT({ message: e.message }))
+            .with(P.tag("PaymentDeclined"), (e) => errors.PAYMENT_REQUIRED({ message: e.message })),
+        ),
+      ),
+    ),
+});

--- a/examples/checkout-api/tsconfig.json
+++ b/examples/checkout-api/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@btravstack/tsconfig/base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/examples/checkout-api/vitest.config.ts
+++ b/examples/checkout-api/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+// No coverage thresholds: an example is judged by whether it compiles and its
+// specs pass, not by line coverage of code written to be read.
+export default defineConfig({
+  test: { include: ["src/**/*.spec.ts"] },
+});

--- a/examples/checkout-domain/package.json
+++ b/examples/checkout-domain/package.json
@@ -18,7 +18,6 @@
   },
   "devDependencies": {
     "@btravstack/tsconfig": "catalog:",
-    "@types/node": "catalog:",
     "@unthrown/vitest": "workspace:*",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/examples/checkout-domain/package.json
+++ b/examples/checkout-domain/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@unthrown/example-checkout-domain",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Errors as values in a small checkout domain — the modelling half",
+  "license": "MIT",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "unthrown": "workspace:^"
+  },
+  "devDependencies": {
+    "@btravstack/tsconfig": "catalog:",
+    "@types/node": "catalog:",
+    "@unthrown/vitest": "workspace:*",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/examples/checkout-domain/src/checkout.ts
+++ b/examples/checkout-domain/src/checkout.ts
@@ -49,21 +49,26 @@ const reserveAll = (
  * a bug in `totalOf` — is not in this type, and arrives as a `Defect`.
  *
  * `Do`/`bind` sequences the steps in an accumulating scope, so each step sees
- * the previous ones by name and any `Err` short-circuits the rest.
+ * the previous ones by name and any `Err` short-circuits the rest. `ensure`
+ * validates the cart in place — no separate step just to rename the same
+ * value — widening `E` from `CartNotFound` to `CartNotFound | CartEmpty`.
  */
 export const placeOrder = (
   deps: CheckoutDeps,
   cartId: string,
 ): AsyncResult<Order, CartNotFound | CartEmpty | OutOfStock | PaymentDeclined> =>
   DoAsync()
-    .bind("cart", () => deps.findCart(cartId))
-    .bind("nonEmpty", ({ cart }) =>
-      cart.lines.length === 0 ? Err(new CartEmpty({ cartId })) : Ok(cart.lines),
+    .bind("cart", () =>
+      deps.findCart(cartId).ensure(
+        (c) => c.lines.length > 0,
+        () => new CartEmpty({ cartId }),
+      ),
     )
-    .bind("lines", ({ nonEmpty }) => reserveAll(deps, nonEmpty))
-    .bind("payment", ({ lines }) => deps.charge(totalOf(lines)))
-    .map(({ lines, payment }) => ({
+    .bind("lines", ({ cart }) => reserveAll(deps, cart.lines))
+    .let("total", ({ lines }) => totalOf(lines))
+    .bind("payment", ({ total }) => deps.charge(total))
+    .map(({ lines, payment, total }) => ({
       id: `order_${payment.reference}`,
-      total: totalOf(lines),
+      total,
       lines,
     }));

--- a/examples/checkout-domain/src/checkout.ts
+++ b/examples/checkout-domain/src/checkout.ts
@@ -1,4 +1,4 @@
-import { DoAsync, Err, Ok, type AsyncResult, type Result } from "unthrown";
+import { DoAsync, Ok, type AsyncResult, type Result } from "unthrown";
 
 import { CartEmpty, type CartNotFound, type OutOfStock, type PaymentDeclined } from "./errors.js";
 
@@ -27,19 +27,25 @@ const totalOf = (lines: readonly CartLine[]): number =>
 /**
  * Reserve every line, failing on the first that cannot be met.
  *
- * A plain loop, not an aggregate: `all` would evaluate every line and we want
- * the first failure to stop the walk.
+ * A `flatMap` fold, not an aggregate: `all` takes an already-materialised array,
+ * so every `reserve` would have run before it saw the first failure. Folding
+ * keeps the walk lazy — after a failure the callback is simply not invoked.
+ *
+ * And not a hand-rolled loop either. The obvious version —
+ * `for (…) { if (r.isErr()) return Err(r.error) }` — is **wrong**: `isErr()` is
+ * false for a `Defect`, so a reservation that blew up on its own account would
+ * fall through the loop and be reported as `Ok`, silently destroying the defect
+ * channel. `flatMap` short-circuits on `Err` *and* passes a `Defect` through
+ * untouched, which is the whole reason to reach for the combinator rather than
+ * branch by hand.
  */
 const reserveAll = (
   deps: CheckoutDeps,
   lines: readonly CartLine[],
-): Result<readonly CartLine[], OutOfStock> => {
-  for (const line of lines) {
-    const reserved = deps.reserve(line);
-    if (reserved.isErr()) return Err(reserved.error);
-  }
-  return Ok(lines);
-};
+): Result<readonly CartLine[], OutOfStock> =>
+  lines
+    .reduce<Result<void, OutOfStock>>((acc, line) => acc.flatMap(() => deps.reserve(line)), Ok())
+    .map(() => lines);
 
 /**
  * Place an order for a cart.

--- a/examples/checkout-domain/src/checkout.ts
+++ b/examples/checkout-domain/src/checkout.ts
@@ -1,0 +1,69 @@
+import { DoAsync, Err, Ok, type AsyncResult, type Result } from "unthrown";
+
+import { CartEmpty, type CartNotFound, type OutOfStock, type PaymentDeclined } from "./errors.js";
+
+export type CartLine = { sku: string; quantity: number; unitPrice: number };
+export type Cart = { id: string; lines: readonly CartLine[] };
+export type Order = { id: string; total: number; lines: readonly CartLine[] };
+export type PaymentRef = { reference: string };
+
+/**
+ * The collaborators, injected. Nothing here talks to a database or a network —
+ * that is what makes this example runnable with nothing listening, and it is
+ * also how a real domain layer stays testable.
+ *
+ * `charge` returns an `AsyncResult`, so `placeOrder` is asynchronous; the other
+ * two are synchronous `Result`s. `bind` sequences all three the same way.
+ */
+export type CheckoutDeps = {
+  findCart: (cartId: string) => AsyncResult<Cart, CartNotFound>;
+  reserve: (line: CartLine) => Result<void, OutOfStock>;
+  charge: (amount: number) => AsyncResult<PaymentRef, PaymentDeclined>;
+};
+
+const totalOf = (lines: readonly CartLine[]): number =>
+  lines.reduce((sum, line) => sum + line.quantity * line.unitPrice, 0);
+
+/**
+ * Reserve every line, failing on the first that cannot be met.
+ *
+ * A plain loop, not an aggregate: `all` would evaluate every line and we want
+ * the first failure to stop the walk.
+ */
+const reserveAll = (
+  deps: CheckoutDeps,
+  lines: readonly CartLine[],
+): Result<readonly CartLine[], OutOfStock> => {
+  for (const line of lines) {
+    const reserved = deps.reserve(line);
+    if (reserved.isErr()) return Err(reserved.error);
+  }
+  return Ok(lines);
+};
+
+/**
+ * Place an order for a cart.
+ *
+ * Read the signature first: the error channel names exactly the four business
+ * outcomes. Anything else that can go wrong — the payment provider timing out,
+ * a bug in `totalOf` — is not in this type, and arrives as a `Defect`.
+ *
+ * `Do`/`bind` sequences the steps in an accumulating scope, so each step sees
+ * the previous ones by name and any `Err` short-circuits the rest.
+ */
+export const placeOrder = (
+  deps: CheckoutDeps,
+  cartId: string,
+): AsyncResult<Order, CartNotFound | CartEmpty | OutOfStock | PaymentDeclined> =>
+  DoAsync()
+    .bind("cart", () => deps.findCart(cartId))
+    .bind("nonEmpty", ({ cart }) =>
+      cart.lines.length === 0 ? Err(new CartEmpty({ cartId })) : Ok(cart.lines),
+    )
+    .bind("lines", ({ nonEmpty }) => reserveAll(deps, nonEmpty))
+    .bind("payment", ({ lines }) => deps.charge(totalOf(lines)))
+    .map(({ lines, payment }) => ({
+      id: `order_${payment.reference}`,
+      total: totalOf(lines),
+      lines,
+    }));

--- a/examples/checkout-domain/src/errors.ts
+++ b/examples/checkout-domain/src/errors.ts
@@ -1,0 +1,40 @@
+import { TaggedError } from "unthrown";
+
+/**
+ * The four ways placing an order can fail *as a matter of business*. Each one
+ * is something a caller branches on — which is exactly the test for whether a
+ * failure belongs in `E` at all.
+ *
+ * A payment provider that will not answer is NOT here. Nobody writes domain
+ * logic for a severed TCP connection; they log it and return 500. That is the
+ * defect channel's job, and `placeOrder` demonstrates it.
+ */
+export class CartNotFound extends TaggedError("CartNotFound")<{ cartId: string }> {
+  override message = `no cart ${this.cartId}`;
+}
+
+export class CartEmpty extends TaggedError("CartEmpty")<{ cartId: string }> {
+  override message = `cart ${this.cartId} has no lines`;
+}
+
+/**
+ * The payload is structured, not baked into a string — Thesis #4. The edge can
+ * render `available` in a message; a caller can decide to partially fulfil.
+ * `message` is derived from the fields, defined once here.
+ */
+export class OutOfStock extends TaggedError("OutOfStock")<{
+  sku: string;
+  requested: number;
+  available: number;
+}> {
+  override message = `${this.requested} × ${this.sku} requested, ${this.available} available`;
+}
+
+/** Discriminated on a second axis (`code`), so a matcher can group its arms. */
+export class PaymentDeclined extends TaggedError("PaymentDeclined")<{
+  code: "insufficient_funds" | "card_expired";
+}> {
+  override message = `payment declined (${this.code})`;
+}
+
+export type CheckoutError = CartNotFound | CartEmpty | OutOfStock | PaymentDeclined;

--- a/examples/checkout-domain/src/index.spec.ts
+++ b/examples/checkout-domain/src/index.spec.ts
@@ -19,7 +19,7 @@ const LINE = { sku: "COFFEE-1KG", quantity: 2, unitPrice: 12_00 };
  */
 const deps = (over: Partial<CheckoutDeps> = {}): CheckoutDeps => ({
   findCart: (id) => Ok({ id, lines: [LINE] } satisfies Cart).toAsync(),
-  reserve: () => Ok(undefined),
+  reserve: () => Ok(),
   charge: () => Ok({ reference: "pay_123" }).toAsync(),
   ...over,
 });

--- a/examples/checkout-domain/src/index.spec.ts
+++ b/examples/checkout-domain/src/index.spec.ts
@@ -1,0 +1,101 @@
+import { Err, Ok, P } from "unthrown";
+import { expect, test } from "vitest";
+import "@unthrown/vitest";
+
+import {
+  CartNotFound,
+  OutOfStock,
+  PaymentDeclined,
+  type Cart,
+  type CheckoutDeps,
+  placeOrder,
+} from "./index.js";
+
+const LINE = { sku: "COFFEE-1KG", quantity: 2, unitPrice: 12_00 };
+
+/**
+ * A fully-working set of dependencies. Each test overrides exactly the one it
+ * is about, so the failure under test is unambiguous.
+ */
+const deps = (over: Partial<CheckoutDeps> = {}): CheckoutDeps => ({
+  findCart: (id) => Ok({ id, lines: [LINE] } satisfies Cart).toAsync(),
+  reserve: () => Ok(undefined),
+  charge: () => Ok({ reference: "pay_123" }).toAsync(),
+  ...over,
+});
+
+test("an order is placed when every step succeeds", async () => {
+  const result = await placeOrder(deps(), "cart_1");
+  await expect(result).toBeOk();
+  expect(result.getOrNull()?.total).toBe(24_00);
+});
+
+test("a missing cart surfaces as CartNotFound, not a throw", async () => {
+  const result = await placeOrder(
+    deps({ findCart: (id) => Err(new CartNotFound({ cartId: id })).toAsync() }),
+    "cart_missing",
+  );
+  await expect(result).toBeErrTagged("CartNotFound", { cartId: "cart_missing" });
+});
+
+test("an empty cart is its own case, distinct from a missing one", async () => {
+  const result = await placeOrder(
+    deps({ findCart: (id) => Ok({ id, lines: [] }).toAsync() }),
+    "cart_1",
+  );
+  await expect(result).toBeErrTagged("CartEmpty", { cartId: "cart_1" });
+});
+
+test("OutOfStock carries the structured detail, and the message is built from it", async () => {
+  const result = await placeOrder(
+    deps({
+      reserve: (line) =>
+        Err(new OutOfStock({ sku: line.sku, requested: line.quantity, available: 1 })),
+    }),
+    "cart_1",
+  );
+  await expect(result).toBeErrTagged("OutOfStock", {
+    sku: "COFFEE-1KG",
+    requested: 2,
+    available: 1,
+  });
+  // The message is derived from the payload — read it back through an
+  // exhaustive fold, since there is no "get the error or null" extractor.
+  const message = result.match({
+    ok: () => "",
+    defect: () => "",
+    errCases: (m) =>
+      m
+        .with(P.tag("OutOfStock"), (e) => e.message)
+        .with(P.tag("CartNotFound"), P.tag("CartEmpty"), P.tag("PaymentDeclined"), () => ""),
+  });
+  expect(message).toBe("2 × COFFEE-1KG requested, 1 available");
+});
+
+test("a declined payment keeps its code for the edge to branch on", async () => {
+  const result = await placeOrder(
+    deps({ charge: () => Err(new PaymentDeclined({ code: "card_expired" })).toAsync() }),
+    "cart_1",
+  );
+  await expect(result).toBeErrTagged("PaymentDeclined", { code: "card_expired" });
+});
+
+// THE POINT OF THE WHOLE EXAMPLE: a provider outage is not a modelled failure.
+// It throws, the pipeline catches it, and it arrives as a Defect — never as an
+// `Err` the caller could mistake for a domain outcome.
+test("a payment-provider outage becomes a Defect, not an Err", async () => {
+  const boom = new Error("connect ETIMEDOUT");
+  const result = await placeOrder(
+    deps({
+      charge: () => {
+        throw boom;
+      },
+    }),
+    "cart_1",
+  );
+  await expect(result).toBeDefect();
+  // Assert the cause too — it is the original throw, not a wrapper.
+  // (Once `toBeDefectWith` lands from #213 this collapses to
+  // `await expect(result).toBeDefectWith(boom)`.)
+  expect(result.isDefect() ? result.cause : undefined).toBe(boom);
+});

--- a/examples/checkout-domain/src/index.spec.ts
+++ b/examples/checkout-domain/src/index.spec.ts
@@ -93,9 +93,8 @@ test("a payment-provider outage becomes a Defect, not an Err", async () => {
     }),
     "cart_1",
   );
-  await expect(result).toBeDefect();
-  // Assert the cause too — it is the original throw, not a wrapper.
-  // (Once `toBeDefectWith` lands from #213 this collapses to
-  // `await expect(result).toBeDefectWith(boom)`.)
-  expect(result.isDefect() ? result.cause : undefined).toBe(boom);
+  // The cause is the original throw, not a wrapper: `bind` is a plain
+  // combinator, so it mints a Defect carrying the thrown value as-is. (The
+  // AggregateError wrapping is reserved for the failure *observers*.)
+  await expect(result).toBeDefectWith(boom);
 });

--- a/examples/checkout-domain/src/index.spec.ts
+++ b/examples/checkout-domain/src/index.spec.ts
@@ -72,6 +72,25 @@ test("OutOfStock carries the structured detail, and the message is built from it
   expect(message).toBe("2 × COFFEE-1KG requested, 1 available");
 });
 
+// A `Result<void, OutOfStock>` can be in the DEFECT state at runtime — the
+// defect variant is never part of `E`. A reservation step that blows up on its
+// own account must therefore pass through as a Defect, not be mistaken for
+// success: `isErr()` is false for a Defect, so anything that branches only on
+// `isErr` silently swallows it.
+test("a reservation step that throws surfaces as a Defect, not a silent Ok", async () => {
+  const boom = new Error("stock service exploded");
+  const result = await placeOrder(
+    deps({
+      reserve: () =>
+        Ok().map(() => {
+          throw boom;
+        }),
+    }),
+    "cart_1",
+  );
+  await expect(result).toBeDefectWith(boom);
+});
+
 test("a declined payment keeps its code for the edge to branch on", async () => {
   const result = await placeOrder(
     deps({ charge: () => Err(new PaymentDeclined({ code: "card_expired" })).toAsync() }),

--- a/examples/checkout-domain/src/index.ts
+++ b/examples/checkout-domain/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./checkout.js";
+export * from "./errors.js";

--- a/examples/checkout-domain/tsconfig.json
+++ b/examples/checkout-domain/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@btravstack/tsconfig/base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/examples/checkout-domain/tsconfig.json
+++ b/examples/checkout-domain/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "@btravstack/tsconfig/base.json",
   "compilerOptions": {
-    "rootDir": "./src",
-    "types": ["node"]
+    "rootDir": "./src"
   },
   "include": ["src/**/*"]
 }

--- a/examples/checkout-domain/vitest.config.ts
+++ b/examples/checkout-domain/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+// No coverage thresholds: an example is judged by whether it compiles and its
+// specs pass, not by line coverage of code written to be read.
+export default defineConfig({
+  test: { include: ["src/**/*.spec.ts"] },
+});

--- a/examples/checkout-persistence/.gitignore
+++ b/examples/checkout-persistence/.gitignore
@@ -1,0 +1,4 @@
+# Prisma's generated client for this example — regenerated from
+# prisma/schema.prisma by the test/typecheck scripts (`prisma generate`). Not
+# committed.
+src/generated/

--- a/examples/checkout-persistence/package.json
+++ b/examples/checkout-persistence/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@unthrown/example-checkout-persistence",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Storing and reading a checkout with @unthrown/prisma",
+  "license": "MIT",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "generate": "prisma generate",
+    "test": "prisma generate && vitest run",
+    "typecheck": "prisma generate && tsc --noEmit"
+  },
+  "dependencies": {
+    "@unthrown/example-checkout-domain": "workspace:*",
+    "@unthrown/prisma": "workspace:*",
+    "unthrown": "workspace:^"
+  },
+  "devDependencies": {
+    "@btravstack/tsconfig": "catalog:",
+    "@prisma/adapter-better-sqlite3": "catalog:",
+    "@prisma/client": "catalog:",
+    "@types/node": "catalog:",
+    "@unthrown/vitest": "workspace:*",
+    "better-sqlite3": "catalog:",
+    "prisma": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/examples/checkout-persistence/prisma/schema.prisma
+++ b/examples/checkout-persistence/prisma/schema.prisma
@@ -1,0 +1,31 @@
+// Generated into src/generated (gitignored) by the test/typecheck scripts —
+// the same arrangement packages/prisma uses for its own test client.
+
+generator client {
+  provider = "prisma-client"
+  output   = "../src/generated/prisma"
+}
+
+datasource db {
+  provider = "sqlite"
+}
+
+model Cart {
+  id    String     @id
+  lines CartLine[]
+}
+
+model CartLine {
+  id        Int    @id @default(autoincrement())
+  sku       String
+  quantity  Int
+  unitPrice Int
+  cart      Cart   @relation(fields: [cartId], references: [id])
+  cartId    String
+}
+
+model Order {
+  id     String @id
+  total  Int
+  cartId String @unique
+}

--- a/examples/checkout-persistence/src/index.spec.ts
+++ b/examples/checkout-persistence/src/index.spec.ts
@@ -1,0 +1,38 @@
+import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
+import { beforeEach, expect, test } from "vitest";
+import "@unthrown/vitest";
+
+import { PrismaClient } from "./generated/prisma/client.js";
+import { createRepository } from "./index.js";
+
+// The test schema's tables, created by hand (no Migrate): an in-memory
+// database is born empty, and DDL-by-hand keeps the suite free of any
+// migration engine — the same approach packages/prisma's own suite uses.
+const DDL = [
+  `CREATE TABLE "Cart" ("id" TEXT PRIMARY KEY)`,
+  `CREATE TABLE "CartLine" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "sku" TEXT NOT NULL, "quantity" INTEGER NOT NULL, "unitPrice" INTEGER NOT NULL, "cartId" TEXT NOT NULL)`,
+  `CREATE TABLE "Order" ("id" TEXT PRIMARY KEY, "total" INTEGER NOT NULL, "cartId" TEXT NOT NULL)`,
+  `CREATE UNIQUE INDEX "Order_cartId_key" ON "Order"("cartId")`,
+];
+
+// An in-memory database per test: no file, no server, nothing to clean up.
+const client = () => new PrismaClient({ adapter: new PrismaBetterSqlite3({ url: ":memory:" }) });
+
+let repo: ReturnType<typeof createRepository>;
+
+beforeEach(async () => {
+  const db = client();
+  for (const stmt of DDL) await db.$executeRawUnsafe(stmt);
+  repo = createRepository(db);
+});
+
+test("a missing cart is a modelled CartNotFound, not a defect", async () => {
+  await expect(repo.findCart("nope")).toBeErrTagged("CartNotFound", { cartId: "nope" });
+});
+
+test("saving the same cart's order twice is a modelled unique violation", async () => {
+  await expect(repo.saveOrder({ id: "o1", total: 100, cartId: "c1" })).toBeOk();
+  await expect(repo.saveOrder({ id: "o2", total: 100, cartId: "c1" })).toBeErrTagged(
+    "UniqueConstraintViolation",
+  );
+});

--- a/examples/checkout-persistence/src/index.spec.ts
+++ b/examples/checkout-persistence/src/index.spec.ts
@@ -1,5 +1,5 @@
 import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
-import { beforeEach, expect, test } from "vitest";
+import { afterEach, beforeEach, expect, test } from "vitest";
 import "@unthrown/vitest";
 
 import { PrismaClient } from "./generated/prisma/client.js";
@@ -15,19 +15,49 @@ const DDL = [
   `CREATE UNIQUE INDEX "Order_cartId_key" ON "Order"("cartId")`,
 ];
 
-// An in-memory database per test: no file, no server, nothing to clean up.
+// An in-memory database per test: no file, no server, nothing to clean up
+// beyond the client itself — see the `afterEach` below. Copying this fixture
+// into a server-backed suite without that teardown would leak a connection
+// per test.
 const client = () => new PrismaClient({ adapter: new PrismaBetterSqlite3({ url: ":memory:" }) });
 
+let db: PrismaClient;
 let repo: ReturnType<typeof createRepository>;
 
 beforeEach(async () => {
-  const db = client();
+  db = client();
   for (const stmt of DDL) await db.$executeRawUnsafe(stmt);
   repo = createRepository(db);
 });
 
+afterEach(async () => {
+  await db.$disconnect();
+});
+
 test("a missing cart is a modelled CartNotFound, not a defect", async () => {
   await expect(repo.findCart("nope")).toBeErrTagged("CartNotFound", { cartId: "nope" });
+});
+
+test("a found cart maps every line back, including unitPrice", async () => {
+  await db.cart.create({
+    data: {
+      id: "cart_1",
+      lines: {
+        create: [
+          { sku: "COFFEE-1KG", quantity: 2, unitPrice: 12_00 },
+          { sku: "MUG", quantity: 1, unitPrice: 5_00 },
+        ],
+      },
+    },
+  });
+
+  await expect(repo.findCart("cart_1")).toBeOkWith({
+    id: "cart_1",
+    lines: [
+      { sku: "COFFEE-1KG", quantity: 2, unitPrice: 12_00 },
+      { sku: "MUG", quantity: 1, unitPrice: 5_00 },
+    ],
+  });
 });
 
 test("saving the same cart's order twice is a modelled unique violation", async () => {

--- a/examples/checkout-persistence/src/index.ts
+++ b/examples/checkout-persistence/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./repository.js";

--- a/examples/checkout-persistence/src/repository.ts
+++ b/examples/checkout-persistence/src/repository.ts
@@ -1,4 +1,4 @@
-import { CartNotFound, type Cart } from "@unthrown/example-checkout-domain";
+import { CartNotFound, type Cart, type CheckoutDeps } from "@unthrown/example-checkout-domain";
 import { unthrownPrisma } from "@unthrown/prisma";
 import { Err, Ok, type AsyncResult } from "unthrown";
 
@@ -12,11 +12,15 @@ import type { PrismaClient } from "./generated/prisma/client.js";
 export const createRepository = (client: PrismaClient) => {
   const db = client.$extends(unthrownPrisma);
 
-  return {
+  const repository = {
     /**
      * A READ has `E = never`: absence is `null`, and a database that will not
      * answer is a defect, not a domain outcome. So the only modelled failure
      * here is the one *we* introduce — the row being absent.
+     *
+     * The `satisfies Pick<CheckoutDeps, "findCart">` below makes the claim
+     * that this matches the domain's `CheckoutDeps["findCart"]` a
+     * compiler-checked fact rather than prose — see the persistence guide.
      */
     findCart: (cartId: string): AsyncResult<Cart, CartNotFound> =>
       db.cart.tryFindUnique({ where: { id: cartId }, include: { lines: true } }).flatMap((row) =>
@@ -33,11 +37,21 @@ export const createRepository = (client: PrismaClient) => {
       ),
 
     /**
-     * A WRITE carries the P-codes a caller would branch on. Here that is
-     * `UniqueConstraintViolation` — one order per cart — which the type forces
-     * every caller to handle.
+     * A WRITE carries the P-codes a caller would branch on: here that is
+     * `UniqueConstraintViolation` (one order per cart), `ForeignKeyViolation`,
+     * and `RecordNotFound` — `create` always carries the latter because a
+     * nested `connect` to a non-existent record raises P2025. The type forces
+     * every caller to handle all three.
+     *
+     * Note this does NOT compose with the domain's `Order` type
+     * (`{ id, total, lines }`) the way `findCart` composes with `Cart` —
+     * `saveOrder` takes `{ id, total, cartId }`, a persistence-shaped input,
+     * not the domain's `placeOrder` output. The two packages share error
+     * vocabulary, not a write-side data path.
      */
     saveOrder: (order: { id: string; total: number; cartId: string }) =>
       db.order.tryCreate({ data: order }),
   };
+
+  return repository satisfies Pick<CheckoutDeps, "findCart">;
 };

--- a/examples/checkout-persistence/src/repository.ts
+++ b/examples/checkout-persistence/src/repository.ts
@@ -1,0 +1,43 @@
+import { CartNotFound, type Cart } from "@unthrown/example-checkout-domain";
+import { unthrownPrisma } from "@unthrown/prisma";
+import { Err, Ok, type AsyncResult } from "unthrown";
+
+import type { PrismaClient } from "./generated/prisma/client.js";
+
+/**
+ * The extension adds a `try*` twin to every delegate operation, each returning
+ * an `AsyncResult` whose error channel is exactly the domain outcomes that
+ * operation can raise — and nothing else.
+ */
+export const createRepository = (client: PrismaClient) => {
+  const db = client.$extends(unthrownPrisma);
+
+  return {
+    /**
+     * A READ has `E = never`: absence is `null`, and a database that will not
+     * answer is a defect, not a domain outcome. So the only modelled failure
+     * here is the one *we* introduce — the row being absent.
+     */
+    findCart: (cartId: string): AsyncResult<Cart, CartNotFound> =>
+      db.cart.tryFindUnique({ where: { id: cartId }, include: { lines: true } }).flatMap((row) =>
+        row === null
+          ? Err(new CartNotFound({ cartId }))
+          : Ok({
+              id: row.id,
+              lines: row.lines.map((line) => ({
+                sku: line.sku,
+                quantity: line.quantity,
+                unitPrice: line.unitPrice,
+              })),
+            } satisfies Cart),
+      ),
+
+    /**
+     * A WRITE carries the P-codes a caller would branch on. Here that is
+     * `UniqueConstraintViolation` — one order per cart — which the type forces
+     * every caller to handle.
+     */
+    saveOrder: (order: { id: string; total: number; cartId: string }) =>
+      db.order.tryCreate({ data: order }),
+  };
+};

--- a/examples/checkout-persistence/tsconfig.json
+++ b/examples/checkout-persistence/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@btravstack/tsconfig/base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "types": ["node"],
+    // The generated Prisma client (src/generated, gitignored) imports its own
+    // files with explicit `.ts` extensions; `noEmit` in the base config makes
+    // this legal.
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "src/generated"]
+}

--- a/examples/checkout-persistence/vitest.config.ts
+++ b/examples/checkout-persistence/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+// No coverage thresholds: an example is judged by whether it compiles and its
+// specs pass, not by line coverage of code written to be read.
+export default defineConfig({
+  test: { include: ["src/**/*.spec.ts"] },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,9 +245,6 @@ importers:
       '@btravstack/tsconfig':
         specifier: 'catalog:'
         version: 0.2.0
-      '@types/node':
-        specifier: 'catalog:'
-        version: 26.1.2
       '@unthrown/vitest':
         specifier: workspace:*
         version: link:../../packages/vitest

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,9 +216,6 @@ importers:
       '@unthrown/orpc':
         specifier: workspace:*
         version: link:../../packages/orpc
-      '@unthrown/standard-schema':
-        specifier: workspace:*
-        version: link:../../packages/standard-schema
       unthrown:
         specifier: workspace:^
         version: link:../../packages/core

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,7 +140,7 @@ importers:
     devDependencies:
       '@btravstack/commitlint':
         specifier: 'catalog:'
-        version: 0.1.0(@commitlint/cli@21.2.1(@types/node@26.1.1)(conventional-commits-parser@7.1.0)(typescript@7.0.2))
+        version: 0.1.0(@commitlint/cli@21.2.1(@types/node@26.1.2)(conventional-commits-parser@7.1.0)(typescript@7.0.2))
       '@btravstack/lefthook':
         specifier: 'catalog:'
         version: 0.1.1(lefthook@2.1.10)
@@ -149,10 +149,10 @@ importers:
         version: 0.2.1(oxlint@1.76.0)
       '@changesets/cli':
         specifier: 'catalog:'
-        version: 2.31.1(@types/node@26.1.1)
+        version: 2.31.1(@types/node@26.1.2)
       '@commitlint/cli':
         specifier: 'catalog:'
-        version: 21.2.1(@types/node@26.1.1)(conventional-commits-parser@7.1.0)(typescript@7.0.2)
+        version: 21.2.1(@types/node@26.1.2)(conventional-commits-parser@7.1.0)(typescript@7.0.2)
       '@unthrown/oxlint':
         specifier: workspace:*
         version: link:packages/oxlint
@@ -198,6 +198,28 @@ importers:
       vitepress:
         specifier: 'catalog:'
         version: 1.6.4(@algolia/client-search@5.55.1)(@types/node@26.1.2)(jiti@2.7.0)(postcss@8.5.25)(tsx@4.23.5)(typescript@6.0.3)(yaml@2.9.0)
+
+  examples/checkout-domain:
+    dependencies:
+      unthrown:
+        specifier: workspace:^
+        version: link:../../packages/core
+    devDependencies:
+      '@btravstack/tsconfig':
+        specifier: 'catalog:'
+        version: 0.2.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 26.1.2
+      '@unthrown/vitest':
+        specifier: workspace:*
+        version: link:../../packages/vitest
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0)
 
   packages/boxed:
     dependencies:
@@ -2336,9 +2358,6 @@ packages:
 
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
-
-  '@types/node@26.1.1':
-    resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
 
   '@types/node@26.1.2':
     resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
@@ -5046,9 +5065,9 @@ snapshots:
     optionalDependencies:
       typescript: 7.0.2
 
-  '@btravstack/commitlint@0.1.0(@commitlint/cli@21.2.1(@types/node@26.1.1)(conventional-commits-parser@7.1.0)(typescript@7.0.2))':
+  '@btravstack/commitlint@0.1.0(@commitlint/cli@21.2.1(@types/node@26.1.2)(conventional-commits-parser@7.1.0)(typescript@7.0.2))':
     dependencies:
-      '@commitlint/cli': 21.2.1(@types/node@26.1.1)(conventional-commits-parser@7.1.0)(typescript@7.0.2)
+      '@commitlint/cli': 21.2.1(@types/node@26.1.2)(conventional-commits-parser@7.1.0)(typescript@7.0.2)
       '@commitlint/config-conventional': 21.2.0
 
   '@btravstack/lefthook@0.1.1(lefthook@2.1.10)':
@@ -5101,7 +5120,7 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/cli@2.31.1(@types/node@26.1.1)':
+  '@changesets/cli@2.31.1(@types/node@26.1.2)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
       '@changesets/assemble-release-plan': 6.0.10
@@ -5117,7 +5136,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@26.1.1)
+      '@inquirer/external-editor': 1.0.3(@types/node@26.1.2)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       enquirer: 2.4.1
@@ -5215,12 +5234,12 @@ snapshots:
       human-id: 4.2.0
       prettier: 2.8.8
 
-  '@commitlint/cli@21.2.1(@types/node@26.1.1)(conventional-commits-parser@7.1.0)(typescript@7.0.2)':
+  '@commitlint/cli@21.2.1(@types/node@26.1.2)(conventional-commits-parser@7.1.0)(typescript@7.0.2)':
     dependencies:
       '@commitlint/config-conventional': 21.2.0
       '@commitlint/format': 21.2.0
       '@commitlint/lint': 21.2.0
-      '@commitlint/load': 21.2.0(@types/node@26.1.1)(typescript@7.0.2)
+      '@commitlint/load': 21.2.0(@types/node@26.1.2)(typescript@7.0.2)
       '@commitlint/read': 21.2.1(conventional-commits-parser@7.1.0)
       '@commitlint/types': 21.2.0
       tinyexec: 1.2.4
@@ -5265,14 +5284,14 @@ snapshots:
       '@commitlint/rules': 21.2.0
       '@commitlint/types': 21.2.0
 
-  '@commitlint/load@21.2.0(@types/node@26.1.1)(typescript@7.0.2)':
+  '@commitlint/load@21.2.0(@types/node@26.1.2)(typescript@7.0.2)':
     dependencies:
       '@commitlint/config-validator': 21.2.0
       '@commitlint/execute-rule': 21.0.1
       '@commitlint/resolve-extends': 21.2.0
       '@commitlint/types': 21.2.0
       cosmiconfig: 9.0.2(typescript@7.0.2)
-      cosmiconfig-typescript-loader: 6.3.0(@types/node@26.1.1)(cosmiconfig@9.0.2(typescript@7.0.2))(typescript@7.0.2)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@26.1.2)(cosmiconfig@9.0.2(typescript@7.0.2))(typescript@7.0.2)
       es-toolkit: 1.49.0
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
@@ -5571,12 +5590,12 @@ snapshots:
 
   '@iconify/types@2.0.0': {}
 
-  '@inquirer/external-editor@1.0.3(@types/node@26.1.1)':
+  '@inquirer/external-editor@1.0.3(@types/node@26.1.2)':
     dependencies:
       chardet: 2.2.0
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -6388,13 +6407,13 @@ snapshots:
 
   '@types/docker-modem@3.0.6':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
       '@types/ssh2': 1.15.5
 
   '@types/dockerode@4.0.1':
     dependencies:
       '@types/docker-modem': 3.0.6
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
       '@types/ssh2': 1.15.5
 
   '@types/estree@1.0.9': {}
@@ -6426,17 +6445,13 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@26.1.1':
-    dependencies:
-      undici-types: 8.3.0
-
   '@types/node@26.1.2':
     dependencies:
       undici-types: 8.3.0
 
   '@types/pg@8.20.3':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
       pg-protocol: 1.15.0
       pg-types: 2.2.0
 
@@ -6446,11 +6461,11 @@ snapshots:
 
   '@types/ssh2-streams@0.1.13':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
 
   '@types/ssh2@0.5.52':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
       '@types/ssh2-streams': 0.1.13
 
   '@types/ssh2@1.15.5':
@@ -7106,9 +7121,9 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  cosmiconfig-typescript-loader@6.3.0(@types/node@26.1.1)(cosmiconfig@9.0.2(typescript@7.0.2))(typescript@7.0.2):
+  cosmiconfig-typescript-loader@6.3.0(@types/node@26.1.2)(cosmiconfig@9.0.2(typescript@7.0.2))(typescript@7.0.2):
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
       cosmiconfig: 9.0.2(typescript@7.0.2)
       jiti: 2.6.1
       typescript: 7.0.2
@@ -8181,7 +8196,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.2
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
       long: 5.3.2
 
   pump@3.0.4:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,6 +221,46 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0)
 
+  examples/checkout-persistence:
+    dependencies:
+      '@unthrown/example-checkout-domain':
+        specifier: workspace:*
+        version: link:../checkout-domain
+      '@unthrown/prisma':
+        specifier: workspace:*
+        version: link:../../packages/prisma
+      unthrown:
+        specifier: workspace:^
+        version: link:../../packages/core
+    devDependencies:
+      '@btravstack/tsconfig':
+        specifier: 'catalog:'
+        version: 0.2.0
+      '@prisma/adapter-better-sqlite3':
+        specifier: 'catalog:'
+        version: 7.9.1
+      '@prisma/client':
+        specifier: 'catalog:'
+        version: 7.9.1(prisma@7.9.1(@types/react@19.2.17)(better-sqlite3@13.0.2)(magicast@0.5.3)(typescript@7.0.2))(typescript@7.0.2)
+      '@types/node':
+        specifier: 'catalog:'
+        version: 26.1.2
+      '@unthrown/vitest':
+        specifier: workspace:*
+        version: link:../../packages/vitest
+      better-sqlite3:
+        specifier: 'catalog:'
+        version: 13.0.2
+      prisma:
+        specifier: 'catalog:'
+        version: 7.9.1(@types/react@19.2.17)(better-sqlite3@13.0.2)(magicast@0.5.3)(typescript@7.0.2)
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0)
+
   packages/boxed:
     dependencies:
       unthrown:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ catalogs:
     vitest:
       specifier: 4.1.10
       version: 4.1.10
+    zod:
+      specifier: 4.4.3
+      version: 4.4.3
   typedoc:
     typescript:
       specifier: 6.0.3
@@ -198,6 +201,46 @@ importers:
       vitepress:
         specifier: 'catalog:'
         version: 1.6.4(@algolia/client-search@5.55.1)(@types/node@26.1.2)(jiti@2.7.0)(postcss@8.5.25)(tsx@4.23.5)(typescript@6.0.3)(yaml@2.9.0)
+
+  examples/checkout-api:
+    dependencies:
+      '@orpc/client':
+        specifier: 'catalog:'
+        version: 2.0.0-beta.23
+      '@orpc/server':
+        specifier: 'catalog:'
+        version: 2.0.0-beta.23
+      '@unthrown/example-checkout-domain':
+        specifier: workspace:*
+        version: link:../checkout-domain
+      '@unthrown/orpc':
+        specifier: workspace:*
+        version: link:../../packages/orpc
+      '@unthrown/standard-schema':
+        specifier: workspace:*
+        version: link:../../packages/standard-schema
+      unthrown:
+        specifier: workspace:^
+        version: link:../../packages/core
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+    devDependencies:
+      '@btravstack/tsconfig':
+        specifier: 'catalog:'
+        version: 0.2.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 26.1.2
+      '@unthrown/vitest':
+        specifier: workspace:*
+        version: link:../../packages/vitest
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0)
 
   examples/checkout-domain:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,9 +229,6 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 26.1.2
-      '@unthrown/vitest':
-        specifier: workspace:*
-        version: link:../../packages/vitest
       typescript:
         specifier: 'catalog:'
         version: 7.0.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,6 +54,7 @@ catalog:
   typescript: 7.0.2
   vitepress: 1.6.4
   vitest: 4.1.10
+  zod: 4.4.3
 
 catalogs:
   # TypeDoc's own TypeScript: 7.x is the native port and ships no `typescript.js`,

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ strictPeerDependencies: true
 
 packages:
   - packages/*
+  - examples/*
   - docs
 
 catalog:


### PR DESCRIPTION
## What & why

Reframes and closes #191.

Documentation snippets rot. #191 proposed generalising core's `doc-examples.spec.ts` — which extracts ` ```ts ` fences from `@example` tags and typechecks them — to every package. **This does something different**, because all four sibling repos (`entity`, `temporal-contract`, `amqp-contract`, `demesne`) already answer this the same way and none of them extracts TSDoc examples: they ship `examples/*`, a workspace glob of real, private, buildable packages with their own `typecheck` and `test`, documented by annotated walkthroughs.

`entity`'s `examples/README.md` states the thesis: *"Unlike the snippets in the guide, this code compiles and is covered by tests."* Real programs beat extracted fragments — they compile against the real surface, they are what a reader actually copies, and they carry tests.

## The three packages

One checkout domain between them, each showing a different job.

| package | shows |
| --- | --- |
| [`checkout-domain`](./examples/checkout-domain) | A four-case `TaggedError` union, `DoAsync`/`bind` sequencing, `ensure`, exhaustive matching — and a test proving a thrown provider outage becomes a **`Defect`**, not an `Err`. |
| [`checkout-persistence`](./examples/checkout-persistence) | `@unthrown/prisma` on in-memory SQLite: why a read infers `E = never` and a write carries only the P-codes you would branch on. |
| [`checkout-api`](./examples/checkout-api) | The oRPC edge: one exhaustive `mapErrCases`, a handler with **no `try`/`catch`**, and a defect collapsing to `INTERNAL_SERVER_ERROR`. |

The error union is the teaching point. Four cases that each earn their place — two mapping to different HTTP statuses, one with a structured payload, one discriminated on a second axis — and a payment-provider outage that is deliberately **not** in `E`. That contrast, one failure modelled and one not, side by side in the same function, is the thing prose has never shown compiling.

## What this does NOT solve, deliberately

An `examples/` package does not typecheck TSDoc `@example` blocks. After this, the satellites' blocks remain unguarded and core's `doc-examples.spec.ts` still guards only core. That is an accepted trade-off, recorded in `CLAUDE.md`.

**While recording it I found the number that motivated #191 is wrong.** A naive `grep -c @example packages/prisma/src` reports 81 — but 47 of those are in Prisma's own *generated* client and 30 more are in `index.spec.ts` / `types.test-d.ts`, all of which the extractor skips by name and by not recursing. The surface it would actually see is `index.ts` alone: **4 blocks**. The earlier figures in `CLAUDE.md` (34) and on #191 (~80) were both artefacts of counting generated and test files. The decision is unchanged; only the number motivating it was wrong.

## Verification worth calling out

These are examples, so "it compiles and the tests pass" is the deliverable — which makes it worth saying what the tests actually pin:

- **The `INTERNAL_SERVER_ERROR` test is not vacuous.** An in-process `createRouterClient` does *not* collapse a thrown exception; only a real `RPCHandler`↔`RPCLink` serialization round-trip does. The first implementation used the shortcut, the test passed against a bare `Error`, and it proved nothing. It now uses the wire loop, matching `packages/orpc`'s own suite.
- **The composition is compiler-guarded, not claimed.** `createRepository`'s return carries `satisfies Pick<CheckoutDeps, "findCart">`, so the persistence half plugging into the domain half is checked rather than asserted in prose. The write side genuinely does *not* line up (`Order` is `{id,total,lines}`, `saveOrder` takes `{id,total,cartId}`), and the code says so rather than pretending otherwise.
- **The documented commands were tested against their failure mode.** They route through turbo so `^build` runs; verified by moving `packages/core/dist` aside and confirming turbo rebuilt it and all seven tasks passed. A raw `pnpm --filter` fails on a fresh clone with "Failed to resolve entry for package unthrown".
- **The examples are a lint conformance fixture.** The repo dogfoods `@unthrown/oxlint`'s recommended preset, so example code is held to the library's own rules — no `P._`, every error case named. Confirmed by dropping a `P._` probe in and watching `oxlint` fail.

## Notes

`examples/*` joins `pnpm-workspace.yaml`; turbo needs no new task, since `typecheck` and `test` are already global. **No changeset** — every package is `private: true` and unpublished, and no published package changes.

`@unthrown/drizzle` is deliberately absent: its suite needs a Docker daemon, and every sibling's `examples/README.md` promises nothing needs to be listening. Its samples are already compiled by its own `docs-examples.test-d.ts` mirror.

## Checklist

- [x] The full gate passes locally: `pnpm format --check && pnpm lint && pnpm typecheck && pnpm knip && pnpm test && pnpm build` — 17/17 test tasks with Docker available, 11/11 build
- [x] Added/updated tests (and invariant guards / type-level tests if behaviour changed)
- [x] Added a changeset (`pnpm changeset`) for any user-facing change — N/A, all packages private
- [x] Updated TSDoc and `CLAUDE.md` if the public surface or a design rule changed
- [x] Commits follow Conventional Commits

Closes #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
