### PR TITLE
feat(prisma): batch $tryTransaction and the TransactionClient type

### DIFF
--- a/.changeset/prisma-batch-transaction.md
+++ b/.changeset/prisma-batch-transaction.md
@@ -1,0 +1,31 @@
+---
+"@unthrown/prisma": minor
+---
+
+Cover Prisma's batch `$transaction([...])` form in `$tryTransaction`.
+
+`$tryTransaction` is now overloaded exactly as Prisma's own `$transaction` is —
+one method, two forms — so the `try*` prefix keeps mapping one-to-one onto a
+Prisma method. The batch form is the natural fit for "insert N rows atomically"
+and is cheaper than the interactive one: a single round trip, with no open
+transaction held across application code.
+
+```ts
+const rows = db.$tryTransaction(inputs.map((data) => db.user.create({ data })));
+//    ^? AsyncResult<User[], PrismaQueryError>
+```
+
+Previously this meant dropping to the raw client, and a `fromSafePromise` fallback
+sent **every** failure to the defect channel — a `UniqueConstraintViolation` that
+`tryCreate` would have modeled arrived untyped, and the call site could not fold
+it into a domain error.
+
+A fixed tuple keeps positional types
+(`[db.user.create(…), db.user.count()]` → `AsyncResult<[User, number], …>`); a
+dynamic array collapses to a list. Two consequences of Prisma's batch form needing
+**unexecuted** `PrismaPromise`s, both deliberate: the array holds the **raw**
+delegate methods (passing a `try*` result is a compile error — it has already
+run), and `E` is the whole `PrismaQueryError` union rather than the per-operation
+narrowing, since a raw `PrismaPromise` carries no error-type information.
+`isolationLevel` is accepted; `maxWait` and `timeout` are not, as they govern an
+interactive transaction's open window.

--- a/.changeset/prisma-transaction-client-type.md
+++ b/.changeset/prisma-transaction-client-type.md
@@ -1,0 +1,25 @@
+---
+"@unthrown/prisma": minor
+---
+
+Export the `TransactionClient<C>` type helper.
+
+Naming the `tx` parameter of a helper factored out of a `$tryTransaction`
+callback had no type to reach for: the deny list is internal, and deriving it
+from the method does not work — `Parameters<Parameters<C["$tryTransaction"]>[0]>[0]`
+degrades to `Omit<unknown, …>`, because `C` is unresolved at that position. So
+adopting services hand-copied the list, which then drifts silently: `Omit` of a
+key that does not exist is not an error, so the copy keeps compiling after the
+library's own list changes.
+
+```ts
+import type { TransactionClient } from "@unthrown/prisma";
+
+type Tx = TransactionClient<typeof db>;
+
+const chargeFees = (tx: Tx, id: number) =>
+  tx.invoice.tryUpdate({ where: { id }, data: { charged: true } });
+```
+
+The deny list stays internal — `$tryTransaction`'s own signature uses this very
+alias, so the two cannot drift.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -857,8 +857,8 @@ AsyncResult<infer T, …>` — structural inference over the whole method surfac
   `qualifyPrismaError`, which **is** a `qualify` — `(cause, defect)`, generic in
   the marker type so core's non-exported `Defect` need not be named — and so
   drops straight into a `fromPromise` at a boundary of your own; the raw methods
-  stay as the escape hatch for batch
-  `$transaction([...])` and raw SQL. Tested against a
+  stay as the escape hatch for raw SQL, and are what a batch
+  `$tryTransaction([...])` is composed from. Tested against a
   real in-memory SQLite client (`@prisma/adapter-better-sqlite3`) with a
   generated, gitignored test client; **deliberately outside the fixed version
   group** — its majors track `@prisma/client`'s cadence, not the family's.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -825,9 +825,25 @@ AsyncResult<infer T, …>` — structural inference over the whole method surfac
   (an unsound omission until 2026-08: the runtime produced a `RecordNotFound`
   the type excluded, so a type-exhaustive `mapErrCases` threw
   `NonExhaustiveError` and the modeled error silently became a `Defect`). Also
