### PR TITLE
fix(oxlint): restore no-throw, and document Prisma's modeled-code boundary

### DIFF
--- a/.changeset/olive-badgers-repeat.md
+++ b/.changeset/olive-badgers-repeat.md
@@ -1,0 +1,23 @@
+---
+"@unthrown/prisma": patch
+---
+
+Document the modeled P-code set as a **boundary**, not a menu (#226). `P2002`,
+`P2003`, `P2018` and `P2025` are the whole of it — every other code (`P2007`,
+`P2023`, `P2000`, `P2011`, `P2015`, …) is a `Defect`, including ones that read
+like domain outcomes.
+
+The README and the Prisma guide now state that next to the per-operation table,
+with the consequence spelled out: where a defect is _retried_ rather than
+surfaced — a Temporal activity rethrows it, so it is retried, while an `Err`
+converted to a non-retryable failure fails fast — a code like `P2007` from a
+malformed id retries forever on input that can never succeed.
+
+The guide also gains a **"Migrating a hand-rolled qualifier"** recipe: diff your
+old `try`/`catch` qualifier against those four codes, and re-qualify anything
+else with `recoverDefect` (rethrowing the causes you did not name, so they stay
+defects). The migration is otherwise silent — the type check passes, since the
+`Err` channel legitimately shrank, and a repository unit test on the `Ok` path
+passes too.
+
+Documentation only; no runtime or type change.

--- a/.changeset/wild-pandas-return.md
+++ b/.changeset/wild-pandas-return.md
@@ -1,0 +1,23 @@
+---
+"@unthrown/oxlint": minor
+---
+
+Restore the `no-throw` rule, removed in 5.4.0 (#227). It is unchanged and still
+**opt-in** — not part of the `recommended` preset, since it bans a core language
+statement.
+
+The 5.4.0 removal reasoned that an unconditional `ThrowStatement` report belongs
+in a `no-restricted-syntax` entry rather than a rule. **oxlint does not implement
+`no-restricted-syntax`**, so that migration path does not exist: a codebase that
+bans `throw` outright had no way left to enforce it. And because oxlint refuses
+to parse a config naming an unknown rule, the upgrade did not degrade to a
+warning — it failed the consumer's _entire_ lint run, every non-unthrown rule
+included, on a minor.
+
+Nothing to do to adopt: a config that still names `"unthrown/no-throw"` resolves
+again, and existing `oxlint-disable-next-line unthrown/no-throw` comments point
+at a rule that exists once more.
+
+`prefer-ensure` stays removed. It flagged correct code that violates no thesis —
+a report-only refactor suggestion, with a known false positive, that was not
+paying for its AST analysis. Configs naming it should drop the entry.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -734,10 +734,10 @@ AsyncResult<infer T, …>` — structural inference over the whole method surfac
   `Result` via `fromSchema` / `fromSchemaAsync`, with the validation issues as
   the modeled `E`)
 - `packages/oxlint` → `@unthrown/oxlint` (an oxlint **JS plugin**, peerDep
-  `oxlint`, dep `@oxlint/plugins`; ships **six rules** — five in the
+  `oxlint`, dep `@oxlint/plugins`; ships **seven rules** — five in the
   `recommended` preset (`no-ambiguous-error-type`, `no-catch-all-pattern`,
   `no-unhandled-result`, `no-unused-matcher`, `prefer-async-result`) plus the
-  opt-in `no-get-or-throw`. Purely syntactic AST rules. No TypeDoc API page;
+  opt-ins `no-get-or-throw` and `no-throw`. Purely syntactic AST rules. No TypeDoc API page;
   documented in the Linting guide. Full spec: `packages/oxlint/CLAUDE.md`.)
 - `packages/prisma` → `@unthrown/prisma` (peerDep `@prisma/client` ^7; a Prisma
   Client **extension** — `$extends(unthrownPrisma)` adds `try*` `AsyncResult`

--- a/docs/how-to/lint-your-codebase.md
+++ b/docs/how-to/lint-your-codebase.md
@@ -4,7 +4,7 @@
 > is an [oxlint](https://oxc.rs/docs/guide/usage/linter) plugin that turns
 > unthrown's theses into automated checks the type system can't enforce on its
 > own — a lazy `E`, a dropped `Result`, a blanket `P._`, an ignored matcher, a
-> thrown-away error channel.
+> raw `throw`, a thrown-away error channel.
 
 ```sh
 pnpm add -D @unthrown/oxlint oxlint
@@ -22,6 +22,7 @@ Register the plugin and turn its rules on in your `.oxlintrc.json`:
     "unthrown/no-unhandled-result": "error",
     "unthrown/no-unused-matcher": "error",
     "unthrown/prefer-async-result": "error",
+    "unthrown/no-throw": "error",
     "unthrown/no-get-or-throw": "error",
     "unthrown/no-catch-all-pattern": "error"
   },
@@ -37,8 +38,8 @@ Register the plugin and turn its rules on in your `.oxlintrc.json`:
 The default export also exposes a `recommended` preset — an oxlint config that
 registers the plugin and enables `no-ambiguous-error-type`, `no-unhandled-result`,
 `no-unused-matcher`, `prefer-async-result`, and `no-catch-all-pattern`
-(`no-get-or-throw` is the one explicit opt-in) — for setups that build their
-config programmatically
+(`no-throw` and `no-get-or-throw` are the two explicit opt-ins) — for setups
+that build their config programmatically
 (`import unthrown from "@unthrown/oxlint"` → `unthrown.recommended`).
 
 `oxlint` is a peer dependency; JS plugins require oxlint ≥ 1.69.
@@ -179,9 +180,44 @@ imports included); the facade companions (`Result.Ok(...)`); and a
 `Result`-ness lives behind an imported declaration needs the type checker and is
 out of scope — no false positives is the design priority.
 
