### PR TITLE
feat(core): add fromExecutor, a callback-API boundary

### DIFF
--- a/.changeset/from-executor.md
+++ b/.changeset/from-executor.md
@@ -26,5 +26,5 @@ route to the defect channel from inside an asynchronous callback, where a
 `throw` runs in its own turn and would escape the boundary entirely.
 
 An `async` executor is caught at runtime rather than by the types: its rejection
-settles a `Defect` instead of floating, which is what `new Promise` does with the
-same mistake.
+settles a `Defect` instead of floating unhandled — `new Promise` lets the same
+mistake float.

--- a/.changeset/from-executor.md
+++ b/.changeset/from-executor.md
@@ -1,0 +1,30 @@
+---
+"unthrown": minor
+---
+
+Add `fromExecutor` — the callback-API boundary.
+
+`fromPromise` needs a promise, so bridging a callback or event API meant two
+nested wrappers, `fromSafePromise(new Promise((resolve) => …))`. `fromExecutor`
+is the single boundary, and its settler takes a **`Result`**:
+
+```ts
+const startServer = (port: number) =>
+  fromExecutor<Server, PortInUse>((settle, defect) => {
+    server.once("error", (cause) =>
+      isAddrInUse(cause)
+        ? settle(Err(new PortInUse(port)))
+        : settle(defect(cause)),
+    );
+    server.listen(port, () => settle(Ok(server)));
+  });
+```
+
+Because the settler names the variant there is no `qualify` to write and no
+`unknown` can reach `E`. The `defect` helper is injected alongside it — the only
+route to the defect channel from inside an asynchronous callback, where a
+`throw` runs in its own turn and would escape the boundary entirely.
+
+An `async` executor is caught at runtime rather than by the types: its rejection
+settles a `Defect` instead of floating, which is what `new Promise` does with the
+same mistake.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,8 +29,9 @@ was planned).
 3. **Qualification is enforced at every boundary.** `fromPromise` / `fromThrowable`
    take a mandatory `qualify: (cause: unknown, defect) => E | Defect`, where
    `defect` is a helper the boundary **injects** as the second argument (domain
-   code never imports it — the qualify-time marker is not a public value).
-   `qualify` is **synchronous**: its return intersects `NotThenable`, so an
+   code never imports it — the qualify-time marker is not a public value);
+   `fromExecutor` injects the same helper as its executor's second argument,
+   with no `qualify` to write. `qualify` is **synchronous**: its return intersects `NotThenable`, so an
    `async` qualify does not compile (its `Promise` would land in `E`
    un-triaged); a thenable slipped past the types at runtime becomes a `Defect`
    (never `Err(Promise)`), and the orphaned thenable is adopted-and-silenced so
@@ -479,8 +480,9 @@ Defect>`); flatMapErrCases: `OkOf`/`ErrOf` — plus `AsyncOkOf`/`AsyncErrOf` on 
   companion aliases them as `AsyncResult.Ok` / `AsyncResult.Err` (suffix dropped,
   same rule as `AsyncResult.all`). A **deliberate** defect needs no constructor
   either — the `defect` helper is **injected wherever a triage decision is
-  made, and nowhere else**: `qualify` at a boundary (Thesis #3) and the
-  error-match branches (Thesis #5). Elsewhere the syntax
+  made, and nowhere else**: `qualify` at a boundary (Thesis #3), an executor
+  passed to `fromExecutor` (the same sanctioned injection, `qualify`-free), and
+  the error-match branches (Thesis #5). Elsewhere the syntax
   is `throw` (the throw → defect invariant is the safety net; a
   known-technical precondition throws in a plain helper wrapped once at its
   origin with `fromSafeThrowable`). A public minting helper was weighed and
@@ -498,7 +500,9 @@ Defect>`); flatMapErrCases: `OkOf`/`ErrOf` — plus `AsyncOkOf`/`AsyncErrOf` on 
   injected alongside it, the triage-site rule of Thesis #3, and is the only route
   to the defect channel from inside an asynchronous callback. `T`/`E` come from
   explicit type arguments or an annotated target — a settler is a parameter, so
-  nothing infers them. An executor that never settles never resolves, the one
+  nothing infers them; both default to `never`, so supplying neither is a
+  compile error at the `settle(...)` call rather than an `unknown` channel. An
+  executor that never settles never resolves, the one
   hazard `fromPromise` does not have.)
 - aggregate: `all` / `allAsync` take a **tuple/array** (a fixed tuple keeps
   positional types; a dynamic `Result<T, E>[]` / `AsyncResult<T, E>[]` collapses

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,6 +263,18 @@ was planned).
   The type therefore over-states the success channel — `Result<Promise<T>, E>` is
   spellable but never inhabited — the mirror of `recoverErrCases`'s `never`
   under-stating the error channel. Guarded in `interop.spec.ts`.
