### PR TITLE
feat(oxlint): no-async-result-race — the sibling-const sequence is a race

### DIFF
--- a/.changeset/no-async-result-race.md
+++ b/.changeset/no-async-result-race.md
@@ -1,0 +1,29 @@
+---
+"@unthrown/oxlint": minor
+---
+
+`no-async-result-race`, in the recommended preset
+
+An `AsyncResult` is eager — constructing it starts the work — so the readable
+spelling of a sequence, each step in its own `const` and chained afterwards,
+is a race, and a silent one: it type-checks, returns a `Result`, and runs the
+steps concurrently. The new rule flags the later construction while an earlier
+sibling binding in the same statement list is still unconsumed:
+
+```ts
+const a = stepA();
+const b = stepB(); // ✗ starts concurrently with `a`
+return a.flatMap(() => b);
+```
+
+Chaining in one statement, consuming the earlier binding first, and the
+explicit join (`allAsync([a, b])`) are exempt. Manual start-both-await-both is
+reported — its sanctioned spelling is `allAsync([…])` in one statement — and a
+site that wants the manual form carries a targeted `oxlint-disable` with a
+reason.
+
+Purely syntactic, like its siblings: recognised constructions are unthrown's
+async producers, the `AsyncResult` companion, chains rooted in either, local
+functions whose return annotation is unthrown's `AsyncResult`, and declarators
+annotated with it — the annotation being the opt-in that catches a service
+method call the syntax alone cannot resolve.

