### PR TITLE
ci: pin the release checkout to the commit CI validated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,5 +18,11 @@ jobs:
       pull-requests: write
       id-token: write
     uses: btravstack/tools/.github/workflows/release-reusable.yml@workflows-v1
+    with:
+      # The exact commit the green CI run measured. Without it a `workflow_run`
+      # checkout takes the default branch's CURRENT tip, which a push landing
+      # after CI went green can have moved — publishing a permanent tarball
+      # from a commit no CI run validated.
+      ref: ${{ github.event.workflow_run.head_sha }}
     secrets:
       RELEASE_PAT: ${{ secrets.RELEASE_PAT }}


### PR DESCRIPTION
Applies btravstack/tools#6's `ref` input, now that `workflows-v1` points at `btravstack/tools@01ed3e01`.

```yaml
with:
  ref: ${{ github.event.workflow_run.head_sha }}
```

The exact commit the green CI run measured. Without it a `workflow_run` checkout takes the default branch's **current tip**, which a push landing after CI went green can have moved — so a permanent npm tarball gets cut from a commit no CI run validated.

The window is small and the newer commit gets its own CI run, but a tarball cannot be unpublished after 72 hours, which is why this is worth closing rather than living with. `btravstack/btravstack`'s `deploy-docs.yml` has guarded the identical hazard all along for a *redeployable* site.

## Nothing else to do here

The same tag move already brought `changesets/action@v2` to this repository for free. That matters even though nothing here is broken today: v1 bundles `@changesets/read@^0.6.7`, which parses **every** `.changeset/*.md` as a changeset, so adding a `.changeset/CLAUDE.md` — an ordinary thing to do — would have failed every release with `could not parse changeset - missing or invalid frontmatter`. It is what happened to `btravstack/btravstack`. `@changesets/read@1.0.0` ignores `README.md`, `AGENTS.md`, `CLAUDE.md` and `GEMINI.md`.

It also moved both workflows off `pnpm/action-setup@v4` and `actions/setup-node@v4`, which were forced onto Node 24 with a deprecation warning on every run.