+- **`fromExecutor`'s executor is sync too — enforced at RUNTIME, the sibling of
+  the `fromThrowable` rule above.** An `async` executor **compiles**: TypeScript's
+  void-return special case accepts a `Promise<void>` against a `=> void`
+  annotation. Neither escape works — `<T, E, R>` with `R & NotThenable<R>` makes
+  the primary call form `TS2558: Expected 3 type arguments, but got 2` (there is
+  no partial type-argument inference), and defaulting `R = void` to fix that
+  pins `R` to the default instead of inferring `Promise<void>`, so the ban never
+  fires. So the returned thenable is adopted and its rejection **settles a
+  `Defect`** unless the executor already settled — strictly better than
+  `new Promise`, which drops the same throw as a floating rejection. Guarded in
+  `interop.spec.ts` and `invariants.spec.ts`; the `TS2558` regression is guarded
+  in `types.test-d.ts`.
 - **A DISCARDED thenable is adopted, so its rejection never floats.** The
   observers (`tap`, `tapErrCases`, `tapDefect`, `tapFailure`) throw their
   callback's return away, and the `Result`-returning combinators reject a
@@ -479,7 +491,15 @@ Defect>`); flatMapErrCases: `OkOf`/`ErrOf` — plus `AsyncOkOf`/`AsyncErrOf` on 
 - interop: `fromNullable`, `fromThrowable`, `fromSafeThrowable` (the sync
   mirror of `fromSafePromise` — every throw a `Defect`, `E = never`, no
   `qualify`; the named form of the `(c, d) => d(c)` boilerplate, an explicit
-  "everything here is a defect" decision), `fromPromise`, `fromSafePromise`
+  "everything here is a defect" decision), `fromPromise`,
+  `fromSafePromise`, `fromExecutor` (the callback-API boundary — this library's
+  `new Promise`, whose settler takes a **`Result`** so the caller names the
+  variant: no `qualify`, and no `unknown` can reach `E`. The `defect` helper is
+  injected alongside it, the triage-site rule of Thesis #3, and is the only route
+  to the defect channel from inside an asynchronous callback. `T`/`E` come from
+  explicit type arguments or an annotated target — a settler is a parameter, so
+  nothing infers them. An executor that never settles never resolves, the one
+  hazard `fromPromise` does not have.)
 - aggregate: `all` / `allAsync` take a **tuple/array** (a fixed tuple keeps
   positional types; a dynamic `Result<T, E>[]` / `AsyncResult<T, E>[]` collapses
   to `Result<T[], E>` / `AsyncResult<T[], E>`), while `allFromDict` /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -451,6 +451,12 @@ Defect>`); flatMapErrCases: `OkOf`/`ErrOf` — plus `AsyncOkOf`/`AsyncErrOf` on 
   combinator callback that returns one is a compile error instead of a silently
   unqualified rejection. `FailureView<E, T>` — the exported `ErrView | DefectView`
   union a `tapFailure` callback receives (error-type-first, like `ErrView`).
+  `Settle<T, E>` — the settler a `fromExecutor` executor receives, exported for
+  the same reason `ErrMatcher` and `@unthrown/prisma`'s `TransactionClient<C>`
+  are: a helper factored out of the callback has to be able to name its
+  parameter, and deriving it from the function (`Parameters<typeof
+fromExecutor<T, E>>[0]`) is the grotesque spelling that invites a hand-copied
+  drifting duplicate instead.
   `ErrMatcher<E>` — the built-in match builder over the error
   (`ReturnType<typeof match<E>>`, i.e. `Matcher<E, E, never>`).
   `OkOf<R>` / `ErrOf<R>` / `AsyncOkOf<R>` / `AsyncErrOf<R>` — public