-  `$tryTransaction` (an interactive transaction whose callback
-  speaks `AsyncResult` — an `Err` rolls back and re-surfaces typed; a defect
-  rolls back and stays a defect, a throwing callback included) and
+  `$tryTransaction`, **overloaded exactly as Prisma's own
+  `$transaction` is** — one method, two forms, so the `try*` prefix keeps
+  mapping one-to-one onto a Prisma method (a separate `$tryBatchTransaction`
+  was rejected for inventing a concept Prisma does not have). The
+  **interactive** form takes a callback speaking `AsyncResult` — an `Err` rolls
+  back and re-surfaces typed; a defect rolls back and stays a defect, a
+  throwing callback included — and its `tx` is nameable from outside as the
+  exported `TransactionClient<C>` (`Omit<C, TxDenyList>`; the deny list itself
+  stays internal, because a hand-copied `Omit` drifts silently — `Omit` of a
+  key that does not exist is not an error). The **batch** form takes an array
+  of unexecuted `Prisma.PrismaPromise`s, one round trip, all or nothing,
+  qualified through the same `qualifyPrismaError`; two limits follow from
+  Prisma's form and are documented rather than papered over: the array holds
+  the **raw** delegate methods (a `try*` has already executed, so passing one
+  is a compile error) and `E` is the whole `PrismaQueryError` union, since a
+  raw `PrismaPromise` carries no error-type information. A fixed tuple keeps
+  positional types, a dynamic array collapses to a list — core's `all` duality.
+  Being overloaded is why `$tryTransaction` is a `const` carrying an overloaded
+  function type rather than an object-literal method and
   `tryPaginate(...).withCursor(...)` (the
   `prisma-extension-pagination` cursor API with its unmerged #35 fix folded
   in; `after`/`before` are mutually exclusive in the type — passing both used to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -843,7 +843,7 @@ AsyncResult<infer T, …>` — structural inference over the whole method surfac
   raw `PrismaPromise` carries no error-type information. A fixed tuple keeps
   positional types, a dynamic array collapses to a list — core's `all` duality.
   Being overloaded is why `$tryTransaction` is a `const` carrying an overloaded
-  function type rather than an object-literal method and
+  function type rather than an object-literal method. Also
   `tryPaginate(...).withCursor(...)` (the
   `prisma-extension-pagination` cursor API with its unmerged #35 fix folded
   in; `after`/`before` are mutually exclusive in the type — passing both used to

--- a/docs/how-to/use-with-prisma.md
+++ b/docs/how-to/use-with-prisma.md
@@ -184,9 +184,48 @@ const moved = db.$tryTransaction((tx) =>
 - A [`Defect`](../explanation/the-defect-channel) also rolls back and **stays a
   defect** — including a callback that _throws_ instead of returning an
   `AsyncResult`. A bug is never quietly downgraded into your error channel.
-- Nesting is a compile error: `tx` has no `$tryTransaction`. For a batch of
-  independent writes, use the raw `$transaction([...])` with the raw promise
-  methods.
+- Nesting is a compile error: `tx` has no `$tryTransaction`.
+- Naming the `tx` parameter of a helper factored out of the callback is
+  `TransactionClient<typeof db>` — use it rather than restating the deny list by
+  hand, which drifts silently (`Omit` of a key that does not exist is not an
+  error):
+
+```ts
+import type { TransactionClient } from "@unthrown/prisma";
+
+type Tx = TransactionClient<typeof db>;
+
+const chargeFees = (tx: Tx, id: number) =>
+  tx.invoice.tryUpdate({ where: { id }, data: { charged: true } });
+```
+
+### Batch transactions
+
+For independent writes with no application logic between them, `$tryTransaction`
+also takes an **array** — Prisma's batch form, one round trip, all or nothing:
+
+```ts
+const rows = db.$tryTransaction(inputs.map((data) => db.user.create({ data })));
+//    ^? AsyncResult<User[], PrismaQueryError>
+```
+
+A fixed tuple keeps positional types
+(`[db.user.create(…), db.user.count()]` → `AsyncResult<[User, number], …>`); a
+dynamic array collapses to a list, the same duality as core's `all`.
+
+Two consequences of Prisma's batch form needing **unexecuted** `PrismaPromise`s,
+both deliberate:
+
+- The array holds the **raw** delegate methods — `db.user.create(...)`, not
+  `tryCreate`. A `try*` method has already run and returns an `AsyncResult`, so
+  passing one is a compile error.
+- `E` is the whole `PrismaQueryError` union rather than the per-operation
+  narrowing you get from `try*`: a raw `PrismaPromise` carries no error-type
+  information. Infrastructure failures are still defects, exactly as everywhere
+  else.
+
+`maxWait` and `timeout` are not accepted — they govern an interactive
+transaction's open window, which a batch does not have. `isolationLevel` is.
 
 ## Cursor pagination
 
@@ -228,9 +267,9 @@ defect.
 ## Raw methods and raw SQL
 
 The bridge is additive: `db.user.findMany(...)` (the raw promise) is still there,
-for exactly two things — batch `$transaction([...])` (which needs unexecuted
-`PrismaPromise`s) and raw SQL. Qualify those yourself at the boundary, reusing the
-exported `qualifyPrismaError`:
+for exactly two things — composing the array a batch `$tryTransaction([...])`
+runs, and raw SQL. Qualify raw SQL yourself at the boundary, reusing the exported
+`qualifyPrismaError`:
 
 ```ts
 import { fromPromise } from "unthrown";

--- a/docs/how-to/use-with-prisma.md
+++ b/docs/how-to/use-with-prisma.md
@@ -195,8 +195,11 @@ import type { TransactionClient } from "@unthrown/prisma";
 
 type Tx = TransactionClient<typeof db>;
 
-const chargeFees = (tx: Tx, id: number) =>
-  tx.invoice.tryUpdate({ where: { id }, data: { charged: true } });
+const chargeFees = (tx: Tx, id: number, fee: number) =>
+  tx.account.tryUpdate({
+    where: { id },
+    data: { balance: { decrement: fee } },
+  });
 ```
 
 ### Batch transactions

--- a/docs/typedoc.prisma.json
+++ b/docs/typedoc.prisma.json
@@ -11,6 +11,7 @@
     "DeleteError",
     "UpsertError",
     "UpdateManyError",
-    "TxDenyList"
+    "TxDenyList",
+    "TryTransaction"
   ]
 }

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -94,6 +94,22 @@ const moved = db.$tryTransaction((tx) =>
 // Err anywhere → both updates rolled back, and the Err is in `moved`.
 ```
 
+- **`$tryTransaction([...])`** — the same method's **batch** form: the operations
+  run in one round trip, all or nothing. It takes the **raw** delegate methods,
+  because Prisma's batch form needs unexecuted `PrismaPromise`s — and for the
+  same reason `E` is the whole `PrismaQueryError` union rather than the
+  per-operation narrowing `try*` gives.
+
+```ts
+const rows = db.$tryTransaction(inputs.map((data) => db.user.create({ data })));
+//    ^? AsyncResult<User[], PrismaQueryError>
+// Any constraint violation → nothing is written, and the Err is modeled.
+```
+
+- **`TransactionClient<C>`** — the type of an interactive callback's `tx`, for
+  naming the parameter of a helper factored out of one:
+  `type Tx = TransactionClient<typeof db>`.
+
 - **`tryPaginate`** — cursor pagination in the style of
   [`prisma-extension-pagination`](https://github.com/deptyped/prisma-extension-pagination)
   (same option names, same `[results, meta]` shape), with one fix folded in: a
@@ -126,8 +142,8 @@ const liked = await db.like
   });
 ```
 
-The raw promise methods stay available on purpose: they are the escape hatch for
-batch `$transaction([...])`, which needs unexecuted `PrismaPromise`s.
+The raw promise methods stay available on purpose: raw SQL goes through them, and
+a batch `$tryTransaction([...])` is composed from them.
 
 `@prisma/client` (v7+) is a peer dependency.
 

--- a/packages/prisma/src/index.spec.ts
+++ b/packages/prisma/src/index.spec.ts
@@ -360,6 +360,12 @@ describe("$tryTransaction (batch form)", () => {
   it("an empty batch is Ok([])", async ({ db }) => {
     await expect(db.$tryTransaction([])).toBeOkWith([]);
   });
+
+  it("threads options through on the batch path", async ({ db }) => {
+    await expect(
+      db.$tryTransaction([db.user.count()], { isolationLevel: "Serializable" }),
+    ).toBeOkWith([0]);
+  });
 });
 
 describe("tryPaginate / withCursor", () => {

--- a/packages/prisma/src/index.spec.ts
+++ b/packages/prisma/src/index.spec.ts
@@ -353,8 +353,7 @@ describe("$tryTransaction (batch form)", () => {
         db.user.create({ data: { email: "dup@example.com" } }),
       ]),
     ).toBeErrTagged("UniqueConstraintViolation");
-    // The rollback is asserted against the DATABASE, not inferred from the Err:
-    // the first two creates succeeded before the third one failed.
+    // The rollback is asserted against the DATABASE, not inferred from the Err.
     await expect(db.user.tryCount()).toBeOkWith(0);
   });
 

--- a/packages/prisma/src/index.spec.ts
+++ b/packages/prisma/src/index.spec.ts
@@ -331,6 +331,38 @@ describe("$tryTransaction", () => {
   });
 });
 
+describe("$tryTransaction (batch form)", () => {
+  it("commits every operation in one transaction", async ({ db }) => {
+    await expect(
+      db.$tryTransaction([
+        db.user.create({ data: { email: "a@example.com" } }),
+        db.user.create({ data: { email: "b@example.com" } }),
+      ]),
+    ).toBeOkWith([
+      expect.objectContaining({ email: "a@example.com" }),
+      expect.objectContaining({ email: "b@example.com" }),
+    ]);
+    await expect(db.user.tryCount()).toBeOkWith(2);
+  });
+
+  it("models a constraint violation and rolls the whole batch back", async ({ db }) => {
+    await expect(
+      db.$tryTransaction([
+        db.user.create({ data: { email: "first@example.com" } }),
+        db.user.create({ data: { email: "dup@example.com" } }),
+        db.user.create({ data: { email: "dup@example.com" } }),
+      ]),
+    ).toBeErrTagged("UniqueConstraintViolation");
+    // The rollback is asserted against the DATABASE, not inferred from the Err:
+    // the first two creates succeeded before the third one failed.
+    await expect(db.user.tryCount()).toBeOkWith(0);
+  });
+
+  it("an empty batch is Ok([])", async ({ db }) => {
+    await expect(db.$tryTransaction([])).toBeOkWith([]);
+  });
+});
+
 describe("tryPaginate / withCursor", () => {
   const ids = (rows: ReadonlyArray<{ id: number }>) => rows.map((r) => r.id);
 

--- a/packages/prisma/src/index.ts
+++ b/packages/prisma/src/index.ts
@@ -334,6 +334,100 @@ type TxDenyList =
  */
 export type TransactionClient<C> = Omit<C, TxDenyList>;
 
+// Prisma's own `UnwrapTuple` lives at `runtime.Types.Utils.UnwrapTuple`, behind a
+// runtime entry path this package deliberately never imports (it moved between
+// Prisma 6 and 7), so the mapping is written here. A fixed tuple keeps positional
+// types; a dynamic `PrismaPromise<T>[]` collapses to `T[]` — the same duality as
+// core's `all`.
+type UnwrapPrismaTuple<P extends readonly unknown[]> = {
+  -readonly [K in keyof P]: P[K] extends Prisma.PrismaPromise<infer X> ? X : never;
+};
+
+type TryTransaction = {
+  /**
+   * An interactive transaction whose callback speaks `AsyncResult`: an `Err`
+   * triggers a ROLLBACK and comes out as the same typed `Err`.
+   *
+   * @remarks
+   * The callback's `Err` is thrown internally as a sentinel so Prisma aborts the
+   * transaction, then unwrapped back into the typed error channel —
+   * `AsyncResult<T, E | PrismaQueryError>`. A defect inside the callback also
+   * rolls back and stays a defect — including a callback that *throws* instead
+   * of returning an `AsyncResult` (a bug, never downgraded to a modeled error).
+   * The `try*` methods are available on `tx` (extensions propagate into the
+   * interactive transaction); the deny list additionally removes
+   * `$tryTransaction` itself — no nesting. Name a helper's `tx` parameter with
+   * {@link TransactionClient}.
+   *
+   * The `| PrismaQueryError` is not merely defensive: a deferred constraint
+   * surfaces its violation at COMMIT rather than at the statement, so the
+   * transaction boundary itself can produce one. Prisma's own machinery failing
+   * any other way (a `maxWait` / `timeout` expiry, a lost connection) is
+   * infrastructure, and so a defect like everywhere else.
+   *
+   * @example
+   * ```ts
+   * const moved = db.$tryTransaction((tx) =>
+   *   tx.account
+   *     .tryUpdate({ where: { id: from }, data: { balance: { decrement: amount } } })
+   *     .flatMap(() =>
+   *       tx.account.tryUpdate({
+   *         where: { id: to },
+   *         data: { balance: { increment: amount } },
+   *       }),
+   *     ),
+   * );
+   * // Err anywhere → both updates rolled back, and the Err is in `moved`.
+   * ```
+   */
+  <C, T, E>(
+    this: C,
+    fn: (tx: TransactionClient<C>) => AsyncResult<T, E>,
+    options?: {
+      maxWait?: number;
+      timeout?: number;
+      isolationLevel?: TransactionIsolationLevel;
+    },
+  ): AsyncResult<T, E | PrismaQueryError>;
+
+  /**
+   * A batch transaction: the operations run in one round trip, all or nothing,
+   * with no application code held open in between.
+   *
+   * @remarks
+   * Two things follow from Prisma's batch form taking **unexecuted**
+   * `PrismaPromise`s, and both are deliberate:
+   *
+   * - The array holds the **raw** delegate methods — `db.user.create(...)`, not
+   *   `tryCreate`. A `try*` method has already executed and returns an
+   *   `AsyncResult`, so passing one is a compile error.
+   * - `E` is the whole {@link PrismaQueryError} union rather than the
+   *   per-operation narrowing the `try*` methods give: a raw `PrismaPromise`
+   *   carries no error-type information. Every infrastructure failure is still
+   *   a defect, exactly as everywhere else.
+   *
+   * A fixed tuple keeps positional types; a dynamic array (a `.map(...)`)
+   * collapses to `AsyncResult<T[], PrismaQueryError>`.
+   *
+   * `maxWait` and `timeout` are absent by design — they govern an interactive
+   * transaction's open window, which a single-round-trip batch does not have.
+   *
+   * @example
+   * ```ts
+   * const rows = db.$tryTransaction(
+   *   inputs.map((data) => db.user.create({ data })),
+   * );
+   * //    ^? AsyncResult<User[], PrismaQueryError>
+   * // Any constraint violation → nothing is written, and the Err is modeled.
+   * ```
+   */
+  <C, P extends readonly Prisma.PrismaPromise<unknown>[]>(
+    this: C,
+    operations: readonly [...P],
+    options?: { isolationLevel?: TransactionIsolationLevel },
+  ): AsyncResult<UnwrapPrismaTuple<P>, PrismaQueryError>;
+};
+
 /**
  * The Prisma Client extension. Apply it with `$extends` to add the `try*`
  * methods to every model delegate, and `$tryTransaction` to the client.
@@ -354,6 +448,65 @@ export type TransactionClient<C> = Omit<C, TxDenyList>;
  * //    ^? AsyncResult<{ id: number }[], never>  — a read has no modeled failure
  * ```
  */