--- a/docs/how-to/lint-your-codebase.md
+++ b/docs/how-to/lint-your-codebase.md
@@ -36,8 +36,9 @@ Register the plugin and turn its rules on in your `.oxlintrc.json`:
 ```
 
 The default export also exposes a `recommended` preset — an oxlint config that
-registers the plugin and enables `no-ambiguous-error-type`, `no-unhandled-result`,
-`no-unused-matcher`, `prefer-async-result`, and `no-catch-all-pattern`
+registers the plugin and enables `no-ambiguous-error-type`, `no-async-result-race`,
+`no-unhandled-result`, `no-unused-matcher`, `prefer-async-result`, and
+`no-catch-all-pattern`
 (`no-throw` and `no-get-or-throw` are the two explicit opt-ins) — for setups
 that build their config programmatically
 (`import unthrown from "@unthrown/oxlint"` → `unthrown.recommended`).
@@ -179,6 +180,43 @@ imports included); the facade companions (`Result.Ok(...)`); and a
 `AsyncResult`. A dropped method _chain_ (`r.map(f);`) or a function whose
 `Result`-ness lives behind an imported declaration needs the type checker and is
 out of scope — no false positives is the design priority.
+
+### `unthrown/no-async-result-race` {#no-async-result-race}
+
+An `AsyncResult` is **eager** — constructing it starts the work. So the
+readable spelling of a sequence, each step in its own `const` and chained
+afterwards, is a race, and a silent one: it still type-checks and still
+returns a `Result`; the steps just run concurrently. This rule flags the later
+construction while an earlier sibling binding in the same statement list is
+still unconsumed:
+
+```ts
+import { OkAsync, allAsync } from "unthrown";
+
+const a = stepA(); // work already in flight (stepA declared `(): AsyncResult<…>`)
+const b = stepB(); // ✗ starts concurrently with `a` — reads as a sequence, runs as a race
+return a.flatMap(() => b);
+
+const r = stepA().flatMap(() => stepB()); // ✓ chained — one statement, one sequence
+const seq = await stepA(); // ✓ consumed before the next starts
+return allAsync([stepA(), stepB()]); // ✓ concurrency, stated as such
+```
+
+A construction is recognised purely syntactically: the async producers
+(`OkAsync`, `ErrAsync`, `DoAsync`, `fromPromise`, `fromSafePromise`,
+`fromExecutor`, `allAsync`, `allFromDictAsync`), the `AsyncResult` companion's
+members, a chain rooted in any of those, a locally-declared function whose
+return annotation is unthrown's `AsyncResult`, or a declarator annotated with
+it — the annotation is the opt-in that catches a service method call the
+syntax alone cannot resolve, and an unannotated one is the documented miss.
+
+Consumption is a **direct** reference: a read inside a nested function is
+deferred, which is exactly how `a.flatMap(() => b)` touches `b` without
+sequencing its already-started work. Two bindings first consumed directly in
+one statement (`allAsync([a, b])`) are the sanctioned join, not a race.
+Manual start-both-await-both concurrency **is** reported — its sanctioned
+spelling is `allAsync([…])` in one statement, and a site that genuinely wants
+the manual form carries a targeted `oxlint-disable` with a reason.
 
 ### `unthrown/no-throw` {#no-throw}
 

--- a/packages/oxlint/CLAUDE.md
+++ b/packages/oxlint/CLAUDE.md
@@ -6,7 +6,7 @@ internal design — live in the root [`CLAUDE.md`](../../CLAUDE.md) and apply
 here too.
 
 An oxlint **JS plugin**, peerDep
-`oxlint`, dep `@oxlint/plugins`; ships **seven rules**: `no-ambiguous-error-type`
+`oxlint`, dep `@oxlint/plugins`; ships **eight rules**: `no-ambiguous-error-type`
 — enforces Thesis #1 against `unknown`/`any`/`Error`/`{}` **and the primitive
 keywords** (`void` included) in `E`, both in a `Result`/`AsyncResult` type
 **annotation** and in the matcher's `returnType<R>()` **pin** — the latter only
@@ -38,7 +38,27 @@ recommended preset — flags a bare `ExpressionStatement` dropping a `Result`:
 a call to an unthrown-imported producer or facade-companion member, or to a
 locally-declared function whose return annotation is unthrown's
 `Result`/`AsyncResult`, awaited or not; deliberately syntactic — a dropped
-method _chain_ like `r.map(f);` is type-dependent and out of scope); and
+method _chain_ like `r.map(f);` is type-dependent and out of scope);
+`no-async-result-race` (**in the recommended preset** — flags a sibling
+`AsyncResult` construction in one statement list while an earlier binding is
+still unconsumed: construction is eager, so the sibling-`const` sequence
+races. A construction is a declarator whose initializer roots — walked through
+a combinator chain — in an async free producer, an `AsyncResult` companion
+member, or a local function annotated `AsyncResult`; a declarator annotated
+`AsyncResult` counts regardless of its initializer, which is the opt-in for a
+service method call the syntax cannot resolve. Consumption is a **direct**
+reference — one whose `Reference.from.variableScope` is the binding's own — so
+a read inside a nested closure defers, which is how `a.flatMap(() => b)`
+touches `b` without sequencing it. Two exemptions: a direct reference to the
+earlier binding before the later initializer ends (an ordinary sequence, or
+consumption BY the construction — `allAsync([a, b])` as an initializer), and
+both bindings first directly consumed in one later statement
+(`return allAsync([a, b])`) unless the later construction was awaited, whose
+references are of the settled `Result`. Start-both-await-both is reported on
+purpose — the sanctioned concurrency is `allAsync` in one statement — and the
+escape hatch is a targeted `oxlint-disable` with a reason. One report per
+later construction, against its nearest open predecessor; cross-block races
+and an un-annotated service call are documented misses); and
 `no-catch-all-pattern` (**in the recommended preset** — reports the catch-all
 `P._` — plus ts-pattern's `P.any` alias, kept because the rule also covers a
 `P` imported straight from there — where `P` is imported from `unthrown` or

--- a/packages/oxlint/src/index.test.ts
+++ b/packages/oxlint/src/index.test.ts
@@ -9,10 +9,11 @@ const manifest: { peerDependencies: Record<string, string> } = JSON.parse(
 );
 
 describe("@unthrown/oxlint plugin", () => {
-  it("exposes all seven rules under the `unthrown` plugin name", () => {
+  it("exposes all eight rules under the `unthrown` plugin name", () => {
     expect(plugin.meta?.name).toBe("unthrown");
     expect(Object.keys(plugin.rules).sort()).toEqual([
       "no-ambiguous-error-type",
+      "no-async-result-race",
       "no-catch-all-pattern",
       "no-get-or-throw",
       "no-throw",
@@ -27,6 +28,7 @@ describe("@unthrown/oxlint plugin", () => {
     // a rule silently added to (or dropped from) it must fail this test.
     expect(plugin.recommended.rules).toEqual({
       "unthrown/no-ambiguous-error-type": "error",
+      "unthrown/no-async-result-race": "error",
       "unthrown/no-catch-all-pattern": "error",
       "unthrown/no-unhandled-result": "error",
       "unthrown/no-unused-matcher": "error",

--- a/packages/oxlint/src/index.ts
+++ b/packages/oxlint/src/index.ts
@@ -1,11 +1,14 @@
 // @unthrown/oxlint — an oxlint (JS) plugin that enforces unthrown's conventions
-// at lint time. Seven rules:
+// at lint time. Eight rules:
 //
 //   unthrown/no-ambiguous-error-type  — keep `E` a concrete domain error
 //                                        (no unknown/any/Error/{}), i.e. Thesis #1;
 //                                        also covers mapErrCases' returnType<R>() pin.
 //   unthrown/prefer-async-result      — use AsyncResult<T,E> over Promise<Result<T,E>>.
 //   unthrown/no-unhandled-result      — don't drop a Result returned by a bare call.
+//   unthrown/no-async-result-race     — don't start a sibling AsyncResult while
+//                                        an earlier one is unconsumed; eager
+//                                        construction makes the sequence a race.
 //   unthrown/no-catch-all-pattern     — ban the `P._` matcher catch-all;
 //                                        enumerate every error case by name.
 //   unthrown/no-get-or-throw          — ban `getOrThrow()`; fold the error channel
@@ -26,6 +29,7 @@ import type { Plugin } from "@oxlint/plugins";
 import type { OxlintConfig } from "oxlint";
 
 import { noAmbiguousErrorType } from "./rules/no-ambiguous-error-type.js";
+import { noAsyncResultRace } from "./rules/no-async-result-race.js";
 import { noCatchAllPattern } from "./rules/no-catch-all-pattern.js";
 import { noGetOrThrow } from "./rules/no-get-or-throw.js";
 import { noThrow } from "./rules/no-throw.js";
@@ -39,6 +43,7 @@ const plugin = eslintCompatPlugin({
   meta: { name: "unthrown" },
   rules: {
     "no-ambiguous-error-type": noAmbiguousErrorType,
+    "no-async-result-race": noAsyncResultRace,
     "no-catch-all-pattern": noCatchAllPattern,
     "no-get-or-throw": noGetOrThrow,
     "no-throw": noThrow,
@@ -89,6 +94,7 @@ plugin.recommended = {
   jsPlugins: [{ name: "unthrown", specifier: "@unthrown/oxlint" }],
   rules: {
     "unthrown/no-ambiguous-error-type": "error",
+    "unthrown/no-async-result-race": "error",
     "unthrown/no-catch-all-pattern": "error",
     "unthrown/no-unhandled-result": "error",
     "unthrown/no-unused-matcher": "error",

--- a/packages/oxlint/src/rules/no-async-result-race.test.ts
+++ b/packages/oxlint/src/rules/no-async-result-race.test.ts
@@ -1,0 +1,107 @@
+import { ruleTester } from "../tester.js";
+import { noAsyncResultRace } from "./no-async-result-race.js";
+
+ruleTester.run("no-async-result-race", noAsyncResultRace, {
+  valid: [
+    // One construction alone cannot race.
+    { code: `import { OkAsync } from "unthrown";\nconst a = OkAsync(1);` },
+    // Chained in one statement — the sanctioned sequence.
+    {
+      code: `import { OkAsync, ErrAsync } from "unthrown";\nconst r = OkAsync(1).flatMap(() => ErrAsync("e"));`,
+    },
+    // The earlier binding is consumed before the later work starts.
+    {
+      code: `import { OkAsync } from "unthrown";\nasync function f() {\n  const a = OkAsync(1);\n  const settled = await a;\n  const b = OkAsync(2);\n  return b;\n}`,
+    },
+    // Chained through the later initializer: `b` hangs off `a`, so `a` is
+    // consumed at `b`'s construction — a sequence, not a race. (`b`'s own init
+    // roots at `a`, not at a producer, so it is not even a construction.)
+    {
+      code: `import { OkAsync } from "unthrown";\nconst a = OkAsync(1);\nconst b = a.flatMap(() => OkAsync(2));`,
+    },
+    // First consumed TOGETHER: the sanctioned explicit join.
+    {
+      code: `import { OkAsync, allAsync } from "unthrown";\nconst a = OkAsync(1);\nconst b = OkAsync(2);\nconst joined = allAsync([a, b]);`,
+    },
+    // A producer inside a nested function is deferred, not constructed.
+    {
+      code: `import { OkAsync } from "unthrown";\nconst a = OkAsync(1);\nconst lazy = () => OkAsync(2);`,
+    },
+    // Different blocks do not share a statement list.
+    {
+      code: `import { OkAsync } from "unthrown";\nfunction f(x: boolean) {\n  if (x) {\n    const a = OkAsync(1);\n    return a;\n  }\n  const b = OkAsync(2);\n  return b;\n}`,
+    },
+    // A sync Result cannot race — settled at construction.
+    {
+      code: `import { Ok } from "unthrown";\nconst a = Ok(1);\nconst b = Ok(2);\nconst c = a.flatMap(() => b);`,
+    },
+    // A `Result` from another module is not unthrown's.
+    {
+      code: `import { OkAsync } from "elsewhere";\nconst a = OkAsync(1);\nconst b = OkAsync(2);\nvoid a;\nvoid b;`,
+    },
+    // The explicit join outside a declarator: both directly consumed in one
+    // later statement.
+    {
+      code: `import { OkAsync, allAsync } from "unthrown";\nfunction f() {\n  const a = OkAsync(1);\n  const b = OkAsync(2);\n  return allAsync([a, b]);\n}`,
+    },
+    // A local function returning a plain Promise is not an AsyncResult.
+    {
+      code: `declare function step(): Promise<number>;\nconst a = step();\nconst b = step();\nvoid a;\nvoid b;`,
+    },
+  ],
+  invalid: [
+    // The canonical race: two producers bound, then chained after the fact.
+    {
+      code: `import { OkAsync } from "unthrown";\nconst a = OkAsync(1);\nconst b = OkAsync(2);\nconst r = a.flatMap(() => b);`,
+      errors: [{ messageId: "noAsyncResultRace" }],
+    },
+    // Never consumed at all is still a race with the sibling.
+    {
+      code: `import { OkAsync, ErrAsync } from "unthrown";\nconst a = OkAsync(1);\nconst b = ErrAsync("e");`,
+      errors: [{ messageId: "noAsyncResultRace" }],
+    },
+    // Start-both-await-both: manual concurrency's sanctioned spelling is
+    // `allAsync([…])` in one statement; separate awaits are reported.
+    {
+      code: `import { OkAsync } from "unthrown";\nasync function f() {\n  const a = OkAsync(1);\n  const b = OkAsync(2);\n  const ra = await a;\n  const rb = await b;\n  return [ra, rb];\n}`,
+      errors: [{ messageId: "noAsyncResultRace" }],
+    },
+    // An awaited later construction still starts while the earlier is open.
+    {
+      code: `import { OkAsync, DoAsync } from "unthrown";\nasync function f() {\n  const a = OkAsync(1);\n  const r = await DoAsync();\n  return [a, r];\n}`,
+      errors: [{ messageId: "noAsyncResultRace" }],
+    },
+    // The chain roots at a producer, so the whole chain is one construction.
+    {
+      code: `import { OkAsync, ErrAsync } from "unthrown";\nconst a = OkAsync(1).map((n) => n + 1);\nconst b = ErrAsync("e").mapErr((e) => e);\nconst r = a.flatMap(() => b);`,
+      errors: [{ messageId: "noAsyncResultRace" }],
+    },
+    // The facade companion constructs too.
+    {
+      code: `import { AsyncResult } from "unthrown";\nconst a = AsyncResult.Ok(1);\nconst b = AsyncResult.fromPromise(Promise.resolve(2), (e) => e);\nconst r = a.flatMap(() => b);`,
+      errors: [{ messageId: "noAsyncResultRace" }],
+    },
+    // A local function whose return annotation is unthrown's AsyncResult.
+    {
+      code: `import { OkAsync, type AsyncResult } from "unthrown";\nconst step = (n: number): AsyncResult<number, never> => OkAsync(n);\nconst a = step(1);\nconst b = step(2);\nconst r = a.flatMap(() => b);`,
+      errors: [{ messageId: "noAsyncResultRace" }],
+    },
+    // A declarator annotated with AsyncResult — the opt-in that catches a
+    // service method call the syntax alone cannot resolve.
+    {
+      code: `import type { AsyncResult } from "unthrown";\ndeclare const svc: { step(n: number): AsyncResult<number, never> };\nconst a: AsyncResult<number, never> = svc.step(1);\nconst b: AsyncResult<number, never> = svc.step(2);\nconst r = a.flatMap(() => b);`,
+      errors: [{ messageId: "noAsyncResultRace" }],
+    },
+    // Renamed import still resolves — keyed by the IMPORTED name.
+    {
+      code: `import { OkAsync as ok } from "unthrown";\nconst a = ok(1);\nconst b = ok(2);\nconst r = a.flatMap(() => b);`,
+      errors: [{ messageId: "noAsyncResultRace" }],
+    },
+    // Three siblings: one fault per later construction, each against its
+    // nearest open predecessor.
+    {
+      code: `import { OkAsync } from "unthrown";\nconst a = OkAsync(1);\nconst b = OkAsync(2);\nconst c = OkAsync(3);\nconst r = a.flatMap(() => b.flatMap(() => c));`,
+      errors: [{ messageId: "noAsyncResultRace" }, { messageId: "noAsyncResultRace" }],
+    },
+  ],
+});

--- a/packages/oxlint/src/rules/no-async-result-race.test.ts
+++ b/packages/oxlint/src/rules/no-async-result-race.test.ts
@@ -73,7 +73,7 @@ ruleTester.run("no-async-result-race", noAsyncResultRace, {
     },
     // The chain roots at a producer, so the whole chain is one construction.
     {
-      code: `import { OkAsync, ErrAsync } from "unthrown";\nconst a = OkAsync(1).map((n) => n + 1);\nconst b = ErrAsync("e").mapErr((e) => e);\nconst r = a.flatMap(() => b);`,
+      code: `import { OkAsync, ErrAsync } from "unthrown";\nconst a = OkAsync(1).map((n) => n + 1);\nconst b = ErrAsync("e").tapFailure(() => {});\nconst r = a.flatMap(() => b);`,
       errors: [{ messageId: "noAsyncResultRace" }],
     },
     // The facade companion constructs too.

--- a/packages/oxlint/src/rules/no-async-result-race.ts
+++ b/packages/oxlint/src/rules/no-async-result-race.ts
@@ -1,0 +1,237 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree, Scope, Variable } from "@oxlint/plugins";
+
+import { declaredReturnType } from "../helpers/declared-return-type.js";
+import { getImportBinding } from "../helpers/get-import-binding.js";
+import { resolveResultType } from "../helpers/resolve-result-type.js";
+
+const MODULE = "unthrown";
+
+// The `AsyncResult`-producing free functions core exports — the sync producers
+// are deliberately absent: a `Result` holds a settled value, so two sibling
+// `Ok(...)`s cannot race.
+const ASYNC_FREE_PRODUCERS: ReadonlySet<string> = new Set([
+  "OkAsync",
+  "ErrAsync",
+  "DoAsync",
+  "fromPromise",
+  "fromSafePromise",
+  "fromExecutor",
+  "allAsync",
+  "allFromDictAsync",
+]);
+
+// The producing members of the `AsyncResult` facade companion.
+const COMPANION_PRODUCERS: ReadonlySet<string> = new Set([
+  "Ok",
+  "Err",
+  "Do",
+  "fromExecutor",
+  "fromPromise",
+  "fromSafePromise",
+  "all",
+  "allFromDict",
+]);
+
+/**
+ * Whether `callee` resolves to a locally-declared function whose declared
+ * return type is unthrown's `AsyncResult` — `Result` is excluded on purpose:
+ * only the async form starts work at construction.
+ */
+const isLocalAsyncResultFunction = (
+  scope: Scope,
+  callee: ESTree.Node,
+  getScope: (node: ESTree.Node) => Scope,
+): boolean => {
+  const def = scope.references.find((ref) => ref.identifier === callee)?.resolved?.defs[0];
+  if (!def) return false;
+  const returnType = declaredReturnType(def.node);
+  if (returnType?.type !== "TSTypeReference") return false;
+  return resolveResultType(getScope(returnType), returnType) === "AsyncResult";
+};
+
+/**
+ * Whether an initializer eagerly constructs an `AsyncResult`: its leftmost
+ * call — walked through a combinator chain, so `OkAsync(1).flatMap(f)` roots
+ * at `OkAsync(1)` — is an unthrown async free producer, an
+ * `AsyncResult.<producer>` companion member, or a locally-declared function
+ * whose return annotation is unthrown's `AsyncResult`. A producer inside a
+ * nested function is NOT a construction — the closure defers it, which is
+ * exactly the lazy spelling the combinators exist for.
+ */
+const isConstruction = (
+  scope: Scope,
+  node: ESTree.Node,
+  getScope: (node: ESTree.Node) => Scope,
+): boolean => {
+  if (node.type !== "CallExpression") return false;
+  const { callee } = node;
+  if (callee.type === "Identifier") {
+    const binding = getImportBinding(scope, callee);
+    if (binding) return binding.source === MODULE && ASYNC_FREE_PRODUCERS.has(binding.imported);
+    return isLocalAsyncResultFunction(scope, callee, getScope);
+  }
+  if (callee.type === "MemberExpression" && !callee.computed) {
+    if (callee.object.type === "Identifier" && callee.property.type === "Identifier") {
+      const binding = getImportBinding(scope, callee.object);
+      if (binding?.source === MODULE && binding.imported === "AsyncResult") {
+        return COMPANION_PRODUCERS.has(callee.property.name);
+      }
+    }
+    // A combinator chain: root the check on what the chain hangs off.
+    return isConstruction(scope, callee.object, getScope);
+  }
+  return false;
+};
+
+type Construction = {
+  readonly name: string;
+  readonly variable: Variable;
+  /** The declarator's own identifier — a WRITE reference in scope analysis, excluded from consumption. */
+  readonly id: ESTree.Node;
+  /** Where the work starts — the initializer, which is where the race is reported. */
+  readonly init: ESTree.Node;
+  readonly start: number;
+  /** `await`ed at construction: consumed on the spot, so it can trigger a report but never be raced against. */
+  readonly awaited: boolean;
+};
+
+/**
+ * Disallow the sibling-`const` `AsyncResult` sequence — the one spelling that
+ * type-checks, returns a `Result`, and still races. An `AsyncResult` is
+ * EAGER: constructing it starts the work, so
+ *
+ * ```ts
+ * const a = repository.save(order);   // work already in flight
+ * const b = outbox.append(event);    // ← starts concurrently with `a`
+ * return a.flatMap(() => b);
+ * ```
+ *
+ * reads as a sequence and runs as a race. The rule reports the later
+ * construction while an earlier sibling binding in the same statement list is
+ * still unconsumed — unless the two are first consumed TOGETHER in one
+ * statement (`allAsync([a, b])`, a chain touching both), which is the
+ * sanctioned join rather than a race. Deliberate start-both-await-both
+ * concurrency is still reported: its sanctioned spelling is `allAsync([...])`
+ * in one statement, and a site that genuinely wants the manual form carries a
+ * targeted `oxlint-disable` with a reason.
+ *
+ * Purely syntactic: a construction is recognised by unthrown's own async
+ * producers, the `AsyncResult` companion, a local function whose return
+ * annotation is unthrown's `AsyncResult`, or a declarator annotated with it —
+ * a method call on a service only the type checker could resolve is a
+ * documented miss, and the annotation is its opt-in.
+ */
+export const noAsyncResultRace = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow starting a sibling `AsyncResult` while an earlier one is still unconsumed — eager construction makes the sequence a race",
+      recommended: true,
+    },
+    messages: {
+      noAsyncResultRace:
+        "`{{ later }}` starts while `{{ earlier }}` is still unconsumed — an `AsyncResult` is eager, so this reads as a sequence and runs as a race. Chain them (`{{ earlier }}.flatTap(…)` / `flatMap` / `DoAsync().bind`), or make the concurrency explicit with `allAsync([…])` in one statement.",
+    },
+  },
+  createOnce: (context) => {
+    const getScope = (node: ESTree.Node) => context.sourceCode.getScope(node);
+
+    /**
+     * The first DIRECT reference consuming a construction — its own declarator
+     * write excluded, and so is every reference inside a nested function: a
+     * closure defers the read, which is precisely how `a.flatMap(() => b)`
+     * consumes `b` without sequencing its already-started work. Deferral is
+     * scope, not position: the reference's nearest function scope must be the
+     * binding's own.
+     */
+    const firstDirectRef = (construction: Construction): number | undefined =>
+      construction.variable.references
+        .filter(
+          (ref) =>
+            ref.identifier !== construction.id &&
+            ref.from.variableScope === construction.variable.scope.variableScope,
+        )
+        .map((ref) => ref.identifier.range[0])
+        .sort((a, b) => a - b)[0];
+
+    const check = (body: readonly ESTree.Statement[]): void => {
+      const constructions: Construction[] = [];
+      for (const statement of body) {
+        if (statement.type !== "VariableDeclaration") continue;
+        for (const declarator of statement.declarations) {
+          if (declarator.id.type !== "Identifier" || !declarator.init) continue;
+          const awaited = declarator.init.type === "AwaitExpression";
+          const init =
+            declarator.init.type === "AwaitExpression" ? declarator.init.argument : declarator.init;
+          const scope = getScope(declarator);
+          const annotated =
+            declarator.id.typeAnnotation?.typeAnnotation.type === "TSTypeReference" &&
+            resolveResultType(
+              getScope(declarator.id.typeAnnotation.typeAnnotation),
+              declarator.id.typeAnnotation.typeAnnotation,
+            ) === "AsyncResult";
+          if (!annotated && !isConstruction(scope, init, getScope)) continue;
+          const variable = scope.set.get(declarator.id.name);
+          if (!variable) continue;
+          constructions.push({
+            name: declarator.id.name,
+            variable,
+            id: declarator.id,
+            init: declarator.init,
+            start: declarator.init.range[0],
+            awaited,
+          });
+        }
+      }
+      if (constructions.length < 2) return;
+
+      /** The index of the top-level statement containing a source position. */
+      const statementAt = (position: number): number =>
+        body.findIndex((s) => s.range[0] <= position && position <= s.range[1]);
+
+      for (const [index, later] of constructions.entries()) {
+        // The LATEST earlier violation, so one fault yields one report.
+        const earlier = constructions
+          .slice(0, index)
+          .reverse()
+          .find((candidate) => {
+            if (candidate.awaited) return false;
+            const consumedAt = firstDirectRef(candidate);
+            // Directly consumed before the later construction ENDS: an
+            // ordinary sequence — or consumption by the construction itself
+            // (`OkAsync(a)`, `allAsync([a, b])` as an initializer), which is a
+            // join rather than a race. A DEFERRED reference does not count:
+            // `a.flatMap(() => b)` reads as sequencing `b` and does not.
+            if (consumedAt !== undefined && consumedAt < later.init.range[1]) return false;
+            // Both first consumed DIRECTLY in one later statement:
+            // `return allAsync([a, b])` — the explicit join. Not when the
+            // later construction was awaited: its references are of the
+            // settled `Result`, joining nothing.
+            const laterConsumedAt = later.awaited ? undefined : firstDirectRef(later);
+            if (
+              consumedAt !== undefined &&
+              laterConsumedAt !== undefined &&
+              statementAt(consumedAt) !== -1 &&
+              statementAt(consumedAt) === statementAt(laterConsumedAt)
+            ) {
+              return false;
+            }
+            return true;
+          });
+        if (!earlier) continue;
+        context.report({
+          node: later.init,
+          messageId: "noAsyncResultRace",
+          data: { earlier: earlier.name, later: later.name },
+        });
+      }
+    };
+
+    return {
+      Program: (node) => check(node.body),
+      BlockStatement: (node) => check(node.body),
+    };
+  },
+});

--- a/skills/unthrown/SKILL.md
+++ b/skills/unthrown/SKILL.md
@@ -265,7 +265,7 @@ what `no-ambiguous-error-type` flags.
   facade namespaces (`Result.*`/`AsyncResult.*`), and utility types. Read when
   choosing a combinator or writing anything beyond the basics above.
 - **[references/ecosystem.md](references/ecosystem.md)** — the `@unthrown/*`
-  satellite packages: vitest matchers (`toBeOk`/`toBeErrTagged`/…), the seven
+  satellite packages: vitest matchers (`toBeOk`/`toBeErrTagged`/…), the eight
   oxlint rules, Prisma extension (`try*` delegates), Drizzle database
   (replaces the stock one — no `try*`), oRPC bridge,
   standard-schema validation, and the effect/neverthrow/boxed interop bridges.

--- a/skills/unthrown/references/ecosystem.md
+++ b/skills/unthrown/references/ecosystem.md
@@ -36,9 +36,9 @@ wiring exports: the seven raw matcher functions, `failOnForgottenAwait`, and the
 
 ## Linting: @unthrown/oxlint
 
-An oxlint JS plugin (peer `oxlint`). Seven rules. The type-shaped ones
+An oxlint JS plugin (peer `oxlint`). Eight rules. The type-shaped ones
 (`no-ambiguous-error-type`, `prefer-async-result`, `no-unhandled-result`,
-`no-catch-all-pattern`) resolve bindings by scope analysis, so they only fire
+`no-async-result-race`, `no-catch-all-pattern`) resolve bindings by scope analysis, so they only fire
 on unthrown's own `Result` — another library's is left alone. Three are keyed
 on a name or shape instead, and need no import to resolve:
 `no-unused-matcher` (the `…Cases` method names), `no-get-or-throw` (a
@@ -55,6 +55,12 @@ statement itself — it reports every `throw`, in any file).
   function-type return positions — those must stay `Promise`).
 - `no-unhandled-result` — flags a bare expression statement dropping a
   `Result` (syntactic; a dropped method chain is out of scope).
+- `no-async-result-race` — flags a sibling `AsyncResult` construction while an
+  earlier binding in the same statement list is still unconsumed: construction
+  is eager, so the sibling-`const` sequence races. Chaining and the one-statement
+  join (`allAsync([a, b])`) are exempt; manual start-both-await-both is
+  reported — its sanctioned spelling is `allAsync`, and a deliberate site
+  carries a targeted `oxlint-disable` with a reason.
 - `no-catch-all-pattern` — reports `P._` (and ts-pattern's `P.any`); self-exempts
   when an in-file `Result` annotation proves `E` is a single non-union type or
   an unresolved generic; unprovable keep-the-wildcard sites carry a targeted


### PR DESCRIPTION
Closes the need tracked in btravstack/start#92.

## The hazard

An `AsyncResult` is eager — constructing it starts the work — so the readable
spelling of a sequence is a race, and a silent one:

```ts
const a = stepA();               // work already in flight
const b = stepB();               // ✗ starts concurrently with `a`
return a.flatMap(() => b);       // reads as a sequence, runs as a race
```

It type-checks, it returns a `Result`, and nothing caught it. The consuming
framework's own spec calls it "the one place this repo's mistakes-are-compile-
errors thesis does not hold", with the measurement: the sibling spelling logs
`start:a start:b end:b end:a` where `flatTap` logs `start:a end:a start:b end:b`.

## The rule

Flags the later construction while an earlier sibling binding in the same
statement list is still unconsumed. The load-bearing definition is
**consumption = a direct reference** — one whose `Reference.from.variableScope`
is the binding's own — because a read inside a nested closure defers, which is
precisely how `a.flatMap(() => b)` touches `b` without sequencing its
already-started work. That one distinction is what separates the canonical race
from the sanctioned join:

```ts
const r = stepA().flatMap(() => stepB()); // ✓ chained — one statement
const s = await stepA();                  // ✓ consumed before the next starts
return allAsync([a, b]);                  // ✓ concurrency, stated as such — both refs direct
return a.flatMap(() => b);                // ✗ b's only ref is deferred — false sequence
```

Start-both-await-both is reported **on purpose**: the sanctioned concurrency is
`allAsync([…])` in one statement, and a site that genuinely wants the manual
form carries a targeted `oxlint-disable` with a reason — the same posture as
`no-catch-all-pattern`'s irreducible uses.

## Recognition, purely syntactic like its siblings

Async free producers (`OkAsync` … `allFromDictAsync`), the `AsyncResult`
companion, combinator chains rooted in either, locally-declared functions whose
return annotation is unthrown's `AsyncResult`, and declarators annotated with
it — the annotation being the deliberate opt-in that catches a service method
call the syntax alone cannot resolve. Cross-block races and un-annotated
service calls are the documented misses; sync `Result`s are excluded because a
settled value cannot race.

## Preset placement

`recommended`. The false-positive budget was the design constraint
(`prefer-ensure`'s removal being the cautionary tale), and the dogfood run is
the evidence: `oxlint .` over this repo — whose examples and specs are
saturated with `AsyncResult`s — passes with zero hits.

## Verified

21 rule tests (11 valid / 10 invalid, every exemption and every recognition
path); the skill-inventory tests forced the agent-skill and ecosystem docs into
sync; 219/219 package tests; repo-wide `lint`, `typecheck`, `knip`, `test`,
`build` all green. Changeset: `minor`.