--- a/docs/how-to/qualify-a-boundary.md
+++ b/docs/how-to/qualify-a-boundary.md
@@ -147,6 +147,37 @@ const status = await user.match({
 });
 ```
 
+## Bridging a callback API
+
+`fromPromise` needs a promise. When the API you are bridging is callback- or
+event-based, `fromExecutor` is the boundary — the `new Promise` of this library,
+except that the settler takes a `Result`:
+
+```ts
+import { fromExecutor, Err, Ok } from "unthrown";
+
+const startServer = (port: number) =>
+  fromExecutor<Server, PortInUse>((settle, defect) => {
+    server.once("error", (cause) =>
+      isAddrInUse(cause)
+        ? settle(Err(new PortInUse(port)))
+        : settle(defect(cause)),
+    );
+    server.listen(port, () => settle(Ok(server)));
+  });
+```
+
+Because the settler names the variant, there is no `qualify` to write and no
+`unknown` can reach `E`. The injected `defect` helper is how an unmodeled
+failure reaches the defect channel — and it is the _only_ way from inside an
+asynchronous callback, since a `throw` there runs in its own turn, long after
+the executor body returned.
+
+Two things to know. `T` and `E` cannot be inferred from the body, so supply them
+explicitly or let them flow from an annotated target. And an executor that never
+settles yields an `AsyncResult` that never resolves — the one hazard
+`fromPromise` does not have, and exactly `new Promise`'s.
+
 ## Where to go next
 
 - Fold that handler cleanly: [Handle results at the edge](./handle-results-at-the-edge).

--- a/docs/how-to/qualify-a-boundary.md
+++ b/docs/how-to/qualify-a-boundary.md
@@ -14,6 +14,7 @@ that matches the shape of the edge.
 | a throwing function, every throw a bug       | `fromSafeThrowable` | `never`                    |
 | a rejecting promise, some rejections modeled | `fromPromise`       | `Exclude<qualify, Defect>` |
 | a rejecting promise, every rejection a bug   | `fromSafePromise`   | `never`                    |
+| a callback-style API (events, listeners)     | `fromExecutor`      | your modeled `E`           |
 
 ## `fromNullable` — absence as a modeled error
 

--- a/docs/reference/combinators.md
+++ b/docs/reference/combinators.md
@@ -208,8 +208,8 @@ where enumeration is impossible — see
 
 Every combinator above exists on **both** `Result` and `AsyncResult` — same names,
 same channel behavior. `AsyncResult` (what you get from `fromPromise` /
-`fromSafePromise`, or by lifting a sync `Result` with `.toAsync()`) differs in
-exactly three ways:
+`fromSafePromise` / `fromExecutor`, or by lifting a sync `Result` with
+`.toAsync()`) differs in exactly three ways:
 
 - **Callbacks stay synchronous.** A raw `Promise` may never enter a combinator —
   that would skip qualification and silently become a defect. Do async work by

--- a/docs/reference/result-surface.md
+++ b/docs/reference/result-surface.md
@@ -162,13 +162,14 @@ const [a, b] = (
 
 ## Interop constructors
 
-| Function            | Produces                  | Purpose                                    |
-| ------------------- | ------------------------- | ------------------------------------------ |
-| `fromNullable`      | `Result<T, E>`            | `null`/`undefined` → modeled `Err`         |
-| `fromThrowable`     | `(…) => Result<T, E>`     | wrap a throwing fn; mandatory `qualify`    |
-| `fromSafeThrowable` | `(…) => Result<T, never>` | wrap a throwing fn; every throw a `Defect` |
-| `fromPromise`       | `AsyncResult<T, E>`       | wrap a promise; mandatory `qualify`        |
-| `fromSafePromise`   | `AsyncResult<T, never>`   | wrap a promise; every rejection a `Defect` |
+| Function            | Produces                  | Purpose                                        |
+| ------------------- | ------------------------- | ---------------------------------------------- |
+| `fromNullable`      | `Result<T, E>`            | `null`/`undefined` → modeled `Err`             |
+| `fromThrowable`     | `(…) => Result<T, E>`     | wrap a throwing fn; mandatory `qualify`        |
+| `fromSafeThrowable` | `(…) => Result<T, never>` | wrap a throwing fn; every throw a `Defect`     |
+| `fromPromise`       | `AsyncResult<T, E>`       | wrap a promise; mandatory `qualify`            |
+| `fromSafePromise`   | `AsyncResult<T, never>`   | wrap a promise; every rejection a `Defect`     |
+| `fromExecutor`      | `AsyncResult<T, E>`       | wrap a callback API; settler names the variant |
 
 Their tasks and signatures are covered in
 [Qualify a boundary](../how-to/qualify-a-boundary).

--- a/docs/typedoc.core.json
+++ b/docs/typedoc.core.json
@@ -27,7 +27,6 @@
     "AsyncResultRecord",
     "ExhaustiveMatch",
     "MatchOut",
-    "Settle",
     "NonExhaustive",
     "MatchedOf",
     "Unset",

--- a/docs/typedoc.core.json
+++ b/docs/typedoc.core.json
@@ -27,6 +27,7 @@
     "AsyncResultRecord",
     "ExhaustiveMatch",
     "MatchOut",
+    "Settle",
     "NonExhaustive",
     "MatchedOf",
     "Unset",

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -90,8 +90,9 @@ export type Result<T, E> = ResultType<T, E>;
  *
  * @remarks
  * The async sibling of {@link Result}. Statics are grouped by what they
- * **return**, so the pre-lifted constructors, `fromPromise`/`fromSafePromise`,
- * and the async aggregates sit here rather than on {@link Result}; the namespace
+ * **return**, so the pre-lifted constructors, `fromExecutor`,
+ * `fromPromise`/`fromSafePromise`, and the async aggregates sit here rather
+ * than on {@link Result}; the namespace
  * already conveys "async", so the members drop the `Async` suffix their free
  * functions carry (`AsyncResult.Ok` is `OkAsync`; `AsyncResult.Err` is
  * `ErrAsync`; `AsyncResult.Do` is `DoAsync`; `AsyncResult.all` is `allAsync`;

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -12,6 +12,7 @@ import {
   allAsync,
   allFromDict,
   allFromDictAsync,
+  fromExecutor,
   fromNullable,
   fromPromise,
   fromSafePromise,
@@ -83,9 +84,9 @@ export type Result<T, E> = ResultType<T, E>;
 /**
  * Companion object grouping the **`AsyncResult`-producing** entry points under
  * the matching namespace: {@link AsyncResult.Ok}, {@link AsyncResult.Err},
- * {@link AsyncResult.Do}, {@link AsyncResult.fromPromise},
- * {@link AsyncResult.fromSafePromise}, {@link AsyncResult.all},
- * {@link AsyncResult.allFromDict}.
+ * {@link AsyncResult.Do}, {@link AsyncResult.fromExecutor},
+ * {@link AsyncResult.fromPromise}, {@link AsyncResult.fromSafePromise},
+ * {@link AsyncResult.all}, {@link AsyncResult.allFromDict}.
  *
  * @remarks
  * The async sibling of {@link Result}. Statics are grouped by what they
@@ -115,6 +116,7 @@ export const AsyncResult = {
   Ok: OkAsync,
   Err: ErrAsync,
   Do: DoAsync,
+  fromExecutor,
   fromPromise,
   fromSafePromise,
   all: allAsync,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ export {
   allAsync,
   allFromDict,
   allFromDictAsync,
+  fromExecutor,
   fromNullable,
   fromPromise,
   fromSafePromise,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,7 @@ export {
 } from "./interop.js";
 export { TaggedError } from "./tagged.js";
 
+export type { Settle } from "./interop.js";
 export type { TaggedErrorConstructor, TaggedErrorInstance } from "./tagged.js";
 export type {
   AsyncErrOf,

--- a/packages/core/src/interop.spec.ts
+++ b/packages/core/src/interop.spec.ts
@@ -332,4 +332,18 @@ describe("fromExecutor", () => {
     });
     expectOk(r, 1);
   });
+
+  it("settles a Defect through the injected helper", async () => {
+    const r = await fromExecutor<number, never>((settle, defect) => {
+      settle(defect(boom));
+    });
+    expectDefect(r);
+  });
+
+  it("routes an asynchronous callback's failure to the defect channel", async () => {
+    const r = await fromExecutor<number, never>((settle, defect) => {
+      setTimeout(() => settle(defect(boom)), 0);
+    });
+    expectDefect(r);
+  });
 });

--- a/packages/core/src/interop.spec.ts
+++ b/packages/core/src/interop.spec.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   type AsyncResult,
+  Err,
+  fromExecutor,
   fromNullable,
   fromPromise,
   fromSafePromise,
@@ -298,5 +300,36 @@ describe("the SYNC boundaries reject an async fn", () => {
       expect(r.value.then).toBe(1);
       expect(r.value.ok).toBe(true);
     }
+  });
+});
+
+describe("fromExecutor", () => {
+  it("settles Ok from an asynchronous callback", async () => {
+    const r = await fromExecutor<number, never>((settle) => {
+      setTimeout(() => settle(Ok(1)), 0);
+    });
+    expectOk(r, 1);
+  });
+
+  it("settles Err from an asynchronous callback", async () => {
+    const r = await fromExecutor<number, "nope">((settle) => {
+      setTimeout(() => settle(Err("nope")), 0);
+    });
+    expectErr(r, "nope");
+  });
+
+  it("settles synchronously when the executor settles synchronously", async () => {
+    const r = await fromExecutor<number, never>((settle) => {
+      settle(Ok(7));
+    });
+    expectOk(r, 7);
+  });
+
+  it("ignores a second settle — the first wins", async () => {
+    const r = await fromExecutor<number, "late">((settle) => {
+      settle(Ok(1));
+      settle(Err("late"));
+    });
+    expectOk(r, 1);
   });
 });

--- a/packages/core/src/interop.spec.ts
+++ b/packages/core/src/interop.spec.ts
@@ -346,4 +346,27 @@ describe("fromExecutor", () => {
     });
     expectDefect(r);
   });
+
+  it("turns a synchronous throw in the executor body into a Defect", async () => {
+    const r = await fromExecutor<number, never>(() => {
+      throw boom;
+    });
+    expectDefect(r);
+  });
+
+  it("turns a non-Result handed to settle into a Defect", async () => {
+    const r = await fromExecutor<number, never>((settle) => {
+      (settle as unknown as (value: unknown) => void)(42);
+    });
+    expect(r.tag).toBe("Defect");
+    if (r.tag === "Defect") expect(r.cause).toBeInstanceOf(TypeError);
+  });
+
+  it("keeps the first settle when the body throws afterwards", async () => {
+    const r = await fromExecutor<number, never>((settle) => {
+      settle(Ok(1));
+      throw boom;
+    });
+    expectOk(r, 1);
+  });
 });

--- a/packages/core/src/interop.spec.ts
+++ b/packages/core/src/interop.spec.ts
@@ -369,4 +369,21 @@ describe("fromExecutor", () => {
     });
     expectOk(r, 1);
   });
+
+  it("routes an async executor's rejection to the defect channel", async () => {
+    // An `async` executor type-checks — see the runtime-not-types note in
+    // CLAUDE.md. `new Promise` would drop this throw as a floating rejection.
+    const r = await fromExecutor<number, never>(async () => {
+      throw boom;
+    });
+    expectDefect(r);
+  });
+
+  it("keeps a settled value when an async executor rejects afterwards", async () => {
+    const r = await fromExecutor<number, never>(async (settle) => {
+      settle(Ok(1));
+      throw boom;
+    });
+    expectOk(r, 1);
+  });
 });

--- a/packages/core/src/interop.ts
+++ b/packages/core/src/interop.ts
@@ -298,7 +298,10 @@ export type Settle<T, E> = (result: Result<T, E> | Defect) => void;
  * its own turn, long after the executor body returned).
  *
  * `T` and `E` cannot be inferred from the body, since `settle` is a parameter.
- * Supply them explicitly, or let them flow from an annotated target.
+ * Supply them explicitly, or let them flow from an annotated target. Absent
+ * either, both default to `never` (Thesis #3: no path may produce `unknown` in
+ * `E`) — so an unannotated call is a compile error at the `settle(...)` call
+ * site, not a silently-`unknown` channel.
  *
  * An executor that never settles yields an `AsyncResult` that never resolves —
  * the one hazard {@link fromPromise} does not have, and identical to
@@ -323,7 +326,7 @@ export type Settle<T, E> = (result: Result<T, E> | Defect) => void;
  *   });
  * ```
  */