+// Declared as a const rather than an object-literal method because it is
+// OVERLOADED (Prisma's `$transaction` has two forms and the `try*` prefix maps
+// one-to-one onto it). The implementation side is untyped, as it is for the
+// `$allModels` methods: the declared signatures carry the safety.
+const $tryTransaction = function <T, E>(this: unknown, arg: unknown, options?: unknown) {
+  const client = Prisma.getExtensionContext(this) as unknown as {
+    $transaction: (arg: unknown, opts?: unknown) => Promise<unknown>;
+  };
+  // The batch form needs none of the sentinel machinery below: there is no
+  // callback whose `Err` has to travel out through a throw. Prisma runs the
+  // array in one transaction and rejects with the first failure, which is
+  // qualified exactly like any other query.
+  if (Array.isArray(arg)) {
+    return fromPromise(() => client.$transaction(arg, options), qualifyPrismaError);
+  }
+  const fn = arg as (tx: unknown) => AsyncResult<T, E>;
+  // Passed as a THUNK so even a synchronous throw out of `$transaction` itself
+  // (e.g. invalid options from untyped code) stays inside the boundary instead
+  // of escaping as a raw throw.
+  //
+  // The triage runs with the concrete `PrismaQueryError` union — `qualify`'s
+  // `NotThenable` return constraint cannot be proven over the unresolved `E`
+  // parameter (the generic-`E` concession, as guards-over-match) — and the
+  // callback's modeled `E` is re-attached by the declared signature.
+  return fromPromise(
+    () =>
+      client.$transaction(async (tx: unknown) => {
+        let result: Result<T, E>;
+        try {
+          const returned: unknown = await fn(tx);
+          // A callback that resolves to a NON-Result (out of contract — e.g. a
+          // raw value from untyped code) is a bug, exactly like a throwing
+          // callback: the TypeError is caught below, so it rolls back as a
+          // DEFECT — never downgraded to a modeled error.
+          if (!isResult(returned)) {
+            throw new TypeError(
+              "@unthrown/prisma: the $tryTransaction callback did not return a Result.",
+            );
+          }
+          result = returned as Result<T, E>;
+        } catch (cause) {
+          // A callback that throws (instead of returning an AsyncResult) is a
+          // bug — roll back and keep it a DEFECT. Only rejections outside this
+          // catch (Prisma's own BEGIN/COMMIT/timeout machinery) qualify as
+          // query failures below.
+          throw new Rollback(cause, true);
+        }
+        if (result.isOk()) return result.value;
+        throw result.isErr() ? new Rollback(result.error, false) : new Rollback(result.cause, true);
+      }, options),
+    (cause, defect) =>
+      cause instanceof Rollback
+        ? cause.wasDefect
+          ? defect(cause.carried)
+          : (cause.carried as PrismaQueryError)
+        : qualifyPrismaError(cause, defect),
+  );
+} as TryTransaction;
+
 export const unthrownPrisma = Prisma.defineExtension({
   name: "@unthrown/prisma",
   model: {
@@ -619,102 +772,5 @@ export const unthrownPrisma = Prisma.defineExtension({
       },
     },
   },
-  client: {
-    /**
-     * An interactive transaction whose callback speaks `AsyncResult`: an `Err`
-     * triggers a ROLLBACK and comes out as the same typed `Err`.
-     *
-     * @remarks
-     * The callback's `Err` is thrown internally as a sentinel so Prisma aborts
-     * the transaction, then unwrapped back into the typed error channel —
-     * `AsyncResult<T, E | PrismaQueryError>`. A defect inside the callback also
-     * rolls back and stays a defect — including a callback that *throws*
-     * instead of returning an `AsyncResult` (a bug, never downgraded to a
-     * modeled error). The `try*` methods are available on `tx`
-     * (extensions propagate into the interactive transaction); the deny list
-     * additionally removes `$tryTransaction` itself — no nesting.
-     *
-     * The `| PrismaQueryError` is not merely defensive: a deferred constraint
-     * surfaces its violation at COMMIT rather than at the statement, so the
-     * transaction boundary itself can produce one. Prisma's own machinery
-     * failing any other way (a `maxWait` / `timeout` expiry, a lost connection)
-     * is infrastructure, and so a defect like everywhere else.
-     *
-     * @example
-     * ```ts
-     * const moved = db.$tryTransaction((tx) =>
-     *   tx.account
-     *     .tryUpdate({ where: { id: from }, data: { balance: { decrement: amount } } })
-     *     .flatMap(() =>
-     *       tx.account.tryUpdate({
-     *         where: { id: to },
-     *         data: { balance: { increment: amount } },
-     *       }),
-     *     ),
-     * );
-     * // Err anywhere → both updates rolled back, and the Err is in `moved`.
-     * ```
-     */
-    $tryTransaction<C, T, E>(
-      this: C,
-      fn: (tx: TransactionClient<C>) => AsyncResult<T, E>,
-      options?: {
-        maxWait?: number;
-        timeout?: number;
-        isolationLevel?: TransactionIsolationLevel;
-      },
-    ): AsyncResult<T, E | PrismaQueryError> {
-      const client = Prisma.getExtensionContext(this) as unknown as {
-        $transaction: <R>(f: (tx: unknown) => Promise<R>, opts?: unknown) => Promise<R>;
-      };
-      // Passed as a THUNK so even a synchronous throw out of `$transaction`
-      // itself (e.g. invalid options from untyped code) stays inside the
-      // boundary instead of escaping as a raw throw.
-      //
-      // The triage runs with the concrete `PrismaQueryError` union — `qualify`'s
-      // `NotThenable` return constraint cannot be proven over the unresolved `E`
-      // parameter (the generic-`E` concession, as guards-over-match) — and the
-      // callback's modeled `E` is re-attached once, on the way out.
-      const lifted: AsyncResult<T, PrismaQueryError> = fromPromise(
-        () =>
-          client.$transaction(async (tx) => {
-            let result: Result<T, E>;
-            try {
-              const returned: unknown = await fn(tx as TransactionClient<C>);
-              // A callback that resolves to a NON-Result (out of contract —
-              // e.g. a raw value from untyped code) is a bug, exactly like a
-              // throwing callback: the TypeError is caught below, so it rolls
-              // back as a DEFECT — never downgraded to a modeled error
-              // (which is what dispatching `returned.isOk()` outside this
-              // try/catch used to do).
-              if (!isResult(returned)) {
-                throw new TypeError(
-                  "@unthrown/prisma: the $tryTransaction callback did not return a Result.",
-                );
-              }
-              result = returned as Result<T, E>;
-            } catch (cause) {
-              // A callback that throws (instead of returning an AsyncResult) is a
-              // bug — roll back and keep it a DEFECT. Only rejections outside
-              // this catch (Prisma's own BEGIN/COMMIT/timeout machinery) qualify
-              // as query failures below.
-              throw new Rollback(cause, true);
-            }
-            if (result.isOk()) return result.value;
-            throw result.isErr()
-              ? new Rollback(result.error, false)
-              : new Rollback(result.cause, true);
-          }, options),
-        (cause, defect) =>
-          cause instanceof Rollback
-            ? cause.wasDefect
-              ? defect(cause.carried)
-              : (cause.carried as PrismaQueryError)
-            : qualifyPrismaError(cause, defect),
-      );
-      // A non-defect `Rollback` carries the callback's own `Err` value, so the
-      // channel is really `E | PrismaQueryError` — re-attached here.
-      return lifted as AsyncResult<T, E | PrismaQueryError>;
-    },
-  },
+  client: { $tryTransaction },
 });

