### PR TITLE
docs: state that TaggedError is a convention, not a requirement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -770,7 +770,12 @@ AsyncResult<infer T, …>` — structural inference over the whole method surfac
   `@unthrown/example-checkout-api`, modelling one checkout between them so each
   package can show a different job the library does (the error union and `Do`
   sequencing; `@unthrown/prisma`'s read/write error shapes; the oRPC edge with
-  no `try`/`catch`). Every guide snippet is hand-written prose, checked by
+  no `try`/`catch`), plus the standalone `@unthrown/example-existing-errors`,
+  which uses **no `TaggedError` at all** — a `kind`-discriminated class
+  hierarchy, a plain `code` union, and untagged third-party classes matched
+  with `P.instanceOf` — because "`TaggedError` is a convention, not a
+  requirement" is a claim about the type system that prose alone lets rot
+  (#235). Every guide snippet is hand-written prose, checked by
   review and nothing else, so it drifts silently; these are workspace packages
   instead — real imports of `unthrown` and its satellites through their
   published entry points, typechecked and tested in CI, so a breaking change
@@ -785,13 +790,14 @@ AsyncResult<infer T, …>` — structural inference over the whole method surfac
   (#220). `.changeset/config.json` therefore sets
   `privatePackages: { version: false, tag: false }`, which pins every example
   (and `docs`) at `0.0.0` with no changelog.
-  `typecheck` runs on all three; `test` runs where no external infrastructure
-  is required (`checkout-domain` and `checkout-api` are pure; `checkout-persistence`
+  `typecheck` runs on all four; `test` runs where no external infrastructure
+  is required (`checkout-domain`, `checkout-api` and `existing-errors` are pure;
+  `checkout-persistence`
   runs against Prisma's in-memory SQLite, the same pattern `@unthrown/prisma`'s
   own suite uses). Each has an annotated walkthrough in `docs/examples/`, linked
   from `examples/README.md`. They double as a **conformance fixture** for the
-  dogfooded oxlint preset — `no-catch-all-pattern` included, so none of the
-  three's error matches reaches for `P._`.
+  dogfooded oxlint preset — `no-catch-all-pattern` included, so none of their
+  error matches reaches for `P._`.
 - `docs` → `@unthrown/docs`, the VitePress site (guide + TypeDoc-generated API
   reference). **TypeDoc runs from here, not from the packages** — it needs its
   own TypeScript (see the toolchain section). One `typedoc.<name>.json` per

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -114,6 +114,7 @@ const EXAMPLES_SIDEBAR = [
       { text: "Checkout domain", link: "/examples/checkout-domain" },
       { text: "Checkout persistence", link: "/examples/checkout-persistence" },
       { text: "Checkout API", link: "/examples/checkout-api" },
+      { text: "Existing error types", link: "/examples/existing-errors" },
     ],
   },
 ];

