### PR TITLE
chore: point CodeRabbit at this repository's own conventions

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+
+reviews:
+  path_filters:
+    - "!**/src/generated/**"
+    - "!**/docs/.vitepress/dist/**"
+    - "!pnpm-lock.yaml"
+  path_instructions:
+    - path: "**/*.ts"
+      instructions: |
+        This repository IS `unthrown`. The idioms other repositories are held to
+        are defined here, so do not cite them as external rules — cite the root
+        `CLAUDE.md`, which is the authoritative spec, and the thesis section at
+        the top of it in particular.
+
+        Two things a reviewer gets wrong here specifically:
+
+        - `unthrown/no-throw` is deliberately NOT enabled in this repository. The
+          library's own boundaries throw and catch on purpose; that is the
+          mechanism the rule exists to spare consumers. Do not flag a `throw` or
+          a `try` in `packages/core/src` as a violation without checking what it
+          implements.
+        - A change to a combinator's behaviour is a change to every consumer in
+          the org. Ask whether the invariants section and the migration notes
+          moved with it.
+
+        Comments are sparse by convention: rationale lives in the spec file,
+        not beside the code. Do not ask for more comments, or for TSDoc on a
+        private symbol.
+
+        `type` not `interface`, `unknown` not `any`, and every relative import
+        carries `.js` — `moduleResolution: NodeNext`.
+
+    - path: "**/{CLAUDE,AGENTS}.md"
+      instructions: |
+        This is the spec, not commentary. Check its claims against the code in
+        the same diff: a sentence that counts call sites or describes a
+        signature is a claim that can go stale silently.


### PR DESCRIPTION
Adds a `.coderabbit.yaml` now that CodeRabbit is installed on the org.

**It points at this repository's spec rather than restating it.** The
conventions are already written down and already reviewed; a second copy in
YAML would be a fifth copy with no gate, which is the drift this org keeps
meeting. So `path_instructions` say *read the spec file, hold the diff to it*,
and spell out only the handful of things a generic reviewer gets actively
wrong — the ones where a suggestion is not debatable but simply not how this
codebase works.

`path_filters` keep generated output and the lockfile out of what it reads.

Nothing else is configured. Every other key stays at its default, deliberately:
`profile: chill`, no `poem`, no `request_changes_workflow`, no `tools` block —
the linters CodeRabbit runs are the ones whose config it finds, and this repo's
gate already runs them in CI.

Two knobs worth knowing about rather than setting blind:

- `reviews.profile: assertive` raises the nitpick volume. Worth trying once
  there is a review or two to judge it against.
- `reviews.request_changes_workflow: true` makes CodeRabbit block a PR until
  its comments are resolved. Off by default, and it should probably stay off
  until the instructions have been tuned.

The GitHub App install itself is a click in the CodeRabbit dashboard — this file
does nothing until the app can see the repository.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository review configuration and guidance.
  * Defined review rules for TypeScript and specification documentation.
  * Added checks for validating documented claims against implementation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->