### PR TITLE
fix: do not list CLAUDE.md/AGENTS.md in path_instructions

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,8 +2,6 @@
 
 reviews:
   path_filters:
-    - "!**/src/generated/**"
-    - "!**/docs/.vitepress/dist/**"
     - "!pnpm-lock.yaml"
   path_instructions:
     - path: "**/*.ts"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -8,6 +8,11 @@ reviews:
   path_instructions:
     - path: "**/*.ts"
       instructions: |
+        When the same diff also changes a `CLAUDE.md`, an `AGENTS.md` or a
+        README, check what it now claims against this code. A sentence that
+        counts call sites, names "the one such site" or describes a signature is
+        a claim that goes stale silently, and one already had.
+
         This repository IS `unthrown`. The idioms other repositories are held to
         are defined here, so do not cite them as external rules — cite the root
         `CLAUDE.md`, which is the authoritative spec, and the thesis section at
@@ -30,9 +35,3 @@ reviews:
 
         `type` not `interface`, `unknown` not `any`, and every relative import
         carries `.js` — `moduleResolution: NodeNext`.
-
-    - path: "**/{CLAUDE,AGENTS}.md"
-      instructions: |
-        This is the spec, not commentary. Check its claims against the code in
-        the same diff: a sentence that counts call sites or describes a
-        signature is a claim that can go stale silently.


### PR DESCRIPTION
Fixes a mistake in the `.coderabbit.yaml` that just merged. CodeRabbit caught it on the sibling PR ([amqp-contract#659](https://github.com/btravstack/amqp-contract/pull/659)), and it was right.

## What was wrong

The config listed `**/{CLAUDE,AGENTS}.md` in `reviews.path_instructions`, to get the spec's claims checked against the code.

CodeRabbit **auto-detects** `**/CLAUDE.md`, `**/AGENTS.md` and `**/AGENT.md` as code guidelines, on by default. Its documentation is explicit about the consequence:

> A common mistake is adding guideline file names (for example `CLAUDE.md`) to `path_instructions`. This tells CodeRabbit to **review** those files as changed code, not to **use** them as guidelines.

So the entry did the opposite of its intent, and it may have been suppressing the auto-detection that was already doing the job the rest of the instructions were written for.

## What changed

The guideline glob is gone. The claim check it existed for moves onto the code's own `**/*.ts` glob, which is where it belongs anyway — *when a diff changes the spec alongside the code, hold the spec to the code* — and the "read the spec file first" preamble is deleted, because auto-detection was already doing that and a redundant instruction is a second copy with no gate.

## Worth a look separately

If auto-detection loads the whole spec, a good part of what remains in `path_instructions` — the unthrown idioms, the comment-density rule — is a **second copy of what those files already say**. That is the exact drift this org keeps meeting, and I would rather raise it than quietly leave it. The case for keeping any of it is that a spec written for an agent editing code is not the same as an instruction to a reviewer; the case against is that it is duplication and duplication rots. Worth deciding once the first few reviews show which half is actually landing.