--- a/docs/examples/existing-errors.md
+++ b/docs/examples/existing-errors.md
@@ -1,0 +1,154 @@
+---
+title: Existing error types example
+description: Adopting unthrown in a codebase that already models its domain errors — a kind-discriminated class hierarchy, a plain code union, and untagged third-party classes, with no TaggedError anywhere.
+---
+
+# Existing error types
+
+[`examples/existing-errors`](https://github.com/btravstack/unthrown/tree/main/examples/existing-errors)
+— the adoption case. A codebase that already has an error convention, wired to
+`Result` without rewriting it. **`TaggedError` does not appear once.**
+
+```sh
+pnpm turbo run test --filter=@unthrown/example-existing-errors
+```
+
+## Why the package exists
+
+`Result<T, E>` is generic in `E` and **unconstrained** — there is no
+`E extends { _tag: string }` anywhere in core, and `P.tag("X")` is only sugar
+for the object pattern `{ _tag: "X" }`. Saying so in prose is cheap; the three
+modules here compile and are tested in CI, so the claim cannot quietly stop
+being true.
+
+Each one takes a different existing convention, matching a section of
+[Model errors](../how-to/model-errors#use-the-errors-you-already-have).
+
+## `tickets.ts` — your own class hierarchy
+
+The convention that was already there: an abstract base carrying a `kind`.
+
+```ts
+export abstract class AppError extends Error {
+  abstract readonly kind: string;
+}
+
+export class TicketNotFound extends AppError {
+  readonly kind = "TicketNotFound" as const;
+  constructor(readonly ticketId: string) {
+    super(`no ticket ${ticketId}`);
+  }
+}
+```
+
+`mapErrCases` drives the same exhaustive matcher the tagged path uses,
+dispatching on `kind` through a plain object pattern:
+
+```ts
+assignTicket(store, ticketId, to).mapErrCases((matcher) =>
+  matcher
+    .with({ kind: "TicketNotFound" }, (e) => ({
+      status: 404,
+      detail: e.ticketId,
+    }))
+    .with({ kind: "TicketLocked" }, (e) => ({
+      status: 423,
+      detail: e.lockedBy,
+    })),
+);
+```
+
+Each branch is narrowed to its own class, so `ticketId` and `lockedBy` are
+reachable without a cast. Add a third `AppError` subclass to the union and this
+stops compiling until it is named — the guarantee comes from the union's shape,
+not from `TaggedError`.
+
+## `billing.ts` — a plain union, no classes at all
+
+The other extreme: a client generated from an OpenAPI document, whose failures
+are plain objects with a `code`. `E` does not have to be an `Error` either.
+
+```ts
+export type BillingError =
+  | { readonly code: "CARD_DECLINED"; readonly declineCode: string }
+  | { readonly code: "INSUFFICIENT_FUNDS" }
+  | { readonly code: "RATE_LIMITED"; readonly retryAfter: number };
+```
+
+Two codes deserve the same response, so they share one arm as a **grouped
+pattern** — both still named, which is the difference from a wildcard:
+
+```ts
+client.charge(cents).match({
+  ok: () => 200,
+  defect: () => 500,
+  errCases: (matcher) =>
+    matcher
+      .with(
+        { code: "CARD_DECLINED" },
+        { code: "INSUFFICIENT_FUNDS" },
+        () => 402,
+      )
+      .with({ code: "RATE_LIMITED" }, () => 429),
+});
+```
+
+The spec pins the `defect` arm too: a socket hang-up in the billing client
+folds to 500 rather than arriving as a fourth code a caller might branch on.
+
+## `vendor.ts` — untagged third-party classes
+
+Two SDK error classes with no shared discriminant, no tag, and no possibility
+of editing them. The boundary is where the real decision gets made:
+
+```ts
+export const render = fromThrowable(
+  (source: string): Template => ({ rendered: vendorRender(source) }),
+  (cause, defect) =>
+    cause instanceof VendorSyntaxError || cause instanceof VendorTimeoutError
+      ? cause
+      : defect(cause),
+);
+```
+
+That is the answer to "how does unthrown know which failures are modelled" — not
+the error's shape, but `qualify`. What you return becomes `E`; what you hand to
+the injected `defect` leaves the modelled type entirely. The spec asserts both
+halves, including that a `RangeError` from inside the SDK never reaches `E`.
+
+Matching then uses `P.instanceOf`, the pattern for a union with nothing to
+dispatch on but identity:
+
+```ts
+result.mapErrCases((matcher) =>
+  matcher
+    .with(P.instanceOf(VendorSyntaxError), (e) => ({
+      detail: `bad syntax at ${e.at}`,
+    }))
+    .with(P.instanceOf(VendorTimeoutError), (e) => ({
+      detail: `timed out after ${e.afterMs}ms`,
+    })),
+);
+```
+
+`P.when(guard)` covers whatever neither an object pattern nor `instanceof` can
+express.
+
+## What you still have to give up
+
+Nothing about the error _type_ — but `E` must be a union TypeScript can
+**discriminate**, because exhaustiveness is `Exclude` over it. A `kind`, a
+`code`, distinct class shapes or a guard all qualify; a widened `Error`,
+`string` or `unknown` does not, and leaves `P._` as the only arm that
+terminates the match. That is the same thing a `switch` needs, and what
+[`no-ambiguous-error-type`](../how-to/lint-your-codebase#no-ambiguous-error-type)
+is really guarding.
+
+## Where to go next
+
+- The guide section this mirrors:
+  [Model errors](../how-to/model-errors#use-the-errors-you-already-have).
+- Why the boundary decides:
+  [Qualification](../explanation/qualification).
+- What `TaggedError` buys you when you _don't_ have a convention:
+  [Model errors](../how-to/model-errors#define-a-tagged-error).

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,14 +1,14 @@
 ---
 title: Examples
-description: Three small packages modelling one checkout — code that compiles and is covered by tests, unlike the snippets in the guide.
+description: Small runnable packages — code that compiles and is covered by tests, unlike the snippets in the guide.
 ---
 
 # Examples
 
 Annotated tours of the runnable packages under
-[`examples/`](https://github.com/btravstack/unthrown/tree/main/examples). They
-model one small checkout between them, each showing a different job
-`unthrown` does.
+[`examples/`](https://github.com/btravstack/unthrown/tree/main/examples). Three
+of them model one small checkout between them, each showing a different job
+`unthrown` does; the fourth stands alone.
 
 **Unlike the snippets elsewhere in this guide, this code compiles and is
 covered by tests.** There is no database and no server to start:
@@ -40,13 +40,20 @@ The edge: `placeOrder` served over oRPC with `@unthrown/orpc` — one exhaustive
 collapses to `INTERNAL_SERVER_ERROR` instead of an unhandled rejection, and
 why oRPC's own input validation is a separate concern from `E`.
 
+## [Existing error types](/examples/existing-errors)
+
+The adoption case, with **no `TaggedError` anywhere**: a codebase that already
+has an error convention — a `kind`-discriminated class hierarchy, a plain
+`code` union from a generated client, and untagged third-party classes — wired
+to `Result` without rewriting any of it.
+
 ## Why these exist as packages rather than snippets
 
 Every fenced block in the rest of this guide is written by hand. It is
 checked by review and nothing else, so it can drift from the library without
 any build noticing.
 
-These three cannot. They are workspace packages: they typecheck, their specs
-run in CI, and they consume `unthrown` and its satellites through their real
-published entry points rather than a path alias. If the library changes
-underneath them, something goes red.
+These cannot. They are workspace packages: they typecheck, their specs run in
+CI, and they consume `unthrown` and its satellites through their real published
+entry points rather than a path alias. If the library changes underneath them,
+something goes red.

--- a/docs/how-to/model-errors.md
+++ b/docs/how-to/model-errors.md
@@ -134,6 +134,10 @@ just sugar for the object pattern `{ _tag: "X" }`, one pattern among several.
 The matcher matches by **structure**, so an error convention you already have
 works unchanged.
 
+Every shape below is a module of the runnable
+[existing error types example](../examples/existing-errors) — it typechecks and
+its specs run in CI, so these are not snippets that can quietly rot.
+
 ### Your own error classes
 
 Any discriminant field does the job — here a `kind` on a shared base class:

--- a/docs/how-to/model-errors.md
+++ b/docs/how-to/model-errors.md
@@ -1,10 +1,16 @@
-# Model errors with `TaggedError`
+# Model errors
 
 > **How-to.** Define matchable domain errors and fold a `Result` on them. Core
-> `Result<T, E>` is generic in `E` — a plain string union works — but for real
-> domains a **tagged error** is the recommended convention.
+> `Result<T, E>` is generic in `E` and **unconstrained** — the only thing the
+> matcher needs is an `E` TypeScript can discriminate. `TaggedError` is
+> unthrown's convenience for getting one, **not** a requirement: if you already
+> have an error convention, [keep it](#use-the-errors-you-already-have).
 
 ## Define a tagged error
+
+`TaggedError` is the shape unthrown proposes when you have no convention yet: a
+discriminant, a typed payload, and `Error` semantics, without writing the class
+boilerplate three times.
 
 `TaggedError(tag)` builds a base class you extend. Supply a payload with an
 instantiation expression; omit it for a payload-less error:
@@ -113,31 +119,6 @@ Miss a tag and it **won't compile** — exhaustiveness is enforced by the type, 
 no `.exhaustive()` to forget. For an `AsyncResult`, `match` resolves to a
 `Promise<R>`.
 
-## Match on more than `_tag`
-
-Because the matcher matches by structure, you can also branch on a `code`, on a
-`P.*` matcher, or on **grouped patterns** — several cases sharing one strategy,
-each still named:
-
-```ts
-// E = { code: "EXPIRED" } | { code: "REVOKED" } | { code: "THROTTLED"; retryAfter: number }
-const status = authorize(id).match({
-  ok: () => 200,
-  defect: () => 500,
-  errCases: (matcher) =>
-    matcher
-      // grouped: one handler, two named cases — not a wildcard
-      .with({ code: "EXPIRED" }, { code: "REVOKED" }, () => 401)
-      .with({ code: "THROTTLED" }, () => 429),
-});
-```
-
-Grouping is the answer when several errors deserve the same response: the union
-stays written out, so adding a fourth code still stops the build here. `P._`
-exists for what enumeration cannot express — a helper generic in `E`, or an `E`
-that is a single type rather than a union — and is covered in
-[Exhaustive error matching](../explanation/exhaustive-error-matching#generic-boundary-helpers-the-catch-all-is-the-only-form-that-compiles).
-
 Unlike the error _combinators_ (`mapErrCases`, `flatMapErrCases`, …), `match`'s `errCases`
 handler receives **no `defect` helper** — `match` is total elimination to a value,
 and a `Result` that already carries a defect is handled by the `defect:` case. To
@@ -145,9 +126,122 @@ keep matching _inside_ the pipeline (transforming or recovering the error rather
 than eliminating it), reach for those combinators — see the
 [combinator reference](../reference/combinators#the-error-channel).
 
+## Use the errors you already have
+
+`TaggedError` is a **convention, not a requirement**. Nothing in core constrains
+`E` — there is no `E extends { _tag: string }` anywhere — and `P.tag("X")` is
+just sugar for the object pattern `{ _tag: "X" }`, one pattern among several.
+The matcher matches by **structure**, so an error convention you already have
+works unchanged.
+
+### Your own error classes
+
+Any discriminant field does the job — here a `kind` on a shared base class:
+
+```ts
+abstract class DomainError extends Error {
+  abstract readonly kind: string;
+}
+
+class TicketNotFound extends DomainError {
+  readonly kind = "TicketNotFound" as const;
+  constructor(readonly ticketId: string) {
+    super(`ticket ${ticketId} not found`);
+  }
+}
+
+class TicketLocked extends DomainError {
+  readonly kind = "TicketLocked" as const;
+  constructor(readonly lockedBy: string) {
+    super("ticket locked");
+  }
+}
+
+type TicketError = TicketNotFound | TicketLocked;
+```
+
+`mapErrCases` takes the same matcher the `match` handler does — one branch per
+case, each narrowed to its own variant, and the un-terminated builder returned:
+
+```ts
+const withStatus = loadTicket(id).mapErrCases((matcher) =>
+  matcher
+    .with({ kind: "TicketNotFound" }, (e) => ({ status: 404, id: e.ticketId }))
+    .with({ kind: "TicketLocked" }, (e) => ({ status: 423, by: e.lockedBy })),
+);
+//    ^? AsyncResult<Ticket, { status: number; id: string } | { status: number; by: string }>
+```
+
+Drop the `TicketLocked` branch and it stops compiling — exhaustiveness comes
+from the union's shape, not from `TaggedError`.
+
+### A plain union type, no classes at all
+
+`E` doesn't have to be an `Error` subclass either. A union of plain objects
+discriminated by a `code` behaves identically, and **grouped patterns** let
+several cases share one handler without a wildcard:
+
+```ts
+type PaymentError =
+  | { code: "CARD_DECLINED"; declineCode: string }
+  | { code: "INSUFFICIENT_FUNDS" }
+  | { code: "RATE_LIMITED"; retryAfter: number };
+
+const status = charge(order).match({
+  ok: () => 200,
+  defect: () => 500,
+  errCases: (matcher) =>
+    matcher
+      // grouped: one handler, two named cases — not a wildcard
+      .with(
+        { code: "CARD_DECLINED" },
+        { code: "INSUFFICIENT_FUNDS" },
+        () => 402,
+      )
+      .with({ code: "RATE_LIMITED" }, () => 429),
+});
+```
+
+Grouping is the answer when several errors deserve the same response: the union
+stays written out, so adding a fourth code still stops the build here.
+
+### Classes with no discriminant field
+
+For third-party or legacy classes carrying no tag at all, `P.instanceOf` is the
+pattern — the branch is narrowed to the class instance:
+
+```ts
+declare const parsed: Result<Config, ParseError | TimeoutError>;
+
+const described = parsed.mapErrCases((matcher) =>
+  matcher
+    .with(P.instanceOf(ParseError), (e) => `bad syntax at ${e.at}`)
+    .with(P.instanceOf(TimeoutError), (e) => `gave up after ${e.afterMs}ms`),
+);
+```
+
+`P.when(guard)` covers whatever the other two can't express — an arbitrary type
+guard, including one over a primitive.
+
+### What `E` _does_ have to be
+
+Exhaustiveness is `Exclude` over the union, so the one real requirement is that
+`E` is a union TypeScript can **discriminate**: a `_tag` / `kind` / `code`
+field, structurally distinct class shapes, or a guard. What does not work is a
+set of structurally identical classes (they collapse into one union member) or a
+widened `E` like `Error`, `string` or `unknown` — with nothing to enumerate, the
+only arm that terminates the match is the `P._` escape hatch, which gives back
+the blanket `catch` the matcher exists to remove.
+[`no-ambiguous-error-type`](./lint-your-codebase#no-ambiguous-error-type) flags those `E`s for exactly
+that reason; a named union of your own types passes.
+
+`P._` remains for what enumeration genuinely cannot express — a helper generic
+in `E`, or an `E` that is a single type rather than a union — and is covered in
+[Exhaustive error matching](../explanation/exhaustive-error-matching#generic-boundary-helpers-the-catch-all-is-the-only-form-that-compiles).
+
 ## Where to go next
 
 - Match inside a pipeline: [Combinator reference](../reference/combinators#the-error-channel).
 - Why the matcher, not a callback:
   [Exhaustive error matching](../explanation/exhaustive-error-matching).
-- Test tagged errors: [Test with Vitest](./test-with-vitest).
+- Test the errors you defined: [Test with Vitest](./test-with-vitest).

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,15 +1,16 @@
 # Examples
 
-Three small packages modelling one checkout between them, each showing a
-different job `unthrown` does.
+Small runnable packages, each showing a different job `unthrown` does. Three of
+them model one checkout between them; the fourth stands alone.
 
 📖 **[Annotated walkthroughs →](https://btravstack.github.io/unthrown/examples/)**
 
-| Package                                          | Shows                                                                                                     |
-| ------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
-| [`checkout-domain`](./checkout-domain)           | The error union, `Do`/`bind` sequencing, exhaustive matching, and the defect channel.                     |
-| [`checkout-persistence`](./checkout-persistence) | `@unthrown/prisma`: why a read infers `E = never` and a write carries only the codes you branch on.       |
-| [`checkout-api`](./checkout-api)                 | The edge: oRPC's own input validation, one exhaustive `mapErrCases`, and a handler with no `try`/`catch`. |
+| Package                                          | Shows                                                                                                                              |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| [`checkout-domain`](./checkout-domain)           | The error union, `Do`/`bind` sequencing, exhaustive matching, and the defect channel.                                              |
+| [`checkout-persistence`](./checkout-persistence) | `@unthrown/prisma`: why a read infers `E = never` and a write carries only the codes you branch on.                                |
+| [`checkout-api`](./checkout-api)                 | The edge: oRPC's own input validation, one exhaustive `mapErrCases`, and a handler with no `try`/`catch`.                          |
+| [`existing-errors`](./existing-errors)           | Adoption with **no `TaggedError`**: your own `kind`-discriminated classes, a plain `code` union, and untagged third-party classes. |
 
 Unlike the snippets in the guide, **this code compiles and is covered by
 tests**. There is no database and no server to start:

--- a/examples/existing-errors/package.json
+++ b/examples/existing-errors/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@unthrown/example-existing-errors",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Adopting unthrown in a codebase that already has its own error convention — no TaggedError anywhere",
+  "license": "MIT",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "unthrown": "workspace:^"
+  },
+  "devDependencies": {
+    "@btravstack/tsconfig": "catalog:",
+    "@unthrown/vitest": "workspace:*",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/examples/existing-errors/src/billing.ts
+++ b/examples/existing-errors/src/billing.ts
@@ -1,0 +1,40 @@
+import type { AsyncResult } from "unthrown";
+
+/**
+ * A second convention, from the other extreme: the billing client is generated
+ * from an OpenAPI document, so its failures arrive as **plain objects** with a
+ * `code`. No classes, no `Error` subclassing, nothing to rewrite.
+ *
+ * `E` does not have to be an `Error` — only discriminable.
+ */
+export type BillingError =
+  | { readonly code: "CARD_DECLINED"; readonly declineCode: string }
+  | { readonly code: "INSUFFICIENT_FUNDS" }
+  | { readonly code: "RATE_LIMITED"; readonly retryAfter: number };
+
+export type BillingClient = {
+  readonly charge: (cents: number) => AsyncResult<{ reference: string }, BillingError>;
+};
+
+/**
+ * Folding at the edge with `match`. Two of the three codes deserve the same
+ * response, so they share one arm as a **grouped pattern** — both still named,
+ * which is the difference that matters: add a fourth code to
+ * {@link BillingError} and this fails to compile, where a `P._` fallback would
+ * have swallowed it silently.
+ *
+ * `match` on an `AsyncResult` resolves to a `Promise` of the folded value.
+ */
+export function chargeForHttp(client: BillingClient, cents: number): Promise<number> {
+  return client.charge(cents).match({
+    ok: () => 200,
+    // The billing client's transport blowing up is not a modelled outcome —
+    // it lands in the defect channel and becomes a 500, never an `E` a caller
+    // might branch on.
+    defect: () => 500,
+    errCases: (matcher) =>
+      matcher
+        .with({ code: "CARD_DECLINED" }, { code: "INSUFFICIENT_FUNDS" }, () => 402)
+        .with({ code: "RATE_LIMITED" }, () => 429),
+  });
+}

--- a/examples/existing-errors/src/index.spec.ts
+++ b/examples/existing-errors/src/index.spec.ts
@@ -1,0 +1,103 @@
+import { Err, Ok } from "unthrown";
+import { expect, test } from "vitest";
+import "@unthrown/vitest";
+
+import {
+  TicketLocked,
+  TicketNotFound,
+  VendorSyntaxError,
+  VendorTimeoutError,
+  assignTicketForHttp,
+  chargeForHttp,
+  readableRenderFailure,
+  render,
+  type BillingClient,
+  type BillingError,
+  type Ticket,
+  type TicketStore,
+} from "./index.js";
+
+const TICKET: Ticket = { id: "t_1", assignee: null };
+
+const store = (over: Partial<TicketStore> = {}): TicketStore => ({
+  find: () => Ok(TICKET).toAsync(),
+  assign: (ticket, to) => Ok({ ...ticket, assignee: to }).toAsync(),
+  ...over,
+});
+
+// --- your own classes, discriminated by `kind` -------------------------------
+
+test("a `kind`-discriminated class union composes with no tag anywhere", async () => {
+  const result = await assignTicketForHttp(store(), "t_1", "ada");
+  await expect(result).toBeOkWith({ id: "t_1", assignee: "ada" });
+});
+
+test("the not-found branch narrows to TicketNotFound and reads `ticketId`", async () => {
+  const result = await assignTicketForHttp(
+    store({ find: (id) => Err(new TicketNotFound(id)).toAsync() }),
+    "t_missing",
+    "ada",
+  );
+  await expect(result).toBeErrWith({ status: 404, detail: "t_missing" });
+});
+
+test("the locked branch narrows to TicketLocked and reads `lockedBy`", async () => {
+  const result = await assignTicketForHttp(
+    store({ assign: (ticket) => Err(new TicketLocked(ticket.id, "grace")).toAsync() }),
+    "t_1",
+    "ada",
+  );
+  await expect(result).toBeErrWith({ status: 423, detail: "grace" });
+});
+
+// --- a plain `code` union, no classes at all ---------------------------------
+
+const billing = (charge: BillingClient["charge"]): BillingClient => ({ charge });
+
+const DECLINED = { code: "CARD_DECLINED", declineCode: "51" } satisfies BillingError;
+const BROKE = { code: "INSUFFICIENT_FUNDS" } satisfies BillingError;
+const THROTTLED = { code: "RATE_LIMITED", retryAfter: 30 } satisfies BillingError;
+
+test("a plain object union folds at the edge, grouped arms included", async () => {
+  const declined = billing(() => Err(DECLINED).toAsync());
+  const broke = billing(() => Err(BROKE).toAsync());
+  const throttled = billing(() => Err(THROTTLED).toAsync());
+  const paid = billing(() => Ok({ reference: "pay_1" }).toAsync());
+
+  // the two grouped codes share one arm — both still named
+  expect(await chargeForHttp(declined, 100)).toBe(402);
+  expect(await chargeForHttp(broke, 100)).toBe(402);
+  expect(await chargeForHttp(throttled, 100)).toBe(429);
+  expect(await chargeForHttp(paid, 100)).toBe(200);
+});
+
+test("a transport blow-up is a defect, not a fourth billing code", async () => {
+  const exploding = billing(() =>
+    Ok(0)
+      .toAsync()
+      .map((): { reference: string } => {
+        throw new Error("socket hang up");
+      }),
+  );
+
+  expect(await chargeForHttp(exploding, 100)).toBe(500);
+});
+
+// --- untagged third-party classes, matched with P.instanceOf -----------------
+
+test("qualify puts the two known vendor classes in E, and nothing else", () => {
+  expect(render("hello")).toBeOkWith({ rendered: "HELLO" });
+  expect(render("{{? oops")).toBeErrWith(expect.any(VendorSyntaxError));
+  expect(render("{{slow}}")).toBeErrWith(expect.any(VendorTimeoutError));
+  // an unmodelled throw never lands in `E`
+  expect(render("{{boom}}")).toBeDefectWith(expect.any(RangeError));
+});
+
+test("P.instanceOf narrows each vendor class to its own fields", () => {
+  expect(readableRenderFailure(render("{{? oops"))).toBeErrWith({
+    detail: "bad template syntax at offset 0",
+  });
+  expect(readableRenderFailure(render("{{slow}}"))).toBeErrWith({
+    detail: "renderer timed out after 5000ms",
+  });
+});

--- a/examples/existing-errors/src/index.ts
+++ b/examples/existing-errors/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./billing.js";
+export * from "./tickets.js";
+export * from "./vendor.js";

--- a/examples/existing-errors/src/tickets.ts
+++ b/examples/existing-errors/src/tickets.ts
@@ -1,0 +1,82 @@
+import type { AsyncResult } from "unthrown";
+
+/**
+ * The error convention this codebase had *before* unthrown: an abstract base
+ * class carrying a `kind` discriminant. Thousands of `instanceof` checks and
+ * log lines already depend on it, so adopting a `Result` type must not mean
+ * rewriting it.
+ *
+ * It doesn't. `Result<T, E>` is generic in `E` and unconstrained — there is no
+ * `E extends { _tag: string }` anywhere in core — and the matcher matches by
+ * *structure*. `TaggedError` is what unthrown offers a codebase with no
+ * convention yet; this file is what happens when you already have one.
+ */
+export abstract class AppError extends Error {
+  abstract readonly kind: string;
+}
+
+export class TicketNotFound extends AppError {
+  readonly kind = "TicketNotFound" as const;
+
+  constructor(readonly ticketId: string) {
+    super(`no ticket ${ticketId}`);
+  }
+}
+
+export class TicketLocked extends AppError {
+  readonly kind = "TicketLocked" as const;
+
+  constructor(
+    readonly ticketId: string,
+    readonly lockedBy: string,
+  ) {
+    super(`ticket ${ticketId} is locked by ${lockedBy}`);
+  }
+}
+
+/** Exactly the union `E` needs to be: discriminable, and every case nameable. */
+export type TicketError = TicketNotFound | TicketLocked;
+
+export type Ticket = { readonly id: string; readonly assignee: string | null };
+
+export type TicketStore = {
+  readonly find: (id: string) => AsyncResult<Ticket, TicketNotFound>;
+  readonly assign: (ticket: Ticket, to: string) => AsyncResult<Ticket, TicketLocked>;
+};
+
+/**
+ * Two fallible steps composed. The error channel widens to the union on its
+ * own — nothing here mentions a tag, and neither error class knows unthrown
+ * exists.
+ */
+export function assignTicket(
+  store: TicketStore,
+  ticketId: string,
+  to: string,
+): AsyncResult<Ticket, TicketError> {
+  return store.find(ticketId).flatMap((ticket) => store.assign(ticket, to));
+}
+
+export type HttpFailure = { readonly status: number; readonly detail: string };
+
+/**
+ * The payoff: `mapErrCases` drives the same exhaustive matcher the tagged path
+ * uses, dispatching on `kind` through a plain object pattern. Each branch is
+ * narrowed to its own class, so `ticketId` and `lockedBy` are both reachable
+ * without a cast.
+ *
+ * Add a third `AppError` subclass to {@link TicketError} and this stops
+ * compiling until it is named here — the guarantee is a property of the
+ * union's shape, not of `TaggedError`.
+ */
+export function assignTicketForHttp(
+  store: TicketStore,
+  ticketId: string,
+  to: string,
+): AsyncResult<Ticket, HttpFailure> {
+  return assignTicket(store, ticketId, to).mapErrCases((matcher) =>
+    matcher
+      .with({ kind: "TicketNotFound" }, (e) => ({ status: 404, detail: e.ticketId }))
+      .with({ kind: "TicketLocked" }, (e) => ({ status: 423, detail: e.lockedBy })),
+  );
+}

--- a/examples/existing-errors/src/vendor.ts
+++ b/examples/existing-errors/src/vendor.ts
@@ -1,0 +1,73 @@
+import { P, fromThrowable, type Result } from "unthrown";
+
+/**
+ * Stand-in for a third-party SDK: two error classes, no shared discriminant
+ * field, no tag, and no intention of ever growing one. You cannot edit them —
+ * which is the point of this file.
+ */
+export class VendorSyntaxError extends Error {
+  constructor(readonly at: number) {
+    super(`unexpected token at ${at}`);
+  }
+}
+
+export class VendorTimeoutError extends Error {
+  constructor(readonly afterMs: number) {
+    super(`vendor gave up after ${afterMs}ms`);
+  }
+}
+
+export type VendorRenderError = VendorSyntaxError | VendorTimeoutError;
+
+export type Template = { readonly rendered: string };
+export type RenderFailure = { readonly detail: string };
+
+/**
+ * The boundary. `qualify` is where the modelled/unexpected split is actually
+ * made — and it is made by *decision*, not by the error's shape: the two
+ * classes above are returned (so they become `E`), and everything else is
+ * handed to the injected `defect` helper, leaving the modelled type entirely.
+ *
+ * `E` is inferred as `Exclude<R, Defect>` — `VendorSyntaxError |
+ * VendorTimeoutError`, with the defect arm subtracted rather than unioned in.
+ */
+export const render = fromThrowable(
+  (source: string): Template => ({ rendered: vendorRender(source) }),
+  (cause, defect) =>
+    cause instanceof VendorSyntaxError || cause instanceof VendorTimeoutError
+      ? cause
+      : defect(cause),
+);
+
+/**
+ * `P.instanceOf` is the pattern for a union with nothing to dispatch on but
+ * identity — the branch is narrowed to the class, so `at` and `afterMs` are
+ * each reachable without a cast. (`P.when(guard)` covers whatever neither an
+ * object pattern nor `instanceof` can express.)
+ *
+ * Exhaustiveness holds here for the same reason it does everywhere else: the
+ * two classes are structurally distinct, so `Exclude` can tell them apart.
+ */
+export function readableRenderFailure(
+  result: Result<Template, VendorRenderError>,
+): Result<Template, RenderFailure> {
+  return result.mapErrCases((matcher) =>
+    matcher
+      .with(P.instanceOf(VendorSyntaxError), (e) => ({
+        detail: `bad template syntax at offset ${e.at}`,
+      }))
+      .with(P.instanceOf(VendorTimeoutError), (e) => ({
+        detail: `renderer timed out after ${e.afterMs}ms`,
+      })),
+  );
+}
+
+/** The SDK's synchronous entry point, faked just enough to throw on cue. */
+function vendorRender(source: string): string {
+  if (source.includes("{{?")) throw new VendorSyntaxError(source.indexOf("{{?"));
+  if (source.includes("{{slow}}")) throw new VendorTimeoutError(5_000);
+  // An unmodelled failure: nobody branches on "the SDK has a bug", so `qualify`
+  // sends it to the defect channel instead of into `E`.
+  if (source.includes("{{boom}}")) throw new RangeError("vendor internal error");
+  return source.toUpperCase();
+}

--- a/examples/existing-errors/tsconfig.json
+++ b/examples/existing-errors/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@btravstack/tsconfig/base.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/examples/existing-errors/vitest.config.ts
+++ b/examples/existing-errors/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+// No coverage thresholds: an example is judged by whether it compiles and its
+// specs pass, not by line coverage of code written to be read.
+export default defineConfig({
+  test: { include: ["src/**/*.spec.ts"] },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,7 +206,7 @@ importers:
         version: 1.6.4(@algolia/client-search@5.55.1)(@types/node@26.1.2)(jiti@2.7.0)(postcss@8.5.25)(tsx@4.23.5)(typescript@6.0.3)(yaml@2.9.0)
       vitepress-plugin-llms:
         specifier: 'catalog:'
-        version: 1.13.4(supports-color@7.2.0)
+        version: 1.13.4
 
   examples/checkout-api:
     dependencies:
@@ -301,6 +301,25 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0)
 
+  examples/existing-errors:
+    dependencies:
+      unthrown:
+        specifier: workspace:^
+        version: link:../../packages/core
+    devDependencies:
+      '@btravstack/tsconfig':
+        specifier: 'catalog:'
+        version: 0.2.0
+      '@unthrown/vitest':
+        specifier: workspace:*
+        version: link:../../packages/vitest
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0)
+
   packages/boxed:
     dependencies:
       unthrown:
@@ -361,7 +380,7 @@ importers:
         version: 0.2.0
       '@testcontainers/postgresql':
         specifier: 'catalog:'
-        version: 12.0.4(supports-color@7.2.0)
+        version: 12.0.4
       '@types/node':
         specifier: 'catalog:'
         version: 26.1.2
@@ -5867,9 +5886,9 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
-  '@kwsites/file-exists@1.1.1(supports-color@7.2.0)':
+  '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -6586,9 +6605,9 @@ snapshots:
 
   '@standardserver/shared@0.6.0': {}
 
-  '@testcontainers/postgresql@12.0.4(supports-color@7.2.0)':
+  '@testcontainers/postgresql@12.0.4':
     dependencies:
-      testcontainers: 12.0.4(supports-color@7.2.0)
+      testcontainers: 12.0.4
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -7464,11 +7483,9 @@ snapshots:
     dependencies:
       d3-array: 3.2.4
 
-  debug@4.4.3(supports-color@7.2.0):
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 7.2.0
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -7510,21 +7527,21 @@ snapshots:
     dependencies:
       yaml: 2.9.0
 
-  docker-modem@5.0.7(supports-color@7.2.0):
+  docker-modem@5.0.7:
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       readable-stream: 3.6.2
       split-ca: 1.0.1
       ssh2: 1.17.0
     transitivePeerDependencies:
       - supports-color
 
-  dockerode@5.0.1(supports-color@7.2.0):
+  dockerode@5.0.1:
     dependencies:
       '@balena/dockerignore': 1.0.2
       '@grpc/grpc-js': 1.14.4
       '@grpc/proto-loader': 0.7.15
-      docker-modem: 5.0.7(supports-color@7.2.0)
+      docker-modem: 5.0.7
       protobufjs: 7.6.5
       tar-fs: 2.1.5
     transitivePeerDependencies:
@@ -8088,14 +8105,14 @@ snapshots:
 
   markdown-title@1.0.2: {}
 
-  mdast-util-from-markdown@2.0.3(supports-color@7.2.0):
+  mdast-util-from-markdown@2.0.3:
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2(supports-color@7.2.0)
+      micromark: 4.0.2
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -8105,12 +8122,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-frontmatter@2.0.1(supports-color@7.2.0):
+  mdast-util-frontmatter@2.0.1:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       escape-string-regexp: 5.0.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       micromark-extension-frontmatter: 2.0.0
     transitivePeerDependencies:
@@ -8271,10 +8288,10 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2(supports-color@7.2.0):
+  micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.13
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -8648,9 +8665,9 @@ snapshots:
       retry: 0.12.0
       signal-exit: 3.0.7
 
-  properties-reader@3.0.1(supports-color@7.2.0):
+  properties-reader@3.0.1:
     dependencies:
-      '@kwsites/file-exists': 1.1.1(supports-color@7.2.0)
+      '@kwsites/file-exists': 1.1.1
       mkdirp: 3.0.1
     transitivePeerDependencies:
       - supports-color
@@ -8747,19 +8764,19 @@ snapshots:
     dependencies:
       regex-utilities: 2.3.0
 
-  remark-frontmatter@5.0.0(supports-color@7.2.0):
+  remark-frontmatter@5.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-frontmatter: 2.0.1(supports-color@7.2.0)
+      mdast-util-frontmatter: 2.0.1
       micromark-extension-frontmatter: 2.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-parse@11.0.0(supports-color@7.2.0):
+  remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -8771,10 +8788,10 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  remark@15.0.1(supports-color@7.2.0):
+  remark@15.0.1:
     dependencies:
       '@types/mdast': 4.0.4
-      remark-parse: 11.0.0(supports-color@7.2.0)
+      remark-parse: 11.0.0
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
@@ -9078,19 +9095,19 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  testcontainers@12.0.4(supports-color@7.2.0):
+  testcontainers@12.0.4:
     dependencies:
       '@balena/dockerignore': 1.0.2
       '@types/dockerode': 4.0.1
       archiver: 7.0.1
       async-lock: 1.4.1
       byline: 5.0.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       docker-compose: 1.4.2
-      dockerode: 5.0.1(supports-color@7.2.0)
+      dockerode: 5.0.1
       get-port: 5.1.1
       proper-lockfile: 4.1.2
-      properties-reader: 3.0.1(supports-color@7.2.0)
+      properties-reader: 3.0.1
       ssh-remote-port-forward: 1.0.4
       tar-fs: 3.1.3
       tmp: 0.2.7
@@ -9315,19 +9332,19 @@ snapshots:
       tsx: 4.23.5
       yaml: 2.9.0
 
-  vitepress-plugin-llms@1.13.4(supports-color@7.2.0):
+  vitepress-plugin-llms@1.13.4:
     dependencies:
       '@11ty/gray-matter': 2.1.0
       markdown-it: 14.3.0
       markdown-title: 1.0.2
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       millify: 6.1.0
       minimatch: 10.2.6
       path-to-regexp: 6.3.0
       picocolors: 1.1.1
       pretty-bytes: 7.1.1
-      remark: 15.0.1(supports-color@7.2.0)
-      remark-frontmatter: 5.0.0(supports-color@7.2.0)
+      remark: 15.0.1
+      remark-frontmatter: 5.0.0
       tokenx: 1.6.0
       unist-util-remove: 4.0.0
       unist-util-visit: 5.1.0

--- a/skills/unthrown/SKILL.md
+++ b/skills/unthrown/SKILL.md
@@ -236,7 +236,8 @@ anywhere — and `P.tag("X")` is only sugar for the object pattern `{ _tag: "X" 
 A codebase with its own error convention keeps it: match a `kind` / `code` field
 with an object pattern, an untagged class with `P.instanceOf`, anything else
 with `P.when`. The requirement is a **discriminable** `E`, not a tagged one; a
-widened `Error` / `string` / `unknown` is what breaks exhaustiveness (rule 1).
+widened `Error` / `string` / `unknown` is what breaks exhaustiveness, which is
+what `no-ambiguous-error-type` flags.
 
 ## Mistakes agents make (habits from neverthrow/Effect/fp-ts)
 

--- a/skills/unthrown/SKILL.md
+++ b/skills/unthrown/SKILL.md
@@ -231,6 +231,13 @@ The payload carries **only structured domain fields** — `name`, `message`, and
 Match with `P.tag("HttpError")`. `options.name` sets the display name when the
 tag is namespaced (`TaggedError("pkg/NotFound", { name: "NotFound" })`).
 
+**Not mandatory.** `E` is unconstrained — no `E extends { _tag: string }`
+anywhere — and `P.tag("X")` is only sugar for the object pattern `{ _tag: "X" }`.
+A codebase with its own error convention keeps it: match a `kind` / `code` field
+with an object pattern, an untagged class with `P.instanceOf`, anything else
+with `P.when`. The requirement is a **discriminable** `E`, not a tagged one; a
+widened `Error` / `string` / `unknown` is what breaks exhaustiveness (rule 1).
+
 ## Mistakes agents make (habits from neverthrow/Effect/fp-ts)
 
 | Habit                                                                          | In unthrown                                                                                                                                                                                     |


### PR DESCRIPTION
Answers [discussion #237](https://github.com/btravstack/unthrown/discussions/237).

## Why

The guide was titled **"Model errors with `TaggedError`"** and buried "the matcher matches by structure" in a section near the bottom, so it read as though a tagged error were the price of entry. #237 came in asking whether `TaggedError` is a hard requirement — "depending on this library at this level is almost an adoption barrier" for a codebase that already models its domain errors.

It isn't one. Nothing in core constrains `E` (there is no `E extends { _tag: string }` anywhere), and `P.tag("X")` is only sugar for the object pattern `{ _tag: "X" }`. The framing was the whole problem.

## What changed

### `docs/how-to/model-errors.md`

- Retitled to **Model errors**; the blurb now states `E` is unconstrained and `TaggedError` is a convenience, linking down to the new section.
- `## Define a tagged error` gains a lead-in saying it's the shape proposed *when you have no convention yet*.
- `## Match on more than `_tag`` → **`## Use the errors you already have`**, with three worked examples:
  - **Your own error classes** — a `kind` discriminator on an abstract base, matched with an object pattern through `mapErrCases` (with the inferred `E` annotated).
  - **A plain union type, no classes at all** — `code`-discriminated objects folded with `match`, absorbing the old grouped-patterns snippet.
  - **Classes with no discriminant field** — `P.instanceOf`, plus `P.when` as the general fallback.
- New **`### What `E` _does_ have to be`** — the honest constraint: exhaustiveness is `Exclude` over the union, so `E` must be discriminable. Structurally identical classes collapse; a widened `Error` / `string` / `unknown` leaves `P._` as the only terminating arm, which is what [`no-ambiguous-error-type`](https://btravstack.github.io/unthrown/how-to/lint-your-codebase#no-ambiguous-error-type) is really guarding.
- Moved the `match`-vs-combinators `defect`-helper paragraph back under the `match` section, where it had been orphaned by the section split.

### `examples/existing-errors` — a new runnable example

Prose alone lets a claim about the type system rot, which is precisely what the `examples/*` packages exist to prevent. `@unthrown/example-existing-errors` uses **no `TaggedError` at all**; its three modules mirror the three guide sections one-for-one:

| Module | Convention | Matched with |
| --- | --- | --- |
| `tickets.ts` | abstract `AppError` with a `kind` discriminant | object pattern, via `mapErrCases` |
| `billing.ts` | plain `code` union, no classes | object pattern + grouped arm, via `match` |
| `vendor.ts` | two untagged third-party classes | `P.instanceOf` |

`vendor.ts` carries the part the question was really about: the modelled/unexpected split is made by `qualify` at a `fromThrowable` boundary, not by the error's shape. The spec pins both halves, including that an unmodelled `RangeError` from inside the SDK becomes a `Defect` and never reaches `E`.

It sits outside the checkout trio deliberately — those three model one domain between them, this one models an adoption path. Walkthrough at `docs/examples/existing-errors.md`, wired into the sidebar and both indexes, and linked from the guide section it backs.

### `skills/unthrown/SKILL.md` and `CLAUDE.md`

- The skill's `TaggedError` section had the identical framing problem; same paragraph mirrored in. (Per `CLAUDE.md`: the skill is a hand-maintained second copy and drifts, so it moves in the same PR as the docs.)
- `CLAUDE.md`'s `examples/*` bullet updated for the fourth package and why it stands apart.

## Verification

`pnpm format --check`, `pnpm lint`, `pnpm typecheck`, `pnpm knip`, `pnpm test` (18/18 tasks; the new package contributes 7) and `pnpm build` are green, plus `pnpm --filter @unthrown/docs build` with no dead links.

The guide snippets are not covered by `doc-examples.spec.ts` (it is core-only, and reads TSDoc `@example` blocks rather than markdown), so each was extracted into a throwaway `packages/core/src/*.test-d.ts` and typechecked against core before landing — including the `^?` annotation and a must-not-compile case. The example package's assertions were mutation-checked: swapping one `expect.any(VendorSyntaxError)` for the sibling class turns the suite red.

No changeset: docs, skill and a private example only — no published package touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)