### PR TITLE
chore(changesets): stop versioning private packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -15,6 +15,7 @@
   ],
   "linked": [],
   "access": "public",
+  "privatePackages": { "version": false, "tag": false },
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1015,6 +1015,14 @@ code: "NOT_FOUND" }, …))`); non-inferable →
   turns one red rather than leaving a stale snippet uncaught. Each is
   `private: true` with **no `build` script** — they are consumed as source,
   never published, so there is nothing to build and no changeset to add.
+  `private: true` already keeps them off npm, but changesets **versions** a
+  private package by default, so bumping a satellite they depend on bumped
+  their version, wrote them a `CHANGELOG.md`, and listed
+  `@unthrown/example-checkout-persistence@0.0.1` under **Releases** in the
+  release PR — a package name that does not and must not exist on the registry
+  (#220). `.changeset/config.json` therefore sets
+  `privatePackages: { version: false, tag: false }`, which pins every example
+  (and `docs`) at `0.0.0` with no changelog.
   `typecheck` runs on all three; `test` runs where no external infrastructure
   is required (`checkout-domain` and `checkout-api` are pure; `checkout-persistence`
   runs against Prisma's in-memory SQLite, the same pattern `@unthrown/prisma`'s


### PR DESCRIPTION
## Problem

The release PR #220 listed `@unthrown/example-checkout-persistence@0.0.1` under **Releases**.

It was never actually published — `private: true` makes `changeset publish` skip it, and `npm view @unthrown/example-checkout-persistence` returns a 404. But changesets *versions* a private package by default (`privatePackages.version` defaults to `true`), so bumping `@unthrown/prisma` cascaded through the `workspace:*` dependency and gave the example a version bump, a `CHANGELOG.md`, and a headline in the release PR body — for a package name that does not and must not exist on the registry.

## Fix

One line in `.changeset/config.json`:

```json
"privatePackages": { "version": false, "tag": false },
```

This pins every `examples/*` package — and `docs`, which would hit the same thing the moment anything depended on it — at `0.0.0`, with no changelog and no git tag.

## Verification

Ran `pnpm changeset version` against the two pending prisma changesets, before and after:

| | before | after |
|---|---|---|
| `packages/prisma` | 0.2.0 → 0.3.0 + CHANGELOG | unchanged behaviour |
| `examples/checkout-persistence` | 0.0.0 → 0.0.1 + new CHANGELOG | **untouched** |

The version output was reverted; only the config change is committed.

## Notes

- No changeset — nothing published changes.
- Once this lands on main, the changesets action rebuilds `changeset-release/main` from scratch, so the stray `examples/checkout-persistence/CHANGELOG.md` and `0.0.1` drop out of #220 with no manual cleanup.
- Rationale recorded in the `examples/*` bullet of `CLAUDE.md`.