-export function fromExecutor<T, E>(
+export function fromExecutor<T = never, E = never>(
   executor: (settle: Settle<T, E>, defect: (cause: unknown) => Defect) => void,
 ): AsyncResult<T, E> {
   let resolve!: (result: Result<T, E>) => void;
@@ -337,6 +340,11 @@ export function fromExecutor<T, E>(
       return;
     }
     if (!isResult(result)) {
+      // A smuggled thenable (a raw-JS/cast caller passing a Promise instead of
+      // a Result) would otherwise be dropped mid-flight; adopt-and-silence so
+      // its later rejection can't float — the sibling of qualifyToResult's and
+      // thenableReturnDefect's nets.
+      if (isThenable(result)) void Promise.resolve(result).then(undefined, () => undefined);
       resolve(
         defectRes<T, E>(
           new TypeError("unthrown: fromExecutor's settle received a non-Result value"),

--- a/packages/core/src/interop.ts
+++ b/packages/core/src/interop.ts
@@ -282,6 +282,8 @@ export function fromSafePromise<T>(
  *
  * @typeParam T - the success type.
  * @typeParam E - the modeled error type.
+ *
+ * @category Types
  */
 export type Settle<T, E> = (result: Result<T, E> | Defect) => void;
 

--- a/packages/core/src/interop.ts
+++ b/packages/core/src/interop.ts
@@ -275,6 +275,90 @@ export function fromSafePromise<T>(
   return new AsyncRes<T, never>(settled);
 }
 
+/**
+ * The settler a {@link fromExecutor} executor receives. Settles the pending
+ * `AsyncResult` **once** — later calls are no-ops, exactly as `resolve` is on a
+ * `Promise`.
+ *
+ * @typeParam T - the success type.
+ * @typeParam E - the modeled error type.
+ */
+export type Settle<T, E> = (result: Result<T, E> | Defect) => void;
+
+/**
+ * Build an {@link AsyncResult} from a callback-style API — this library's
+ * answer to `new Promise((resolve, reject) => …)`.
+ *
+ * @remarks
+ * The settler takes a **`Result`**, not a value-or-reason pair: the caller names
+ * the variant, so no `unknown` can enter `E` and there is no `qualify` to pass.
+ * For a failure that is *not* modeled, settle the injected `defect` helper's
+ * marker — the same injection `qualify` receives, and the only way to reach the
+ * defect channel from inside an asynchronous callback (a `throw` there runs in
+ * its own turn, long after the executor body returned).
+ *
+ * `T` and `E` cannot be inferred from the body, since `settle` is a parameter.
+ * Supply them explicitly, or let them flow from an annotated target.
+ *
+ * An executor that never settles yields an `AsyncResult` that never resolves —
+ * the one hazard {@link fromPromise} does not have, and identical to
+ * `new Promise`.
+ *
+ * @typeParam T - the success type.
+ * @typeParam E - the modeled error type.
+ * @param executor - runs immediately; receives the settler and the `defect` helper.
+ *
+ * @category Interop
+ *
+ * @example
+ * ```ts
+ * import { fromExecutor, Err, Ok } from "unthrown";
+ *
+ * const listen = (port: number) =>
+ *   fromExecutor<Server, PortInUse>((settle, defect) => {
+ *     server.once("error", (cause) =>
+ *       isAddrInUse(cause) ? settle(Err(new PortInUse(port))) : settle(defect(cause)),
+ *     );
+ *     server.listen(port, () => settle(Ok(server)));
+ *   });
+ * ```
+ */
+export function fromExecutor<T, E>(
+  executor: (settle: Settle<T, E>, defect: (cause: unknown) => Defect) => void,
+): AsyncResult<T, E> {
+  let resolve!: (result: Result<T, E>) => void;
+  const promise = new Promise<Result<T, E>>((r) => {
+    resolve = r;
+  });
+
+  const settle: Settle<T, E> = (result) => {
+    if (isDefectMarker(result)) {
+      resolve(defectRes<T, E>(result.cause));
+      return;
+    }
+    if (!isResult(result)) {
+      resolve(
+        defectRes<T, E>(
+          new TypeError("unthrown: fromExecutor's settle received a non-Result value"),
+        ),
+      );
+      return;
+    }
+    resolve(result);
+  };
+
+  try {
+    const returned: unknown = executor(settle, defect);
+    if (isThenable(returned)) {
+      void Promise.resolve(returned).then(undefined, (cause: unknown) => settle(defect(cause)));
+    }
+  } catch (cause) {
+    settle(defect(cause));
+  }
+
+  return new AsyncRes<T, E>(promise);
+}
+
 function qualifyToResult<T, E>(
   cause: unknown,
   qualify: (cause: unknown, defect: (cause: unknown) => Defect) => E | Defect,

--- a/packages/core/src/invariants.spec.ts
+++ b/packages/core/src/invariants.spec.ts
@@ -330,6 +330,11 @@ describe("Invariant 6: a DISCARDED thenable is adopted, so its rejection never f
     ["flatTap", (t: PromiseLike<never>) => Ok(1).flatTap((() => t) as never)],
     ["bind", (t: PromiseLike<never>) => Do().bind("a", (() => t) as never)],
     ["fromExecutor", (t: PromiseLike<never>) => fromExecutor<number, never>(() => t)],
+    [
+      "fromExecutor settle",
+      (t: PromiseLike<never>) =>
+        fromExecutor<number, never>((s) => (s as unknown as (v: unknown) => void)(t)),
+    ],
   ])("%s adopts a smuggled thenable rather than dropping it", async (_label, run) => {
     await expectAdopted(run);
   });

--- a/packages/core/src/invariants.spec.ts
+++ b/packages/core/src/invariants.spec.ts
@@ -5,7 +5,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 
-import { Do, Err, fromSafePromise, Ok, P, type Result, GetError } from "./index.js";
+import { Do, Err, fromExecutor, fromSafePromise, Ok, P, type Result, GetError } from "./index.js";
 import { adoptionProbe, boom, defectOf, flushMicrotasks } from "./test-helpers.js";
 
 describe("Invariant 1: throw inside any combinator becomes a Defect", () => {
@@ -276,6 +276,15 @@ describe("Invariant 5: an AsyncResult's internal promise never rejects", () => {
     const defectR = await fromSafePromise(Promise.reject(boom));
     expect(okR.get()).toBe(1);
     expect(defectR.isDefect()).toBe(true);
+    await expect(
+      fromExecutor<number, never>(() => {
+        throw boom;
+      }),
+    ).resolves.toMatchObject({});
+    const executorR = await fromExecutor<number, never>(async () => {
+      throw boom;
+    });
+    expect(executorR.isDefect()).toBe(true);
   });
 });
 
@@ -320,6 +329,7 @@ describe("Invariant 6: a DISCARDED thenable is adopted, so its rejection never f
     ["flatMap", (t: PromiseLike<never>) => Ok(1).flatMap((() => t) as never)],
     ["flatTap", (t: PromiseLike<never>) => Ok(1).flatTap((() => t) as never)],
     ["bind", (t: PromiseLike<never>) => Do().bind("a", (() => t) as never)],
+    ["fromExecutor", (t: PromiseLike<never>) => fromExecutor<number, never>(() => t)],
   ])("%s adopts a smuggled thenable rather than dropping it", async (_label, run) => {
     await expectAdopted(run);
   });

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -1216,3 +1216,11 @@ void fromExecutor<number, "boom">((settle) => {
   // @ts-expect-error - "other" is not in the error channel
   settle(Err("other"));
 });
+
+// No explicit type arguments and no annotated target: T/E default to `never`,
+// so settling anything but a Defect is a compile error at the call — never a
+// silent `unknown` channel (Thesis #3).
+void fromExecutor((settle) => {
+  // @ts-expect-error - T/E default to never with no explicit args or contextual target
+  settle(Ok(1));
+});

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -25,6 +25,7 @@ import {
   ErrAsync,
   type ErrView,
   type FailureView,
+  fromExecutor,
   fromPromise,
   fromSafeThrowable,
   fromThrowable,
@@ -1185,3 +1186,33 @@ declare function sometimesWork(): Promise<number>;
   const locked = lock(r);
   type _Locked = Expect<Equal<typeof locked, Result<number, ApiError>>>;
 }
+
+// --- fromExecutor: two type arguments, no third generic for NotThenable -----
+
+// fromExecutor: the two-type-argument call compiles. A third generic (for a
+// `R & NotThenable<R>` executor return) would make this `TS2558: Expected 3
+// type arguments, but got 2` — see CLAUDE.md's runtime-not-types invariant.
+const fromExecutorExplicit = fromExecutor<number, "boom">((settle) => {
+  settle(Ok(1));
+});
+type _FromExecutorExplicit = Expect<
+  Equal<typeof fromExecutorExplicit, AsyncResult<number, "boom">>
+>;
+
+// T/E flow from an annotated target, so a call site with a typed home needs no
+// explicit type arguments.
+type ExecutorClock = { readonly sleep: (ms: number) => AsyncResult<void, never> };
+const executorClock: ExecutorClock = {
+  sleep: (ms) =>
+    fromExecutor((settle) => {
+      void ms;
+      settle(Ok());
+    }),
+};
+void executorClock;
+
+// settle rejects a Result outside the declared channels.
+void fromExecutor<number, "boom">((settle) => {
+  // @ts-expect-error - "other" is not in the error channel
+  settle(Err("other"));
+});

--- a/packages/oxlint/src/rules/no-unhandled-result.test.ts
+++ b/packages/oxlint/src/rules/no-unhandled-result.test.ts
@@ -15,6 +15,7 @@ const FREE_PRODUCERS = [
   "fromSafeThrowable",
   "fromPromise",
   "fromSafePromise",
+  "fromExecutor",
   "all",
   "allAsync",
   "allFromDict",

--- a/packages/oxlint/src/rules/no-unhandled-result.ts
+++ b/packages/oxlint/src/rules/no-unhandled-result.ts
@@ -20,6 +20,7 @@ const FREE_PRODUCERS: ReadonlySet<string> = new Set([
   "fromSafeThrowable",
   "fromPromise",
   "fromSafePromise",
+  "fromExecutor",
   "all",
   "allAsync",
   "allFromDict",
@@ -40,7 +41,16 @@ const COMPANION_PRODUCERS: Readonly<Record<string, ReadonlySet<string>>> = {
     "all",
     "allFromDict",
   ]),
-  AsyncResult: new Set(["Ok", "Err", "Do", "fromPromise", "fromSafePromise", "all", "allFromDict"]),
+  AsyncResult: new Set([
+    "Ok",
+    "Err",
+    "Do",
+    "fromExecutor",
+    "fromPromise",
+    "fromSafePromise",
+    "all",
+    "allFromDict",
+  ]),
 };
 
 /**

--- a/skills/unthrown/SKILL.md
+++ b/skills/unthrown/SKILL.md
@@ -76,6 +76,7 @@ import {
   fromThrowable,
   fromSafeThrowable,
   fromSafePromise,
+  fromExecutor,
   fromNullable,
 } from "unthrown";
 
@@ -95,6 +96,12 @@ parse("nope"); // => Err("invalid_json")
 // "every throw here is a bug" → E = never, no qualify
 const decode = fromSafeThrowable((row: Row) => schema.parse(row));
 const cfg = fromSafePromise(loadConfig()); // async twin
+
+// callback/event APIs: the settler takes a Result, so there is no qualify
+const ready = fromExecutor<Server, PortInUse>((settle, defect) => {
+  server.once("error", (c) => settle(defect(c)));
+  server.listen(port, () => settle(Ok(server)));
+});
 
 // nullable APIs (the Option replacement)
 fromNullable(map.get(key), () => "absent" as const); // Result<V, "absent">

--- a/skills/unthrown/references/api.md
+++ b/skills/unthrown/references/api.md
@@ -176,8 +176,8 @@ group them **by what they return**:
 - `Result.*`: `Ok`, `Err`, `Do`, `fromNullable`, `fromThrowable`,
   `fromSafeThrowable`, `all`, `allFromDict`, `isOk`/`isErr`/`isDefect`/`isResult`.
 - `AsyncResult.*`: `Ok` (= `OkAsync`), `Err` (= `ErrAsync`), `Do`
-  (= `DoAsync`), `fromPromise`, `fromSafePromise`, `all` (= `allAsync`),
-  `allFromDict` (= `allFromDictAsync`).
+  (= `DoAsync`), `fromExecutor`, `fromPromise`, `fromSafePromise`, `all`
+  (= `allAsync`), `allFromDict` (= `allFromDictAsync`).
 
 Both are value + type companions — `Result<T, E>` / `AsyncResult<T, E>` are the
 same names as types.


### PR DESCRIPTION
## Why

`fromPromise` needs a promise, so bridging a callback or event API meant two nested wrappers:

```ts
// start/packages/start/src/clock.ts — sleep, a setTimeout + abort bridge
fromSafePromise(new Promise<void>((resolve) => { … }))
```

That form appears at **5 production sites** (all in `start`) and **17 more** in tests and examples across four repos — seven of those in this repo's own `packages/vitest/src/index.spec.ts`.

`start/probes.ts:23` is the shape that decided the design: it nests the executor *and* flattens a nested `Result` afterwards (`.flatMap((r) => r)` at line 66). Making the settler take a **`Result`** collapses all three into one call.

## What

```ts
export function fromExecutor<T = never, E = never>(
  executor: (settle: Settle<T, E>, defect: (cause: unknown) => Defect) => void,
): AsyncResult<T, E>;
```

```ts
const startServer = (port: number) =>
  fromExecutor<Server, PortInUse>((settle, defect) => {
    server.once("error", (cause) =>
      isAddrInUse(cause) ? settle(Err(new PortInUse(port))) : settle(defect(cause)),
    );
    server.listen(port, () => settle(Ok(server)));
  });
```

Because the settler names the variant there is no `qualify` to write and no `unknown` can reach `E`. The `defect` helper is injected alongside it — the only route to the defect channel from inside an *asynchronous* callback, where a `throw` runs in its own turn and would escape the boundary entirely.

## Two decisions worth reviewing

**An `async` executor is caught at runtime, not by the types.** Every other thenable ban in the library is a compile error; this one cannot be. Both spellings were probed and both fail:

- `<T, E, R>` with `R & NotThenable<R>` makes the primary call form `TS2558: Expected 3 type arguments, but got 2` — TypeScript has no partial type-argument inference.
- Adding `R = void` to fix that makes an `async` executor compile *silently*: the default is taken instead of inferring `Promise<void>`, so `NotThenable` never sees the thenable.

So the returned thenable is adopted and its rejection **settles a `Defect`** unless the executor already settled — strictly better than `new Promise`, which lets the same throw float. This is the sibling of the existing "a sync boundary's `fn` is sync too, enforced at RUNTIME" invariant.

**`T`/`E` default to `never`.** A settler is a parameter, so nothing infers `T`/`E` from the body; unannotated they used to land on `unknown`, which made Thesis #3's "there is no path that produces `unknown` in `E`" literally false. The defaults turn that into a compile error at the `settle(...)` call. Explicit type arguments and contextual inference from an annotated target both behave exactly as before.

## Guards

- `interop.spec.ts` — Ok/Err settle, settle-once, the injected `defect` (including from an async callback), sync throw, non-`Result` settle, settle-then-throw, async-executor rejection.
- `invariants.spec.ts` — rows added to Invariant 5 (internal promise never rejects, both defect routes) and Invariant 6 (adoption, on **both** the executor-return and settle paths). Each adoption net was verified load-bearing by deleting it and confirming the guard fails.
- `types.test-d.ts` — the `TS2558` regression guard (any future third type parameter breaks it), contextual inference, and `settle` rejecting an out-of-channel `Result`.
- Core stays at 100% line/function coverage. Zero new dependencies.

## Also

`no-unhandled-result` now knows `fromExecutor`, so a dropped statement is reported like any other producer. CLAUDE.md's `defect`-injection enumeration and Thesis #3 now name the executor as a sanctioned injection site, and the three docs tables that enumerate the boundary family list it.

## Gate

`format --check`, `lint`, `typecheck`, `knip`, `test` (17/17, drizzle's Docker-backed suite included), `build` — all green at `a787dac`.