### PR TITLE
chore(deps): move the fast-uri floor to 3.1.6 for four more advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,7 +137,7 @@ overrides:
   nanoid@<3.3.18: 3.3.18
   vite@<6.4.3: 6.4.3
   '@hono/node-server@<2.0.10': 2.0.10
-  fast-uri@<3.1.5: 3.1.5
+  fast-uri@<3.1.6: 3.1.6
   find-my-way@<9.7.0: 9.7.0
   valibot@<1.4.2: 1.4.2
   deepmerge-ts@<8.0.0: 8.0.1
@@ -3629,8 +3629,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -6934,7 +6934,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7514,7 +7514,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -107,12 +107,15 @@ overrides:
   # (@prisma/dev). 2.0.10 is the first release patched for all three; the
   # resolved hono 4.x satisfies its `hono: ^4` peer.
   "@hono/node-server@<2.0.10": "2.0.10"
-  # GHSA-v2hh-gcrm-f6hx: fast-uri host confusion via literal backslash authority
-  # delimiter. Only the 3.x line is present (via ajv, under commitlint's config
-  # loading and the `prisma` CLI). 3.1.4 was believed patched; the advisory was
-  # subsequently widened to <3.1.5, so the floor moves with it. Scoped to the
-  # vulnerable range so future patched 3.x releases resolve normally.
-  "fast-uri@<3.1.5": "3.1.5"
+  # GHSA-v2hh-gcrm-f6hx (host confusion via a literal backslash authority
+  # delimiter), then four more in the same parser — GHSA-5jgf-p345-68v8,
+  # GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf and GHSA-jqff-g426-hqxp. Only the
+  # 3.x line is present (via ajv, under commitlint's config loading and the
+  # `prisma` CLI). The floor has moved twice as the advisories widened —
+  # 3.1.4, then 3.1.5 — and 3.1.6 is the first release patched for all five.
+  # Scoped to the vulnerable range so future patched 3.x releases resolve
+  # normally.
+  "fast-uri@<3.1.6": "3.1.6"
   # GHSA-c96f-x56v-gq3h: find-my-way HTTP/2 DDoS (<=9.6.0), pulled in through
   # Prisma 7's @prisma/dev dependency chain. 9.7.0 is the first published
   # patched release.


### PR DESCRIPTION
`ci / Security Audit` is red on `main` again — four advisories published into the same parser since the last bump, none of them caused by anything in the tree:

- **GHSA-5jgf-p345-68v8**, **GHSA-f65p-4m7j-42xc**, **GHSA-fph4-wmhf-6fwf**, **GHSA-jqff-g426-hqxp** — ReDoS and parsing confusion in `fast-uri` below **3.1.6**.

Same path as the advisory this override already existed for: `ajv`, under `@commitlint/cli`'s config loading and the `prisma` CLI's dev server. Build tooling only; no published package here has a runtime dependency on it.

**The existing entry's floor moves rather than a second entry being added.** Two overlapping ranges for one package is how a floor stops applying without anybody noticing — I tried the second-entry version first and pnpm resolved 3.1.5, still vulnerable. The comment now carries all five advisories and the fact that this floor has moved twice as they widened.

`pnpm audit --audit-level=high` → clean (one moderate remains, below the gate's level); typecheck and tests green.

This unblocks #269, whose only red check is this.

https://claude.ai/code/session_01GGixjxi5AQ2cNK62bBymfF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `fast-uri` package override to version 3.1.6 for affected 3.x versions.
  * Expanded the documented security advisories covered by the override.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->