### PR TITLE
feat!: unthrown is a peer of every companion, never a dependency

### DIFF
--- a/.changeset/unthrown-as-peer.md
+++ b/.changeset/unthrown-as-peer.md
@@ -1,0 +1,19 @@
+---
+"@unthrown/boxed": minor
+"@unthrown/effect": minor
+"@unthrown/neverthrow": minor
+"@unthrown/standard-schema": minor
+"@unthrown/orpc": minor
+"@unthrown/prisma": minor
+"@unthrown/drizzle": minor
+---
+
+`unthrown` is a peerDependency now, not a dependency. As a dependency the
+package manager was free to give each companion its own copy whenever the
+app's copy did not satisfy the subtree — and two copies diverge in both type
+(structurally incompatible `Result`/`AsyncResult` across versions) and
+runtime identity (`isResult` compares across copies). As a peer an
+application installs exactly one `unthrown`, and an unmet range fails loudly
+at install instead of silently forking the tree. npm ≥7 and pnpm
+auto-install peers, so most installs are unchanged; add `unthrown` to your
+dependencies explicitly if your setup does not.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -716,6 +716,13 @@ AsyncResult<infer T, …>` — structural inference over the whole method surfac
 
 ## Monorepo layout
 
+Every companion package **peers on `unthrown`** (`workspace:^` in
+`peerDependencies`, kept in `devDependencies` for the workspace build; pnpm
+rewrites it to a real `^` range at publish). As a regular dependency the
+package manager was free to fork the tree into two `unthrown` copies, which
+diverge in both type and runtime identity (`isResult` compares across
+copies) — issue #256, observed live in btravstack/start#99.
+
 - `packages/core` → `unthrown` (**zero runtime dependencies** — the exhaustive
   error matcher is built-in (`matcher.ts`, exported as `match`/`P`/
   `NonExhaustiveError`); it replaced the former `ts-pattern` peer so the
@@ -734,9 +741,10 @@ AsyncResult<infer T, …>` — structural inference over the whole method surfac
   `Result` via `fromSchema` / `fromSchemaAsync`, with the validation issues as
   the modeled `E`)
 - `packages/oxlint` → `@unthrown/oxlint` (an oxlint **JS plugin**, peerDep
-  `oxlint`, dep `@oxlint/plugins`; ships **seven rules** — five in the
-  `recommended` preset (`no-ambiguous-error-type`, `no-catch-all-pattern`,
-  `no-unhandled-result`, `no-unused-matcher`, `prefer-async-result`) plus the
+  `oxlint`, dep `@oxlint/plugins`; ships **eight rules** — six in the
+  `recommended` preset (`no-ambiguous-error-type`, `no-async-result-race`,
+  `no-catch-all-pattern`, `no-unhandled-result`, `no-unused-matcher`,
+  `prefer-async-result`) plus the
   opt-ins `no-get-or-throw` and `no-throw`. Purely syntactic AST rules. No TypeDoc API page;
   documented in the Linting guide. Full spec: `packages/oxlint/CLAUDE.md`.)
 - `packages/prisma` → `@unthrown/prisma` (peerDep `@prisma/client` ^7; a Prisma

--- a/packages/boxed/README.md
+++ b/packages/boxed/README.md
@@ -7,7 +7,7 @@
 [API Reference](https://btravstack.github.io/unthrown/api/boxed/)
 
 ```sh
-pnpm add @unthrown/boxed @bloodyowl/boxed
+pnpm add @unthrown/boxed @bloodyowl/boxed unthrown
 ```
 
 Boxed's `Result` has two channels (`Ok`/`Error`) and no defect channel. Coming

--- a/packages/boxed/package.json
+++ b/packages/boxed/package.json
@@ -49,9 +49,6 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
-  "dependencies": {
-    "unthrown": "workspace:^"
-  },
   "devDependencies": {
     "@bloodyowl/boxed": "catalog:",
     "@btravstack/tsconfig": "catalog:",
@@ -59,10 +56,12 @@
     "@vitest/coverage-v8": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",
+    "unthrown": "workspace:^",
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@bloodyowl/boxed": "^3"
+    "@bloodyowl/boxed": "^3",
+    "unthrown": "workspace:^"
   },
   "engines": {
     "node": ">=20"

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -59,9 +59,6 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test-d.json"
   },
-  "dependencies": {
-    "unthrown": "workspace:^"
-  },
   "devDependencies": {
     "@btravstack/tsconfig": "catalog:",
     "@testcontainers/postgresql": "catalog:",
@@ -73,11 +70,13 @@
     "pg": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",
+    "unthrown": "workspace:^",
     "vitest": "catalog:"
   },
   "peerDependencies": {
     "drizzle-orm": "^1.0.0-rc",
-    "pg": "^8.16.0"
+    "pg": "^8.16.0",
+    "unthrown": "workspace:^"
   },
   "engines": {
     "node": ">=20"

--- a/packages/effect/README.md
+++ b/packages/effect/README.md
@@ -7,7 +7,7 @@
 [API Reference](https://btravstack.github.io/unthrown/api/effect/)
 
 ```sh
-pnpm add @unthrown/effect effect
+pnpm add @unthrown/effect effect unthrown
 ```
 
 Effect is the one neighbour that shares unthrown's three-channel shape: an

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -49,9 +49,6 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
-  "dependencies": {
-    "unthrown": "workspace:^"
-  },
   "devDependencies": {
     "@btravstack/tsconfig": "catalog:",
     "@types/node": "catalog:",
@@ -59,10 +56,12 @@
     "effect": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",
+    "unthrown": "workspace:^",
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "effect": "^3"
+    "effect": "^3",
+    "unthrown": "workspace:^"
   },
   "engines": {
     "node": ">=20"

--- a/packages/neverthrow/README.md
+++ b/packages/neverthrow/README.md
@@ -7,7 +7,7 @@
 [API Reference](https://btravstack.github.io/unthrown/api/neverthrow/)
 
 ```sh
-pnpm add @unthrown/neverthrow neverthrow
+pnpm add @unthrown/neverthrow neverthrow unthrown
 ```
 
 neverthrow has two channels (`Ok`/`Err`) and no defect channel. Coming **in**,

--- a/packages/neverthrow/package.json
+++ b/packages/neverthrow/package.json
@@ -48,9 +48,6 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
-  "dependencies": {
-    "unthrown": "workspace:^"
-  },
   "devDependencies": {
     "@btravstack/tsconfig": "catalog:",
     "@types/node": "catalog:",
@@ -58,10 +55,12 @@
     "neverthrow": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",
+    "unthrown": "workspace:^",
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "neverthrow": "^8"
+    "neverthrow": "^8",
+    "unthrown": "workspace:^"
   },
   "engines": {
     "node": ">=20"

--- a/packages/orpc/package.json
+++ b/packages/orpc/package.json
@@ -68,9 +68,6 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
-  "dependencies": {
-    "unthrown": "workspace:^"
-  },
   "devDependencies": {
     "@btravstack/tsconfig": "catalog:",
     "@orpc/client": "catalog:",
@@ -81,11 +78,13 @@
     "@vitest/coverage-v8": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",
+    "unthrown": "workspace:^",
     "vitest": "catalog:"
   },
   "peerDependencies": {
     "@orpc/client": "^2.0.0-beta",
-    "@orpc/server": "^2.0.0-beta"
+    "@orpc/server": "^2.0.0-beta",
+    "unthrown": "workspace:^"
   },
   "peerDependenciesMeta": {
     "@orpc/server": {

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -51,9 +51,6 @@
     "test": "prisma generate && vitest run",
     "typecheck": "prisma generate && tsc --noEmit"
   },
-  "dependencies": {
-    "unthrown": "workspace:^"
-  },
   "devDependencies": {
     "@btravstack/tsconfig": "catalog:",
     "@prisma/adapter-better-sqlite3": "catalog:",
@@ -65,10 +62,12 @@
     "prisma": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",
+    "unthrown": "workspace:^",
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@prisma/client": "^7"
+    "@prisma/client": "^7",
+    "unthrown": "workspace:^"
   },
   "engines": {
     "node": ">=20.19"

--- a/packages/standard-schema/README.md
+++ b/packages/standard-schema/README.md
@@ -7,7 +7,7 @@
 [API Reference](https://btravstack.github.io/unthrown/api/standard-schema/)
 
 ```sh
-pnpm add @unthrown/standard-schema
+pnpm add @unthrown/standard-schema unthrown
 ```
 
 Bridge any [Standard Schema](https://standardschema.dev) validator — **Zod**,

--- a/packages/standard-schema/package.json
+++ b/packages/standard-schema/package.json
@@ -52,8 +52,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@standard-schema/spec": "catalog:",
-    "unthrown": "workspace:^"
+    "@standard-schema/spec": "catalog:"
   },
   "devDependencies": {
     "@btravstack/tsconfig": "catalog:",
@@ -61,7 +60,11 @@
     "@vitest/coverage-v8": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",
+    "unthrown": "workspace:^",
     "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "unthrown": "workspace:^"
   },
   "engines": {
     "node": ">=20"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ catalogs:
     '@changesets/cli':
       specifier: 3.0.0
       version: 3.0.0
+    '@commitlint/cli':
+      specifier: 21.2.2
+      version: 21.2.2
     '@orpc/client':
       specifier: 2.0.0-beta.28
       version: 2.0.0-beta.28
@@ -319,10 +322,6 @@ importers:
         version: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
 
   packages/boxed:
-    dependencies:
-      unthrown:
-        specifier: workspace:^
-        version: link:../core
     devDependencies:
       '@bloodyowl/boxed':
         specifier: 'catalog:'
@@ -342,6 +341,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      unthrown:
+        specifier: workspace:^
+        version: link:../core
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
@@ -368,10 +370,6 @@ importers:
         version: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
 
   packages/drizzle:
-    dependencies:
-      unthrown:
-        specifier: workspace:^
-        version: link:../core
     devDependencies:
       '@btravstack/tsconfig':
         specifier: 'catalog:'
@@ -403,15 +401,14 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      unthrown:
+        specifier: workspace:^
+        version: link:../core
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
 
   packages/effect:
-    dependencies:
-      unthrown:
-        specifier: workspace:^
-        version: link:../core
     devDependencies:
       '@btravstack/tsconfig':
         specifier: 'catalog:'
@@ -431,15 +428,14 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      unthrown:
+        specifier: workspace:^
+        version: link:../core
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
 
   packages/neverthrow:
-    dependencies:
-      unthrown:
-        specifier: workspace:^
-        version: link:../core
     devDependencies:
       '@btravstack/tsconfig':
         specifier: 'catalog:'
@@ -459,15 +455,14 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      unthrown:
+        specifier: workspace:^
+        version: link:../core
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
 
   packages/orpc:
-    dependencies:
-      unthrown:
-        specifier: workspace:^
-        version: link:../core
     devDependencies:
       '@btravstack/tsconfig':
         specifier: 'catalog:'
@@ -496,6 +491,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      unthrown:
+        specifier: workspace:^
+        version: link:../core
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
@@ -529,10 +527,6 @@ importers:
         version: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
 
   packages/prisma:
-    dependencies:
-      unthrown:
-        specifier: workspace:^
-        version: link:../core
     devDependencies:
       '@btravstack/tsconfig':
         specifier: 'catalog:'
@@ -564,6 +558,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      unthrown:
+        specifier: workspace:^
+        version: link:../core
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
@@ -573,9 +570,6 @@ importers:
       '@standard-schema/spec':
         specifier: 'catalog:'
         version: 1.1.0
-      unthrown:
-        specifier: workspace:^
-        version: link:../core
     devDependencies:
       '@btravstack/tsconfig':
         specifier: 'catalog:'
@@ -592,6 +586,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      unthrown:
+        specifier: workspace:^
+        version: link:../core
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)


### PR DESCRIPTION
Closes #256.

## What

Seven packages move `unthrown` from `dependencies` to `peerDependencies` — `boxed`, `effect`, `neverthrow`, `standard-schema`, `orpc`, `prisma`, `drizzle` — adopting the shape `@unthrown/vitest` already had: `workspace:^` in `peerDependencies` (pnpm rewrites it to a real `^` range at publish), kept in `devDependencies` for the workspace build. `@unthrown/oxlint` is untouched (no runtime need for `unthrown`).

## Why

As a regular dependency the package manager was free to give each companion its **own** `unthrown` copy whenever the app's copy did not satisfy the subtree. btravstack/start#99 hit it live: a lockfile-stuck 5.5.0 beside the app's 5.6.0, the two copies' `AsyncResult`s made mutually unassignable by 5.6.0's `NotThenable`, and `isResult`'s cross-copy identity comparison one step away. As a peer, an application installs exactly one copy and an unmet range fails loudly at install.

## Versioning choice — flagging for your call

The commit is `feat!:` because dep→peer is honestly a packaging break, but the changeset says **minor**: npm ≥7 and pnpm auto-install peers by default, so the breakage window is narrow (yarn v1, `auto-install-peers=false` setups), the three independent packages are 0.x where minor is the breaking slot, and a major would take the fixed group to 6.0.0 for a change with no API surface. If you'd rather signal it as major, flip the changeset before merging.

## Also

- README install lines now name `unthrown` explicitly where they didn't (`effect`, `boxed`, `neverthrow`, `standard-schema`).
- CLAUDE.md's monorepo layout records the peer rule and why; the `@unthrown/oxlint` entry catches up with 5.6.0 (eight rules, six in `recommended` — it still said seven/five).

Gate green: build, typecheck, lint, knip, tests 18/18.