--- a/packages/prisma/src/index.ts
+++ b/packages/prisma/src/index.ts
@@ -428,26 +428,6 @@ type TryTransaction = {
   ): AsyncResult<UnwrapPrismaTuple<P>, PrismaQueryError>;
 };
 
-/**
- * The Prisma Client extension. Apply it with `$extends` to add the `try*`
- * methods to every model delegate, and `$tryTransaction` to the client.
- *
- * @remarks
- * Typing follows Prisma's documented `$allModels` pattern: `this: T` binds the
- * concrete delegate, `Prisma.Exact` checks args, and `Prisma.Result` computes
- * the payload — so `select` / `include` inference survives the wrap.
- *
- * @example
- * ```ts
- * import { PrismaClient } from "./generated/prisma/client.ts";
- * import { unthrownPrisma } from "@unthrown/prisma";
- *
- * const db = new PrismaClient({ adapter }).$extends(unthrownPrisma);
- *
- * const users = db.user.tryFindMany({ select: { id: true } });
- * //    ^? AsyncResult<{ id: number }[], never>  — a read has no modeled failure
- * ```
- */
 // Declared as a const rather than an object-literal method because it is
 // OVERLOADED (Prisma's `$transaction` has two forms and the `try*` prefix maps
 // one-to-one onto it). The implementation side is untyped, as it is for the