+### `unthrown/no-throw` {#no-throw}
+
+**An opt-in rule** — not part of the `recommended` preset, because it bans a
+core language statement. For codebases committed to errors-as-values
+end-to-end, it closes the loop: ordinary errors are _returned_, so a raw
+`throw` is either a modeled failure in disguise or an unmodeled one that
+belongs to the defect channel's machinery.
+
+```ts
+function parse(input: string) {
+  if (!input) throw new Error("empty"); // ✗ — return Err(new EmptyInput()) instead
+}
+```
+
+Every sanctioned form is a call, not a statement, so the rule stays clean on
+them: a modeled failure → `return Err(...)`; a failure that is genuinely
+unmodeled here → fold it into the defect channel with
+[`recoverErrCases`](../reference/combinators#the-error-channel) +
+[`get`](../reference/combinators#eliminating-a-result); a known-technical
+precondition throw → keep it in a plain helper wrapped **once** with
+[`fromSafeThrowable`](./qualify-a-boundary); a genuinely deliberate remaining
+`throw` — a framework that reads the thrown value, say — → a targeted
+`// oxlint-disable-next-line unthrown/no-throw -- <reason>` comment. The rule
+has no options and no autofix — the disable comment is the escape hatch.
+
+::: warning Removed in 5.4.0, restored in 5.5.0
+This rule was deleted in `@unthrown/oxlint` 5.4.0 on the reasoning that a
+bare `ThrowStatement` report belongs in a `no-restricted-syntax` entry.
+oxlint does not implement `no-restricted-syntax`, so that left a codebase
+banning `throw` with nothing — and because oxlint refuses to parse a config
+naming an unknown rule, the upgrade failed the _whole_ lint run rather than
+just the rule ([#227](https://github.com/btravstack/unthrown/issues/227)).
+5.5.0 restores it, unchanged and still opt-in.
+:::
+
 ### `unthrown/no-get-or-throw` {#no-get-or-throw}
 
-**An opt-in rule**, and the plugin's only one. `getOrThrow()` extracts `T`
+**An opt-in rule** — the other half of `no-throw`. `getOrThrow()` extracts `T`
 but **throws the modeled error as-is** on `Err`, which abandons
 errors-as-values at the very last step: a caller of the enclosing function sees
 a throw, not a channel, and every guarantee the exhaustive matcher bought
@@ -233,6 +269,15 @@ this, and works with whatever glob your tests use:
   ]
 }
 ```
+
+#### Stacking with `no-throw`
+
+The two rules close different doors, and enabling both closes the room:
+
+|                           | `no-throw` off  | `no-throw` on                                                |
+| ------------------------- | --------------- | ------------------------------------------------------------ |
+| **`no-get-or-throw` off** | escapes: both   | escape: `getOrThrow()`                                       |
+| **`no-get-or-throw` on**  | escape: `throw` | **no lint-clean escape — fold with `recoverErrCases`+`get`** |
 
 ### `unthrown/no-catch-all-pattern` {#no-catch-all-pattern}
 

--- a/docs/how-to/use-with-prisma.md
+++ b/docs/how-to/use-with-prisma.md
@@ -51,6 +51,24 @@ that can't happen:
 `P2025` — plus `P2018`, which says the same thing from the to-many side of a
 nested write (a 404).
 
+::: danger Those four codes are the whole modeled set
+`P2002`, `P2003`, `P2018`, `P2025` — and nothing else. **Every other P-code
+becomes a [`Defect`](../explanation/the-defect-channel)**, including ones that
+read like domain outcomes: `P2007` (malformed value / inconsistent column
+data), `P2023` (inconsistent column data), `P2000` (value too long), `P2011`
+(null constraint), `P2015` (related record not found). The table above is a
+**boundary**, not a menu.
+
+That matters wherever a defect is retried rather than surfaced. Folded at an
+HTTP edge, a defect is a 500 and the request is over. Inside a **Temporal
+activity** — or any supervisor that retries on a thrown error — an `Err` you
+convert to a non-retryable failure fails fast, while a defect is rethrown and
+**retried**. A `P2007` from a malformed id can never succeed on a retry, so a
+path that carries that id (an `onError` handler, a dead-letter reprocessor)
+retries forever. Re-qualify such a code explicitly — see
+[below](#migrating-a-hand-rolled-qualifier).
+:::
+
 A **read has no modeled failure at all**. Absence is `null`, and a database that
 will not answer is a defect — so `tryFindMany` is `AsyncResult<User[], never>`.
 
@@ -112,6 +130,52 @@ Deadlocks (`P2034`) and pool timeouts (`P2024`) are defects too, so a retry
 wrapper reaches for `recoverDefect` and inspects the cause, rather than matching a
 tag. That is one place in a codebase — versus an arm at every call site.
 :::
+
+### Migrating a hand-rolled qualifier {#migrating-a-hand-rolled-qualifier}
+
+Replacing your own `try`/`catch` qualifier with `try*` is not a like-for-like
+swap: **diff your old qualifier against the four modeled codes**, because
+anything else it used to turn into an `Err` now lands on the defect channel.
+
+The migration is silent by every signal you would normally trust — the type
+check passes (the `Err` channel legitimately shrank), and a repository unit
+test asserting the `Ok` path passes too. What changes is the behaviour of the
+_failure_ path, one layer up.
+
+Re-qualify the codes you were modelling with `recoverDefect`, right where the
+query is issued:
+
+```ts
+import { RecordNotFound } from "@unthrown/prisma";
+import { Err, type AsyncResult } from "unthrown";
+
+// Recognized by `name` + a string `code`, not `instanceof`: Prisma's runtime
+// module path moves between majors, and an `instanceof` against the wrong copy
+// silently fails. This is the same check the extension itself uses.
+const hasCode = (cause: unknown, code: string): boolean =>
+  cause instanceof Error &&
+  cause.name === "PrismaClientKnownRequestError" &&
+  (cause as { code?: unknown }).code === code;
+
+const findUser = (id: string): AsyncResult<User, RecordNotFound> =>
+  db.user.tryFindUniqueOrThrow({ where: { id } }).recoverDefect((cause) => {
+    // A malformed id is the same domain outcome as a missing row — and it can
+    // never succeed on a retry, so it must not stay a defect.
+    if (hasCode(cause, "P2007")) return Err(new RecordNotFound({ cause }));
+    // oxlint-disable-next-line unthrown/no-throw -- rethrow keeps the defect intact
+    throw cause;
+  });
+```
+
+The `throw cause` is caught by the pipeline's own throw-to-defect net, so
+everything you did not name stays a defect with its original cause — no
+`try`/`catch`, and nothing untriaged leaks into `E`. Keep the comment: without
+it, the next reader "simplifies" the branch away.
+
+Re-qualifying into the error the operation _already_ models — `RecordNotFound`
+here — keeps `E` unchanged, so no call site has to grow an arm. A code that is
+genuinely a different outcome gets your own tagged error, and every exhaustive
+match on that channel stops compiling until it is handled, which is the point.
 
 ## Handle the errors
 

--- a/packages/oxlint/CLAUDE.md
+++ b/packages/oxlint/CLAUDE.md
@@ -6,7 +6,7 @@ internal design — live in the root [`CLAUDE.md`](../../CLAUDE.md) and apply
 here too.
 
 An oxlint **JS plugin**, peerDep
-`oxlint`, dep `@oxlint/plugins`; ships **six rules**: `no-ambiguous-error-type`
+`oxlint`, dep `@oxlint/plugins`; ships **seven rules**: `no-ambiguous-error-type`
 — enforces Thesis #1 against `unknown`/`any`/`Error`/`{}` **and the primitive
 keywords** (`void` included) in `E`, both in a `Result`/`AsyncResult` type
 **annotation** and in the matcher's `returnType<R>()` **pin** — the latter only
@@ -64,7 +64,16 @@ the `…Cases` method names alone (unthrown's own coinage — no receiver
 typing), a callback passed by reference is a documented miss, and there is
 deliberately **no escape hatch**: a `…Cases` callback that does not use its
 matcher is never what you meant); and
-`no-get-or-throw` (**the one opt-in** — reports
+`no-throw` (**an opt-in** — reports every `throw` statement, keyed on the
+language statement itself with nothing to resolve. Removed in 5.4.0 as "a
+`no-restricted-syntax` entry rather than a rule" and **restored in 5.5.0**
+(#227): oxlint implements no `no-restricted-syntax`, so the removal left a
+codebase that bans `throw` with no replacement, and — because oxlint refuses
+to parse a config naming an unknown rule — it hard-failed the consumer's whole
+lint run, not just this rule. Opt-in because it bans a core language statement;
+the escape hatch is a targeted `oxlint-disable` with a reason, and `index.test.ts`
+guards both its presence and its absence from the preset); and
+`no-get-or-throw` (**the other opt-in** — reports
 `getOrThrow()`, matched as a **zero-argument** member call so Effect's
 one-argument `Option.getOrThrow(o)` is untouched; a computed access and a
 detached reference are documented misses. It throws the modeled error,

--- a/packages/oxlint/README.md
+++ b/packages/oxlint/README.md
@@ -21,7 +21,8 @@ library's theses into automated checks.
 | `unthrown/no-unhandled-result`     | A `Result` / `AsyncResult` returned by a bare call (awaited or not) must not be dropped on the floor — it carries the error channel; dropping it silently discards failures. Bind it, return it, or eliminate it with `match` / a `get*` extractor.                                                                                                                                                                                                                                                                                                                |
 | `unthrown/no-catch-all-pattern`    | No `P._` catch-all in a matcher (nor ts-pattern's `P.any` alias) — enumerate every error case by name (`.with(P.tag("A"), P.tag("B"), …, handler)`, grouping cases that share a handler), so a new error can't be silently absorbed. This is unthrown's default position; `P._` is an escape hatch — a helper generic in `E`, or an `E` that is a single type rather than a union — and carries a targeted `oxlint-disable`. See [below](#the-catch-all-escape-hatch).                                                                                             |
 | `unthrown/no-unused-matcher`       | A `…Cases` callback (the five error combinators, and `match`'s `errCases` handler) must use the matcher it was handed. The injected matcher is the only builder bound to the actual error — a builder sourced elsewhere satisfies the structural `ExhaustiveMatch` constraint but picks its branch from whatever value _it_ closed over: the wrong case is recovered silently, or nothing matches and the modeled error becomes a Defect. Also flags a second `match(...)` built inside the callback's own body (branch handlers are free to match their payload). |
-| `unthrown/no-get-or-throw`         | **Opt-in** (not in `recommended`): no `getOrThrow()` — it throws the modeled error, abandoning errors-as-values at the last step. Fold the error channel instead: `recoverErrCases((matcher, defect) => …)` empties `E`, so `.get()` compiles. Matched as a **zero-argument** member call, so Effect's one-argument `Option.getOrThrow(o)` is left alone. `getOrThrow()` is right in a **test** — exempt those files with an oxlint `overrides` entry rather than a rule option.                                                                                   |
+| `unthrown/no-throw`                | **Opt-in** (not in `recommended`): no raw `throw` statements — errors are returned (`Err(...)`), only a true defect ever throws. A modeled failure → `return Err(...)`; a failure genuinely unmodeled here → `recoverErrCases` + `get` (routing the case to the injected `defect(...)`); a known-technical precondition throw → a plain helper wrapped once with `fromSafeThrowable`; a deliberate throw site carries a targeted `oxlint-disable`. oxlint ships no `no-restricted-syntax`, so this rule is the only way to enforce the ban.                        |
+| `unthrown/no-get-or-throw`         | **Opt-in** (not in `recommended`): no `getOrThrow()` — it throws the modeled error, abandoning errors-as-values at the last step. Fold the error channel instead: `recoverErrCases((matcher, defect) => …)` empties `E`, so `.get()` compiles. Matched as a **zero-argument** member call, so Effect's one-argument `Option.getOrThrow(o)` is left alone. `getOrThrow()` is right in a **test** — exempt those files with an oxlint `overrides` entry rather than a rule option. Pairs with `no-throw`: with both on, there is no escape left.                     |
 
 Most rules resolve import bindings via scope analysis (through the _imported_
 name, so renamed imports resolve too), and only fire on unthrown's own
@@ -30,7 +31,8 @@ are keyed on a **name or shape** instead — unthrown's own vocabulary, needing
 no `Result` binding to resolve: `no-get-or-throw` (a zero-argument
 `.getOrThrow()` member call), `no-unused-matcher` (the `…Cases` method names),
 and the `returnType<R>()` pin on a `mapErrCases` callback's own matcher
-parameter.
+parameter. `no-throw` is keyed on the language statement itself — it reports
+every `throw`, with nothing to resolve at all.
 
 ## Usage
 
@@ -44,6 +46,7 @@ Register the plugin and enable its rules in your `.oxlintrc.json`:
     "unthrown/no-catch-all-pattern": "error",
     "unthrown/no-get-or-throw": "error",
     "unthrown/no-unhandled-result": "error",
+    "unthrown/no-throw": "error",
     "unthrown/no-unused-matcher": "error",
     "unthrown/prefer-async-result": "error"
   },
@@ -58,8 +61,8 @@ Register the plugin and enable its rules in your `.oxlintrc.json`:
 
 The package's default export also exposes a `recommended` preset (an oxlint
 config that registers the plugin and turns the recommended rules on —
-`no-get-or-throw` is the one explicit opt-in) for setups that build their config
-programmatically:
+`no-throw` and `no-get-or-throw` are the two explicit opt-ins) for setups that
+build their config programmatically:
 
 ```ts
 import unthrown from "@unthrown/oxlint";

--- a/packages/oxlint/src/index.test.ts
+++ b/packages/oxlint/src/index.test.ts
@@ -9,12 +9,13 @@ const manifest: { peerDependencies: Record<string, string> } = JSON.parse(
 );
 
 describe("@unthrown/oxlint plugin", () => {
-  it("exposes all six rules under the `unthrown` plugin name", () => {
+  it("exposes all seven rules under the `unthrown` plugin name", () => {
     expect(plugin.meta?.name).toBe("unthrown");
     expect(Object.keys(plugin.rules).sort()).toEqual([
       "no-ambiguous-error-type",
       "no-catch-all-pattern",
       "no-get-or-throw",
+      "no-throw",
       "no-unhandled-result",
       "no-unused-matcher",
       "prefer-async-result",
@@ -54,6 +55,17 @@ describe("@unthrown/oxlint plugin", () => {
   it("keeps `no-get-or-throw` out of the `recommended` preset — tests need an overrides entry first", () => {
     expect(plugin.recommended.rules).not.toHaveProperty("unthrown/no-get-or-throw");
     expect(plugin.rules["no-get-or-throw"]?.meta?.docs?.recommended).toBe(false);
+  });
+
+  // Regression guard for #227. Removing this rule broke every downstream config
+  // that named it — oxlint fails to parse a config referencing an unknown rule,
+  // which kills the whole lint run — and nothing replaces it: oxlint ships no
+  // `no-restricted-syntax`. It stays out of the preset (it bans a core language
+  // statement), but it stays.
+  it("ships `no-throw`, outside the `recommended` preset", () => {
+    expect(plugin.rules).toHaveProperty("no-throw");
+    expect(plugin.recommended.rules).not.toHaveProperty("unthrown/no-throw");
+    expect(plugin.rules["no-throw"]?.meta?.docs?.recommended).toBe(false);
   });
 
   it("keeps every preset rule pointing at a rule the plugin actually defines", () => {

--- a/packages/oxlint/src/index.ts
+++ b/packages/oxlint/src/index.ts
@@ -1,5 +1,5 @@
 // @unthrown/oxlint — an oxlint (JS) plugin that enforces unthrown's conventions
-// at lint time. Six rules:
+// at lint time. Seven rules:
 //
 //   unthrown/no-ambiguous-error-type  — keep `E` a concrete domain error
 //                                        (no unknown/any/Error/{}), i.e. Thesis #1;
@@ -14,6 +14,9 @@
 //   unthrown/no-unused-matcher        — a `…Cases` callback must use the matcher it
 //                                        was handed; a foreign builder matches the
 //                                        wrong value.
+//   unthrown/no-throw                 — ban the `throw` statement; return `Err(...)`
+//                                        and let the boundaries own the defect
+//                                        channel (opt-in; not in `recommended`).
 //
 // Enable the bundled `recommended` preset, or wire the rules by hand. See the
 // package README.
@@ -25,6 +28,7 @@ import type { OxlintConfig } from "oxlint";
 import { noAmbiguousErrorType } from "./rules/no-ambiguous-error-type.js";
 import { noCatchAllPattern } from "./rules/no-catch-all-pattern.js";
 import { noGetOrThrow } from "./rules/no-get-or-throw.js";
+import { noThrow } from "./rules/no-throw.js";
 import { noUnhandledResult } from "./rules/no-unhandled-result.js";
 import { noUnusedMatcher } from "./rules/no-unused-matcher.js";
 import { preferAsyncResult } from "./rules/prefer-async-result.js";
@@ -37,13 +41,23 @@ const plugin = eslintCompatPlugin({
     "no-ambiguous-error-type": noAmbiguousErrorType,
     "no-catch-all-pattern": noCatchAllPattern,
     "no-get-or-throw": noGetOrThrow,
+    "no-throw": noThrow,
     "no-unhandled-result": noUnhandledResult,
     "no-unused-matcher": noUnusedMatcher,
     "prefer-async-result": preferAsyncResult,
   },
 }) as UnthrownPlugin;
 
-// One deliberate opt-out from the preset.
+// Two deliberate opt-outs from the preset.
+//
+// `no-throw` bans a core language statement, so it only suits a codebase that
+// has committed to the convention end to end — every sanctioned `throw` (a
+// framework that reads a thrown value, a deliberate rethrow onto the defect
+// channel) carries a targeted `oxlint-disable` with a reason. It is opt-in for
+// that reason, not because the ban is optional where it applies: there is no
+// other way to enforce it, oxlint having no `no-restricted-syntax` of its own
+// (#227 — which is why removing this rule in 5.4.0 left downstream bans with
+// no replacement, and why it is back).
 //
 // `no-get-or-throw` is a whole-codebase commitment, and it has a property no
 // preset rule has: `getOrThrow()` is the right tool in a test, so an existing

--- a/packages/oxlint/src/rules/no-throw.test.ts
+++ b/packages/oxlint/src/rules/no-throw.test.ts
@@ -1,0 +1,54 @@
+import { ruleTester } from "../tester.js";
+import { noThrow } from "./no-throw.js";
+
+ruleTester.run("no-throw", noThrow, {
+  valid: [
+    // Errors as values: nothing thrown, nothing to report.
+    {
+      code: `import { Err, Ok } from "unthrown";\nfunction f(n) { return n > 0 ? Ok(n) : Err("negative"); }`,
+    },
+    // `getOrThrow()` is a call, not a `throw` statement, so this rule is
+    // silent on it — `no-get-or-throw` is what reports it.
+    { code: `const value = result.getOrThrow();` },
+    // A try/catch with no throw is fine — catching is not throwing.
+    { code: `try { risky(); } catch (e) { report(e); }` },
+  ],
+  invalid: [
+    // A throw in a plain function.
+    {
+      code: `function f() { throw new Error("boom"); }`,
+      errors: [{ messageId: "noThrow" }],
+    },
+    // A throw in an arrow body.
+    {
+      code: `const f = () => { throw new Error("boom"); };`,
+      errors: [{ messageId: "noThrow" }],
+    },
+    // A throw in a class method.
+    {
+      code: `class C { m() { throw new Error("boom"); } }`,
+      errors: [{ messageId: "noThrow" }],
+    },
+    // A throw inside try — still a throw.
+    {
+      code: `try { throw new Error("boom"); } catch {}`,
+      errors: [{ messageId: "noThrow" }],
+    },
+    // A rethrow in a catch clause too — the deliberate form carries a
+    // targeted oxlint-disable instead.
+    {
+      code: `try { risky(); } catch (e) { throw e; }`,
+      errors: [{ messageId: "noThrow" }],
+    },
+    // A top-level throw.
+    {
+      code: `throw new Error("boom");`,
+      errors: [{ messageId: "noThrow" }],
+    },
+    // Non-Error values are throws all the same.
+    {
+      code: `function f() { throw "boom"; }`,
+      errors: [{ messageId: "noThrow" }],
+    },
+  ],
+});

--- a/packages/oxlint/src/rules/no-throw.ts
+++ b/packages/oxlint/src/rules/no-throw.ts
@@ -1,0 +1,44 @@
+import { defineRule } from "@oxlint/plugins";
+
+/**
+ * Disallow `throw`. unthrown's thesis is errors-as-values: a modeled failure is
+ * *returned* (`Err(...)`), never flung up the stack — only a true defect ever
+ * throws, and the library's boundaries (`fromThrowable` / `fromPromise` / the
+ * throw→defect net) own that channel. This rule bans the raw statement so the
+ * sanctioned forms stand out:
+ *
+ * - a modeled failure → `return Err(...)`;
+ * - a failure that is genuinely unmodeled here → route it to the defect
+ *   channel in expression position:
+ *   `.recoverErrCases((matcher, defect) => matcher.with(P.tag("…"), (e) => defect(e))).get()`;
+ * - a known-technical precondition throw → a plain helper wrapped once at its
+ *   origin with `fromSafeThrowable`;
+ * - a genuinely deliberate remaining `throw` site → a targeted
+ *   `oxlint-disable` comment with a reason.
+ *
+ * Deliberately option-free and not autofixable — the disable comment is the
+ * escape hatch. Opt-in (not part of the `recommended` preset): it bans a core
+ * language statement, so it suits codebases that have committed to the
+ * convention end-to-end.
+ */
+export const noThrow = defineRule({
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Disallow `throw` statements — return `Err(...)` instead; only a true defect ever throws",
+      recommended: false,
+    },
+    messages: {
+      noThrow:
+        'Unexpected `throw`. Return `Err(...)` for a modeled failure. When the failure is genuinely unmodeled here, route it to the defect channel in expression position — `.recoverErrCases((matcher, defect) => matcher.with(P.tag("…"), (e) => defect(e))).get()`. A known-technical precondition throw belongs in a plain helper wrapped once with `fromSafeThrowable`; a genuinely deliberate `throw` carries a targeted `oxlint-disable` with a reason.',
+    },
+  },
+  createOnce: (context) => {
+    return {
+      ThrowStatement: (node) => {
+        context.report({ node, messageId: "noThrow" });
+      },
+    };
+  },
+});

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -72,6 +72,15 @@ await db.user.tryCreate({ data }).match({
   only force every call site to carry an arm duplicating its own `defect` arm.
   (A defect is not a crash — it flows through the pipeline untouched and is
   folded at the edge like any other unmodeled failure.)
+
+  Those four codes are the **whole** modeled set: every other P-code — `P2007`,
+  `P2023`, `P2000`, `P2011`, `P2015`, … — is a defect. That matters where a
+  defect is _retried_ rather than surfaced (a Temporal activity rethrows it, and
+  a malformed id can never succeed on a retry). Replacing a hand-rolled
+  qualifier? Diff it against these four and re-qualify the rest with
+  `recoverDefect` — see
+  [Migrating a hand-rolled qualifier](https://btravstack.github.io/unthrown/how-to/use-with-prisma#migrating-a-hand-rolled-qualifier).
+
 - **`$tryTransaction`** — an interactive transaction whose callback speaks
   `AsyncResult`: an `Err` triggers a ROLLBACK and comes out as the same typed
   `Err`; a defect also rolls back and stays a defect. The `try*` methods are

--- a/skills/unthrown/SKILL.md
+++ b/skills/unthrown/SKILL.md
@@ -254,7 +254,7 @@ tag is namespaced (`TaggedError("pkg/NotFound", { name: "NotFound" })`).
   facade namespaces (`Result.*`/`AsyncResult.*`), and utility types. Read when
   choosing a combinator or writing anything beyond the basics above.
 - **[references/ecosystem.md](references/ecosystem.md)** — the `@unthrown/*`
-  satellite packages: vitest matchers (`toBeOk`/`toBeErrTagged`/…), the six
+  satellite packages: vitest matchers (`toBeOk`/`toBeErrTagged`/…), the seven
   oxlint rules, Prisma extension (`try*` delegates), Drizzle database
   (replaces the stock one — no `try*`), oRPC bridge,
   standard-schema validation, and the effect/neverthrow/boxed interop bridges.

--- a/skills/unthrown/references/ecosystem.md
+++ b/skills/unthrown/references/ecosystem.md
@@ -36,7 +36,7 @@ wiring exports: the seven raw matcher functions, `failOnForgottenAwait`, and the
 
 ## Linting: @unthrown/oxlint
 
-An oxlint JS plugin (peer `oxlint`). Six rules; scope-analysis keyed to
+An oxlint JS plugin (peer `oxlint`). Seven rules; scope-analysis keyed to
 unthrown imports, so they only fire on unthrown's `Result`.
 
 **Recommended preset:**
@@ -64,6 +64,13 @@ unthrown imports, so they only fire on unthrown's `Result`.
   modeled error, abandoning errors-as-values at the last step; fold with
   `recoverErrCases` + `get`. Legitimate in tests — exempt them with an oxlint
   `overrides` entry, not a rule option.
+- `no-throw` — reports every `throw` statement. For a codebase that has
+  committed to errors-as-values end to end: a modeled failure is `Err(...)`,
+  an unmodeled one reaches the defect channel through a boundary or the
+  injected `defect(cause)`, and a genuinely deliberate `throw` (a framework
+  that reads the thrown value) carries a targeted `oxlint-disable` with a
+  reason. Opt-in because it bans a core language statement — but the only way
+  to enforce the ban, oxlint having no `no-restricted-syntax`.
 
 ## Prisma: @unthrown/prisma
 

--- a/skills/unthrown/references/ecosystem.md
+++ b/skills/unthrown/references/ecosystem.md
@@ -36,8 +36,14 @@ wiring exports: the seven raw matcher functions, `failOnForgottenAwait`, and the
 
 ## Linting: @unthrown/oxlint
 
-An oxlint JS plugin (peer `oxlint`). Seven rules; scope-analysis keyed to
-unthrown imports, so they only fire on unthrown's `Result`.
+An oxlint JS plugin (peer `oxlint`). Seven rules. The type-shaped ones
+(`no-ambiguous-error-type`, `prefer-async-result`, `no-unhandled-result`,
+`no-catch-all-pattern`) resolve bindings by scope analysis, so they only fire
+on unthrown's own `Result` — another library's is left alone. Three are keyed
+on a name or shape instead, and need no import to resolve:
+`no-unused-matcher` (the `…Cases` method names), `no-get-or-throw` (a
+zero-argument `.getOrThrow()` member call), and `no-throw` (the language
+statement itself — it reports every `throw`, in any file).
 
 **Recommended preset:**
 


### PR DESCRIPTION
Closes #227, closes #226.

## #227 — `no-throw` comes back

5.4.0 removed `no-throw` on the reasoning that an unconditional `ThrowStatement` report is a `no-restricted-syntax` entry rather than a rule. **oxlint does not implement `no-restricted-syntax`** — verified against the pinned host:

```
$ oxlint -c .oxlintrc.json .     # {"rules":{"no-restricted-syntax":[...]}}
Failed to parse oxlint configuration file.
  x Rule 'no-restricted-syntax' not found in plugin 'eslint'
```

So the removal left a codebase that bans `throw` outright with nothing, and — because oxlint refuses to parse a config naming an unknown rule — the upgrade failed the consumer's *entire* lint run, every non-unthrown rule included, on a minor.

The rule is restored **unchanged and still opt-in** (it bans a core language statement, so it stays out of `recommended`). `index.test.ts` gains a regression guard for both halves: it ships, and it is not in the preset.

`prefer-ensure` stays removed — it flagged correct code that violates no thesis, and the issue does not argue for it. Configs naming it should drop the entry.

Verified end to end against the built plugin: a config naming `unthrown/no-throw` resolves again and the rule reports.

## #226 — the Prisma modeled set is a boundary, not a menu

Docs only; no runtime or type change.

- README and the guide now state, next to the per-operation table, that `P2002`/`P2003`/`P2018`/`P2025` are the **whole** modeled set — every other code (`P2007`, `P2023`, `P2000`, `P2011`, `P2015`, …) is a `Defect`.
- The consequence is named: where a defect is *retried* rather than surfaced — a Temporal activity rethrows it, while an `Err` folded to a non-retryable failure fails fast — a `P2007` from a malformed id retries forever on input that can never succeed.
- New guide section, **Migrating a hand-rolled qualifier**: diff the old `try`/`catch` qualifier against those four codes, and re-qualify the rest with `recoverDefect`, rethrowing what you did not name (the same `throw cause` idiom the drizzle guide already documents). It notes why the migration is silent — the type check passes because the `Err` channel legitimately shrank, and a repository unit test on the `Ok` path passes too.

The issue's optional item (3), a qualifier extension point on `unthrownPrisma`, is **not** added: `recoverDefect` at the call site already expresses it, and per-operation `E` inference for caller-supplied codes is real complexity for a case the docs now cover.

## Gate

`format --check`, `lint`, `typecheck`, `knip`, `test` (17 tasks, drizzle's Docker suite included) and `build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)