@@ -507,6 +487,26 @@ const $tryTransaction = function <T, E>(this: unknown, arg: unknown, options?: u
   );
 } as TryTransaction;
 
+/**
+ * The Prisma Client extension. Apply it with `$extends` to add the `try*`
+ * methods to every model delegate, and `$tryTransaction` to the client.
+ *
+ * @remarks
+ * Typing follows Prisma's documented `$allModels` pattern: `this: T` binds the
+ * concrete delegate, `Prisma.Exact` checks args, and `Prisma.Result` computes
+ * the payload — so `select` / `include` inference survives the wrap.
+ *
+ * @example
+ * ```ts
+ * import { PrismaClient } from "./generated/prisma/client.ts";
+ * import { unthrownPrisma } from "@unthrown/prisma";
+ *
+ * const db = new PrismaClient({ adapter }).$extends(unthrownPrisma);
+ *
+ * const users = db.user.tryFindMany({ select: { id: true } });
+ * //    ^? AsyncResult<{ id: number }[], never>  — a read has no modeled failure
+ * ```
+ */
 export const unthrownPrisma = Prisma.defineExtension({
   name: "@unthrown/prisma",
   model: {

--- a/packages/prisma/src/index.ts
+++ b/packages/prisma/src/index.ts
@@ -310,6 +310,31 @@ type TxDenyList =
   | "$tryTransaction";
 
 /**
+ * The client an interactive `$tryTransaction` callback receives — the extended
+ * client minus what a transaction cannot do.
+ *
+ * @remarks
+ * Name the `tx` parameter of a helper factored out of a callback with this,
+ * rather than restating the deny list: `$tryTransaction` uses the very same
+ * alias, so the two cannot drift. Restating it by hand does drift silently —
+ * `Omit` of a key that does not exist is not an error, so a hand-copied list
+ * keeps compiling after the library's own list changes.
+ *
+ * @typeParam C - the extended client, usually `typeof db`.
+ *
+ * @example
+ * ```ts
+ * type Tx = TransactionClient<typeof db>;
+ *
+ * const chargeFees = (tx: Tx, id: number) =>
+ *   tx.invoice.tryUpdate({ where: { id }, data: { charged: true } });
+ *
+ * db.$tryTransaction((tx) => chargeFees(tx, 1));
+ * ```
+ */
+export type TransactionClient<C> = Omit<C, TxDenyList>;
+
+/**
  * The Prisma Client extension. Apply it with `$extends` to add the `try*`
  * methods to every model delegate, and `$tryTransaction` to the client.
  *
@@ -632,7 +657,7 @@ export const unthrownPrisma = Prisma.defineExtension({
      */
     $tryTransaction<C, T, E>(
       this: C,
-      fn: (tx: Omit<C, TxDenyList>) => AsyncResult<T, E>,
+      fn: (tx: TransactionClient<C>) => AsyncResult<T, E>,
       options?: {
         maxWait?: number;
         timeout?: number;
@@ -655,7 +680,7 @@ export const unthrownPrisma = Prisma.defineExtension({
           client.$transaction(async (tx) => {
             let result: Result<T, E>;
             try {
-              const returned: unknown = await fn(tx as Omit<C, TxDenyList>);
+              const returned: unknown = await fn(tx as TransactionClient<C>);
               // A callback that resolves to a NON-Result (out of contract —
               // e.g. a raw value from untyped code) is a bug, exactly like a
               // throwing callback: the TypeError is caught below, so it rolls

--- a/packages/prisma/src/index.ts
+++ b/packages/prisma/src/index.ts
@@ -142,8 +142,7 @@ const constraintFields = (meta: unknown): readonly string[] => {
 
 /**
  * Qualify a Prisma rejection — the runtime half of the bridge, and a ready-made
- * `qualify` for any boundary you build yourself (raw SQL, a batch
- * `$transaction([...])`).
+ * `qualify` for any boundary you build yourself (raw SQL).
  *
  * @remarks
  * The three P-codes that describe a **domain** outcome map to their tagged
@@ -321,6 +320,9 @@ type TxDenyList =
  * alias, so the two cannot drift. Restating it by hand does drift silently —
  * `Omit` of a key that does not exist is not an error, so a hand-copied list
  * keeps compiling after the library's own list changes.
+ *
+ * Not to be confused with Prisma's own generated `Prisma.TransactionClient` —
+ * that one is non-generic and, notably, does not remove `$tryTransaction`.
  *
  * @typeParam C - the extended client, usually `typeof db`.
  *

--- a/packages/prisma/src/index.ts
+++ b/packages/prisma/src/index.ts
@@ -30,8 +30,10 @@
 // So a read has NO modeled failure: `tryFindMany` is `AsyncResult<User[], never>`
 // (absence is `null`, not an error).
 //
-// The raw promise methods stay available on purpose: they are the escape hatch
-// for batch `$transaction([...])`, which needs unexecuted `PrismaPromise`s.
+// The raw promise methods stay available on purpose: raw SQL goes through them,
+// and a batch `$tryTransaction([...])` is composed FROM them — Prisma's batch
+// form needs unexecuted `PrismaPromise`s, which a `try*` method (already
+// executed, already an `AsyncResult`) cannot supply.
 
 import { Prisma } from "@prisma/client/extension";
 import { type AsyncResult, fromPromise, isResult, type Result, TaggedError } from "unthrown";

--- a/packages/prisma/src/types.test-d.ts
+++ b/packages/prisma/src/types.test-d.ts
@@ -141,6 +141,25 @@ namedTx.$transaction;
 // @ts-expect-error — and the connection/extension methods.
 namedTx.$extends;
 
+// --- $tryTransaction: the batch form ------------------------------------------
+
+const batch = db.$tryTransaction([
+  db.user.create({ data: { email: "a@example.com" } }),
+  db.user.count(),
+]);
+
+declare const inputs: readonly { email: string }[];
+const batchDynamic = db.$tryTransaction(inputs.map((data) => db.user.create({ data })));
+
+// @ts-expect-error — a batch takes UNEXECUTED PrismaPromises; `try*` has already run.
+db.$tryTransaction([db.user.tryCreate({ data: { email: "a@example.com" } })]);
+// @ts-expect-error — not a Prisma isolation level.
+db.$tryTransaction([db.user.count()], { isolationLevel: "Chaotic" });
+// @ts-expect-error — `timeout` governs an interactive transaction, not a batch.
+db.$tryTransaction([db.user.count()], { timeout: 10 });
+
+db.$tryTransaction([db.user.count()], { isolationLevel: "Serializable" });
+
 export type _Assertions = [
   // full read: default payload flows through
   Expect<Equal<AsyncOkOf<typeof all>[number]["email"], string>>,
@@ -209,4 +228,13 @@ export type _Assertions = [
     Equal<AsyncErrOf<typeof tx>, UniqueConstraintViolation | ForeignKeyViolation | RecordNotFound>
   >,
   Expect<Equal<AsyncOkOf<typeof tx>["email"], string>>,
+  // the batch form: a fixed tuple keeps positional types...
+  Expect<Equal<AsyncOkOf<typeof batch>["length"], 2>>,
+  Expect<Equal<AsyncOkOf<typeof batch>[0]["email"], string>>,
+  Expect<Equal<AsyncOkOf<typeof batch>[1], number>>,
+  // ...a dynamic array collapses to a list, as core's `all` does
+  Expect<Equal<AsyncOkOf<typeof batchDynamic>[number]["email"], string>>,
+  // and E is the whole union — a raw PrismaPromise carries no error type
+  Expect<Equal<AsyncErrOf<typeof batch>, PrismaQueryError>>,
+  Expect<Equal<AsyncErrOf<typeof batchDynamic>, PrismaQueryError>>,
 ];

--- a/packages/prisma/src/types.test-d.ts
+++ b/packages/prisma/src/types.test-d.ts
@@ -16,6 +16,7 @@ import type {
   ForeignKeyViolation,
   PrismaQueryError,
   RecordNotFound,
+  TransactionClient,
   UniqueConstraintViolation,
 } from "./index.js";
 import { qualifyPrismaError, unthrownPrisma } from "./index.js";
@@ -125,6 +126,20 @@ db.$tryTransaction((txc) => {
   txc.$transaction;
   return txc.user.tryFindMany();
 });
+
+// --- TransactionClient: the tx parameter has a nameable type -------------------
+
+declare const namedTx: TransactionClient<typeof db>;
+
+// The delegates and their try* methods survive the Omit.
+namedTx.user.tryFindMany();
+
+// @ts-expect-error — the deny list removes $tryTransaction (no nesting).
+namedTx.$tryTransaction;
+// @ts-expect-error — and the raw $transaction with it.
+namedTx.$transaction;
+// @ts-expect-error — and the connection/extension methods.
+namedTx.$extends;
 
 export type _Assertions = [
   // full read: default payload flows through

--- a/packages/prisma/src/types.test-d.ts
+++ b/packages/prisma/src/types.test-d.ts
@@ -141,6 +141,11 @@ namedTx.$transaction;
 // @ts-expect-error — and the connection/extension methods.
 namedTx.$extends;
 
+// The round trip: the `tx` the callback actually receives is assignable to the
+// exported alias — the whole point of naming a helper's parameter with it.
+const chargeFees = (t: TransactionClient<typeof db>) => t.user.tryFindMany();
+db.$tryTransaction((txc) => chargeFees(txc));
+
 // --- $tryTransaction: the batch form ------------------------------------------
 
 const batch = db.$tryTransaction([

--- a/skills/unthrown/references/ecosystem.md
+++ b/skills/unthrown/references/ecosystem.md
@@ -99,13 +99,19 @@ db.user.tryFindMany();
   own `defect` arm.
 - `$tryTransaction(cb)` — interactive transaction whose callback speaks
   `AsyncResult`: an `Err` rolls back and re-surfaces typed; a defect (throwing
-  callback included) rolls back and stays a defect.
+  callback included) rolls back and stays a defect. `TransactionClient<typeof
+db>` names the callback's `tx` for a helper factored out of it.
+- `$tryTransaction([...])` — the batch form, one round trip, all or nothing. It
+  takes the **raw** delegate methods (Prisma's batch needs unexecuted
+  `PrismaPromise`s), so `E` is the whole `PrismaQueryError` union rather than
+  the per-operation narrowing. A tuple keeps positional types; a dynamic array
+  collapses to a list.
 - `tryPaginate(...).withCursor(...)` — cursor pagination; its `E` is
   `InvalidCursor` (the cursor is the only part of the query that came from
   outside). `after` and `before` are mutually exclusive.
 - `qualifyPrismaError` — the exported qualify, for hand-rolled boundaries.
-- Raw methods remain the escape hatch for batch `$transaction([...])` and raw
-  SQL.
+- Raw methods remain the escape hatch for raw SQL, and are what a batch
+  `$tryTransaction([...])` is composed from.
 
 ## Drizzle: @unthrown/drizzle
 

--- a/skills/unthrown/references/ecosystem.md
+++ b/skills/unthrown/references/ecosystem.md
@@ -99,8 +99,8 @@ db.user.tryFindMany();
   own `defect` arm.
 - `$tryTransaction(cb)` — interactive transaction whose callback speaks
   `AsyncResult`: an `Err` rolls back and re-surfaces typed; a defect (throwing
-  callback included) rolls back and stays a defect. `TransactionClient<typeof
-db>` names the callback's `tx` for a helper factored out of it.
+  callback included) rolls back and stays a defect. `TransactionClient<C>`
+  names the callback's `tx` for a helper factored out of it.
 - `$tryTransaction([...])` — the batch form, one round trip, all or nothing. It
   takes the **raw** delegate methods (Prisma's batch needs unexecuted
   `PrismaPromise`s), so `E` is the whole `PrismaQueryError` union rather than


### PR DESCRIPTION
## What & why

Closes #218. Closes #217.

Both issues were found migrating the same downstream service, and both are about `$tryTransaction`.

**`TransactionClient<C>`** (#218) — naming the `tx` parameter of a helper factored out of an interactive callback had no type to reach for: `TxDenyList` is internal, and deriving it from the method does not work (`Parameters<Parameters<C["$tryTransaction"]>[0]>[0]` degrades to `Omit<unknown, …>`, because `C` is unresolved at that position). So adopting services hand-copy the deny list, and that copy drifts silently — `Omit` of a key that does not exist is not an error. The deny list stays internal; `$tryTransaction`'s own signature uses the exported alias, so the two cannot drift.

**The batch form** (#217) — `$tryTransaction` is now overloaded exactly as Prisma's own `$transaction` is, one method and two forms, so the `try*` prefix keeps mapping one-to-one onto a Prisma method. Previously the batch form meant dropping to the raw client, where a `fromSafePromise` fallback sent every failure to the defect channel: a `UniqueConstraintViolation` that `tryCreate` would have modeled arrived untyped.

```ts
const rows = db.$tryTransaction(inputs.map((data) => db.user.create({ data })));
//    ^? AsyncResult<User[], PrismaQueryError>
```

A fixed tuple keeps positional types; a dynamic array collapses to a list — core's `all` duality. Two limits follow from Prisma's batch form needing **unexecuted** `PrismaPromise`s, and are documented rather than papered over: the array holds the **raw** delegate methods (passing a `try*` result is a compile error — it has already run), and `E` is the whole `PrismaQueryError` union rather than the per-operation narrowing. `isolationLevel` is accepted; `maxWait` / `timeout` are not, as they govern an interactive transaction's open window.

The interactive overload is byte-identical and listed first, so no existing caller changes behaviour.

## Checklist

- [x] The full gate passes locally: `pnpm format --check && pnpm lint && pnpm typecheck && pnpm knip && pnpm test && pnpm build`
- [x] Added/updated tests (and invariant guards / type-level tests if behaviour changed)
- [x] Added a changeset (`pnpm changeset`) for any user-facing change
- [x] Updated TSDoc and `CLAUDE.md` if the public surface or a design rule changed
- [x] Commits follow Conventional Commits

Covered by new integration specs against the real in-memory SQLite client (commit, rollback asserted against the database rather than inferred from the `Err`, empty batch, options threading) and by type tests pinning tuple/array inference, the `PrismaQueryError` channel, the `TransactionClient` round trip, and each must-not-compile case.