### PR TITLE
feat: add validateAll, validateAllFromDict and their async counterparts

### DIFF
--- a/.changeset/oxlint-validate-all-producers.md
+++ b/.changeset/oxlint-validate-all-producers.md
@@ -1,0 +1,10 @@
+---
+"@unthrown/oxlint": patch
+---
+
+`no-unhandled-result` and `no-async-result-race` now recognise the accumulating
+aggregates. Both rules resolve producers by name, so a dropped
+`validateAll(...)` statement went unreported and the sibling-race
+`no-async-result-race` exists for was invisible on `validateAllAsync`. The four
+free functions and their `Result.*` / `AsyncResult.*` facade members are now in
+the producer sets.

--- a/.changeset/validate-all.md
+++ b/.changeset/validate-all.md
@@ -1,0 +1,61 @@
+---
+"unthrown": minor
+---
+
+`validateAll` / `validateAllFromDict` and their async counterparts
+(`validateAllAsync` / `validateAllFromDictAsync`): the accumulating siblings of
+`all` / `allFromDict`, which report only the first `Err`.
+
+```ts
+const checked = validateAllFromDict(
+  {
+    stock: checkStock(order),
+    credit: checkCreditLimit(customer),
+    address: checkAddress(order),
+  },
+  (entries) => new OrderRejected({ violations: entries }),
+);
+// stock and address failed → Err(OrderRejected) naming both, not just the first
+```
+
+The success channel is `all`'s, unchanged: a fixed tuple keeps its positional
+types, a dynamic array collapses to `Result<T[], E2>`, and a record answers a
+record. Only the error channel differs.
+
+**`merge` is mandatory, and that is the point.** neverthrow's
+`combineWithAllErrors` answers `Result<T[], E[]>`; here you supply
+`(errors) => E2`. An `E[]` is a _shape_, not a domain failure — Thesis #1 says
+`E` holds anticipated failures a caller can match on and act upon, and an array
+pushes "what does it mean that several rules failed?" to every consuming site,
+forever. Naming an `E2` answers it once, where the errors were collected.
+
+`merge` receives a **non-empty** list, so it is total — it never runs on an
+all-`Ok` batch. The record form hands it **`[key, error]` entries correlated per
+key** (`{ a: Result<A, E1>; b: Result<B, E2> }` yields `["a", E1] | ["b", E2]`),
+so a `switch` on the key narrows the error and an impossible pairing does not
+typecheck — which is what keeps two checks sharing one error type
+distinguishable.
+
+Every existing aggregate rule still holds. A `Defect` **dominates** and
+discards the accumulated errors — a batch carrying an unmodeled failure produced
+violations computed alongside broken code, so `merge` is never called; an
+out-of-contract non-`Result` element is still a `TypeError`-caused `Defect`; a
+throw inside `merge` becomes a `Defect`; the async pair resolves concurrently
+(order preserved) and its internal promise never rejects. `merge` must be
+**synchronous** (`NotThenable`) — an `async` one would land an unqualified
+`Promise` in `E`, the boundary rule from Thesis #3.
+
+This narrows, rather than reverses, the "no error accumulation" decision. For
+**schema-shaped** input — a request body, a form — `@unthrown/standard-schema`'s
+`fromSchema` is still the tool: a validator already hands you every issue as the
+modeled error, and `validateAll` there duplicates a job it does better. What the
+old argument never reached is independent checks you wrote yourself — business
+rules that hit the database and encode policy rather than shape. No validator
+expresses `checkCreditLimit(customer)`, and reporting one violation of five is a
+worse product. That is the case these four exist for.
+
+Both facades gained the entry points (`Result.validateAll` /
+`Result.validateAllFromDict`, `AsyncResult.validateAll` /
+`AsyncResult.validateAllFromDict`, dropping the `Async` suffix as the namespace
+already says async), and `examples/checkout-domain` exercises the record form on
+three independent order checks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,8 +149,8 @@ was planned).
   with **no surrounding `try/catch`**.
 - **An out-of-contract non-`Result` surfaces as a `Defect`, never a raw
   throw/rejection.** Reachable only from untyped/cast callers: the aggregates
-  (`all` / `allFromDict` and their async pair) turn a non-`Result` element into
-  a `TypeError`-caused `Defect`, and every combinator whose callback is
+  (`all` / `allFromDict` / `validateAll` / `validateAllFromDict` and their async
+  counterparts) turn a non-`Result` element into a `TypeError`-caused `Defect`, and every combinator whose callback is
   constrained to return a `Result` (`flatMap`, `flatTap`, `bind`, `flatMapErrCases`,
   `flatTapErrCases`, `recoverDefect` — both surfaces; the async ones check the
   **awaited** value, so a legitimately returned `AsyncResult` still passes)
@@ -517,19 +517,45 @@ fromExecutor<T, E>>[0]`) is the grotesque spelling that invites a hand-copied
   `Result<{ a: A }, E>`) — named parallel work without tupling. Array and record
   are **separate functions**, not one overload (positional vs named is a distinct
   concept). All four short-circuit on the first `Err`, let any `Defect` dominate,
-  and are **not** error accumulation (which stays deliberately excluded);
-  `allAsync` / `allFromDictAsync` resolve concurrently (order preserved) and never
-  reject. The record fold writes keys via `Object.defineProperty`, so a
-  caller-supplied `"__proto__"` key can't pollute the prototype.
+  and `allAsync` / `allFromDictAsync` resolve concurrently (order preserved) and
+  never reject. The record fold builds its object with `Object.fromEntries`, so a
+  caller-supplied `"__proto__"` key can't pollute the prototype (`fromEntries`
+  defines own properties rather than assigning — the guarantee is the built-in's,
+  not a hand-written `defineProperty` loop's).
+- **accumulating** aggregate: `validateAll` / `validateAllFromDict` and their
+  async pair `validateAllAsync` / `validateAllFromDictAsync` — same four shapes,
+  same success channel (positional tuple, collapsing array, record), but **every**
+  `Err` is collected in input order and folded by a **mandatory
+  `merge: (errors) => E2`** whose return becomes the modeled error. `merge` is
+  what keeps this on-thesis: an `E[]` in the error channel is a _shape_, not an
+  anticipated domain failure (Thesis #1), and it would push "what does it mean
+  that several rules failed?" to every consuming site forever — so unthrown has
+  no `Validation` applicative and no `combineWithAllErrors`. `merge` receives a
+  **non-empty** list, so it is total (never called on an all-`Ok` batch); the
+  record form hands it **`[key, error]` entries correlated per key**
+  (`{ a: Result<A, E1>; b: Result<B, E2> }` → `["a", E1] | ["b", E2]`, so a
+  `switch` on the key narrows the error and an impossible pairing does not
+  typecheck), in `Object.keys` order. A `Defect` still **dominates** and discards
+  the accumulated errors — `merge` is not called, because violations computed
+  alongside an unmodeled failure aren't trustworthy — a throw in `merge` becomes
+  a `Defect`, and `merge` must be **synchronous** (`NotThenable`): an `async` one
+  would land an unqualified `Promise` in `E`. All four share the fail-fast forms'
+  folds (`foldArray` / `foldRecord`, which take the `merge` as an optional
+  parameter), so the `Defect` domination, non-`Result` hardening and prototype
+  guarantee come from one place. Scope: **not** the tool for schema-shaped input
+  (a request body, a form) — `@unthrown/standard-schema`'s `fromSchema` already
+  hands you every issue as the modeled error; these are for independent checks
+  you wrote yourself, business rules a validator can't express.
 - facade: two companion objects alias the standalone entry points, **grouped by
   what they return** so a static lives in exactly one namespace. `Result.*` holds
   the `Result`-producing ones
-  (`Result.Ok`/`Err`/`Do`/`fromNullable`/`fromThrowable`/`fromSafeThrowable`/`all`/`allFromDict`/`is*`);
+  (`Result.Ok`/`Err`/`Do`/`fromNullable`/`fromThrowable`/`fromSafeThrowable`/`all`/`allFromDict`/`validateAll`/`validateAllFromDict`/`is*`);
   `AsyncResult.*` holds the `AsyncResult`-producing ones
-  (`AsyncResult.Ok`/`Err`/`Do`/`fromPromise`/`fromSafePromise`/`all`/`allFromDict` —
+  (`AsyncResult.Ok`/`Err`/`Do`/`fromPromise`/`fromSafePromise`/`all`/`allFromDict`/`validateAll`/`validateAllFromDict` —
   the pre-lifted entry points and aggregates drop the `Async` suffix the free
   functions carry (`OkAsync`→`AsyncResult.Ok`, `DoAsync`→`AsyncResult.Do`,
-  `allAsync`→`AsyncResult.all`), since the
+  `allAsync`→`AsyncResult.all`, `validateAllAsync`→`AsyncResult.validateAll`),
+  since the
   namespace already says async). Both are value+type companions (the value and
   the `Result<T,E>` / `AsyncResult<T,E>` type share one name). The free functions
   remain the primary, tree-shakeable API; the companions are opt-in sugar (only
@@ -575,7 +601,9 @@ fromExecutor<T, E>>[0]`) is the grotesque spelling that invites a hand-copied
 
 Deliberately **excluded** for now: **generator** do-notation (`gen`/`yield*`
 "safeTry" style — the fluent `Do`/`bind`/`let`/`DoAsync` above covers sequential
-code without the generator machinery), accumulation/`Validation`,
+code without the generator machinery), a `Validation` applicative / an `E[]`
+error channel (accumulation itself now exists as `validateAll` above, but only
+folded into a domain error by a mandatory `merge`),
 **serialization** (a `Result` does not survive `structuredClone`/JSON by design
 — fold with `match` at the boundary and re-enter through a constructor/boundary
 on the other side), and aliases
@@ -992,7 +1020,10 @@ onRejected)`, so the fixture records the handler _and invokes it_, proving both
   enforced by thresholds in its `vitest.config.ts`.
 - **Type-level tests:** `packages/core/src/types.test-d.ts` asserts the
   type-level behaviour the runtime can't (the conditional `all`/`allFromDict`
-  shapes, `Exclude<R, Defect>` boundary inference, `flatTap`/`recoverErrCases` channel
+  shapes — and `validateAll`/`validateAllFromDict`'s, where `merge` carries a
+  conditional type on both sides (`ErrOf<Rs[number]>` in, `NotThenable<E2>` out)
+  and a deflected inference would silently degrade its parameter to `unknown[]`
+  with no compile error — `Exclude<R, Defect>` boundary inference, `flatTap`/`recoverErrCases` channel
   widening, the `this is …` guard narrowing, `match`'s `errCases`-matcher
   exhaustiveness (a missing tag does not compile; the folded type unions the
   branch returns), and the

--- a/docs/examples/checkout-domain.md
+++ b/docs/examples/checkout-domain.md
@@ -98,6 +98,70 @@ A test pins it:
 await expect(result).toBeDefectWith(boom);
 ```
 
+## When you want _every_ failure: `reviewCart`
+
+`reserveAll` stops at the first bad line, and for placing an order that is right —
+the transaction is over, so checking the rest is wasted work.
+
+Rendering a **cart-review screen** is the opposite. Telling a shopper about one
+unavailable line, then a second one after they fix it, is a worse product. So
+`review.ts` reaches for the accumulating aggregate:
+
+```ts
+validateAll(
+  cart.lines.map((line) => deps.reserve(line).map(() => line)),
+  (violations) => new CartRejected({ violations }),
+);
+// Result<readonly CartLine[], CartRejected>
+```
+
+The `merge` argument is **mandatory**, and that is the design talking.
+neverthrow's `combineWithAllErrors` would hand the caller an `OutOfStock[]`; an
+array is a _shape_, not a domain failure, so every consuming site would have to
+work out what it means. `CartRejected` decides once, here, and keeps a structured
+payload the edge can render however it likes.
+
+Two rules are worth seeing in the tests. `merge` receives a **non-empty** list, so
+it is total — there is no "shouldn't happen" branch, and it is simply not called
+when every line reserves. And a `Defect` still **dominates**: the test that makes
+one line blow up gets a defect back, with the `OutOfStock` it beat discarded,
+because a violation computed alongside broken code is not a violation you can
+trust.
+
+That test also shows something easy to get wrong. `deps.reserve` runs while the
+array is being **built**, before `validateAll` sees anything — so a raw `throw`
+there escapes the aggregate entirely. The defect has to arrive the way defects
+always do, through a boundary (`fromSafeThrowable`). The throw → defect net covers
+callbacks _inside_ combinators, not the code that produced their arguments.
+
+## Named checks keep their key: `checkPolicies`
+
+`validateAllFromDict` hands `merge` a list of `[key, error]` **entries**,
+correlated per key:
+
+```ts
+(entries) =>
+  new CheckoutBlocked({
+    reasons: entries.map((entry) => {
+      switch (entry[0]) {
+        case "minimum":
+          return `total ${entry[1].total} < ${entry[1].minimum}`;
+        case "region":
+          return `no shipping to ${entry[1].region}`;
+      }
+    }),
+  });
+```
+
+The union is `["minimum", BelowMinimum] | ["region", UnservedRegion]`, **not**
+the cross product — so switching on the key narrows the error with no casts and
+no re-checking, `["region", BelowMinimum]` would not compile, and the `switch`
+needs no `default` to be exhaustive.
+
+That correlation is what makes the record form worth having. It still tells you
+which check failed even when two of them share one error type, which a flat list
+of errors could not.
+
 ## Where to go next
 
 - Store and read it back: [Checkout persistence](./checkout-persistence).

--- a/docs/examples/checkout-domain.md
+++ b/docs/examples/checkout-domain.md
@@ -142,12 +142,12 @@ correlated per key:
 ```ts
 (entries) =>
   new CheckoutBlocked({
-    reasons: entries.map((entry) => {
-      switch (entry[0]) {
+    reasons: entries.map(([check, violation]) => {
+      switch (check) {
         case "minimum":
-          return `total ${entry[1].total} < ${entry[1].minimum}`;
+          return `total ${violation.total} < ${violation.minimum}`;
         case "region":
-          return `no shipping to ${entry[1].region}`;
+          return `no shipping to ${violation.region}`;
       }
     }),
   });
@@ -156,7 +156,9 @@ correlated per key:
 The union is `["minimum", BelowMinimum] | ["region", UnservedRegion]`, **not**
 the cross product — so switching on the key narrows the error with no casts and
 no re-checking, `["region", BelowMinimum]` would not compile, and the `switch`
-needs no `default` to be exhaustive.
+needs no `default` to be exhaustive. The correlation survives destructuring the
+entry, so the branches name their halves instead of reading `entry[0]` /
+`entry[1]`.
 
 That correlation is what makes the record form worth having. It still tells you
 which check failed even when two of them share one error type, which a flat list

--- a/docs/explanation/comparison.md
+++ b/docs/explanation/comparison.md
@@ -21,7 +21,7 @@ callback throws**.
 | Boundary forces error typing       | ✅ mandatory `qualify`            | partial²               | partial²   | ✅                    | ✅ `catch` (or `safe`)              |
 | `Option` type                      | ❌ (deliberate)                   | ❌                     | ✅         | ✅                    | ❌                                  |
 | Tagged errors                      | ✅ `TaggedError`                  | ❌                     | ❌         | ✅ `Data.TaggedError` | ❌                                  |
-| Error accumulation                 | ❌ (deliberate)                   | `combineWithAllErrors` | ❌         | ✅                    | ✅ `collect`                        |
+| Error accumulation                 | ✅ `validateAll` (merged to `E2`) | `combineWithAllErrors` | ❌         | ✅                    | ✅ `collect`                        |
 | Runtime dependencies (core)        | **0** (matcher built-in)          | 0                      | 0          | a runtime             | 0                                   |
 
 ¹ byethrow's combinators don't `try/catch`; it relies on an oxlint rule
@@ -77,8 +77,8 @@ This isn't a clean sweep — pick the tool for the job:
 
 - **byethrow** — if you want a lightweight, pipe-idiomatic Result with **one**
   failure axis and don't need the defect distinction, it's an excellent, smaller,
-  more mature choice. It also ships error-accumulating `collect`, which unthrown
-  deliberately omits.
+  more mature choice. Its error-accumulating `collect` returns the errors as an
+  array; unthrown's `validateAll` makes you merge them into a named domain error instead.
 - **neverthrow** — the established, widely-adopted class-based option; reach for
   it if ecosystem maturity outweighs the defect channel.
 - **boxed** — if you specifically want an `Option` type and a broader functional

--- a/docs/explanation/design-decisions.md
+++ b/docs/explanation/design-decisions.md
@@ -45,18 +45,38 @@ cost of a second composition style, generator-transpilation overhead, and a
 long enough that `Do` feels heavy, that is usually a sign the steps deserve named
 functions composed with `flatMap`.
 
-## No error accumulation (`Validation`)
+## Accumulation, but only into a domain error
 
-`all` / `allFromDict` (and their async pair) **short-circuit on the first
-`Err`** — they are not error accumulation. There is no `combineWithAllErrors`, no
-`Validation` applicative.
+`all` / `allFromDict` (and their async pair) **report the first `Err`**.
+`validateAll` / `validateAllFromDict` (and theirs) **accumulate every one**. What
+unthrown does not have is a `Validation` applicative, or anything that puts an
+`E[]` in the error channel.
 
-Accumulating every failure is a genuinely different operation with a different
-type (`Result<T, E[]>`-shaped), most useful for form validation — and for that
-case the [Standard Schema bridge](../how-to/validate-with-standard-schema) already
-hands you the validator's full issues array as the modeled error. Building a
-second accumulation primitive into the core would widen the surface for a job a
-validator does better.
+For **form validation** the original argument still holds, and it is why
+`validateAll` is not the tool there: accumulating field errors is most useful on
+schema-shaped input, and the
+[Standard Schema bridge](../how-to/validate-with-standard-schema) already hands
+you the validator's full issues array as the modeled error. Reaching for
+`validateAll` on a request body is duplicating a job a validator does better.
+
+What the argument does **not** reach is independent checks you wrote yourself —
+business rules that hit the database and encode policy rather than shape. No
+validator can express `checkCreditLimit(customer)`, and reporting only the first
+violation of five is a genuinely worse product. That is the case `validateAll`
+exists for.
+
+The part worth defending is the mandatory `merge`. neverthrow's
+`combineWithAllErrors` returns `Result<T[], E[]>`; unthrown makes you supply
+`(errors) => E2`. An `E[]` is a _shape_, not a domain failure — and
+[Thesis #1](./why-unthrown) says `E` holds anticipated domain failures, each one
+something a caller can match on and act upon. `E[]` pushes that decision to every
+consuming site, forever. Naming an `E2` makes it once, where the errors are
+collected and where you actually know what "several rules failed" means.
+
+Two smaller consequences fall out of the same reasoning: a `Defect` still
+dominates and discards the accumulated errors (a batch with an unmodeled failure
+in it produced violations you can't trust), and `merge` must be synchronous (an
+`async` merge would land an unqualified `Promise` in `E`).
 
 ## No `Defect` constructor
 

--- a/docs/how-to/combine-parallel-results.md
+++ b/docs/how-to/combine-parallel-results.md
@@ -29,8 +29,7 @@ import { allFromDict, Ok } from "unthrown";
 allFromDict({ id: Ok(1), name: Ok("ada") }).get(); // => { id: 1, name: "ada" }
 ```
 
-Both short-circuit on the first `Err` — this is **not** error accumulation (see
-[Design decisions](../explanation/design-decisions#no-error-accumulation-validation)).
+Both report the **first** `Err` and stop looking. To report every one instead, see [Accumulate every error](#accumulate-every-error-with-validateall) below.
 
 ## Combine async results concurrently
 
@@ -51,6 +50,62 @@ page.map(([profile, posts, followers]) =>
 ```
 
 Use `allFromDictAsync` to key the concurrent results by name instead of position.
+
+## Accumulate every error with `validateAll`
+
+`all` tells you the first thing that went wrong. When you are running
+**independent checks** — business rules that don't depend on one another — you usually want all of them:
+
+```ts
+import { validateAll } from "unthrown";
+
+// each check returns Result<_, OutOfStock | OverLimit | UnservedZone>
+validateAll(
+  [checkStock(order), checkCreditLimit(customer), checkShippingZone(address)],
+  (violations) => new OrderRejected({ violations }),
+);
+// Result<[StockHold, CreditLine, Zone], OrderRejected>
+```
+
+`merge` is **mandatory**, and that is the design. neverthrow's `combineWithAllErrors` hands you an `E[]`; unthrown makes you name an `E2`, because an array of errors is a _shape_, not a domain failure — and `E` holds anticipated domain failures ([why](../explanation/why-unthrown)). You decide what "three rules were violated" means in your domain, once, at the point you collect them.
+
+Four things worth knowing:
+
+- **`merge` is total.** It receives a **non-empty** list, and it is called only
+  when at least one `Err` was collected — never on an all-`Ok` input. No
+  "shouldn't happen" branch.
+- **A `Defect` still dominates**, and the accumulated errors are discarded
+  without reaching `merge`. A defect means something in the batch failed in a way
+  nobody modeled, so the violations computed alongside it aren't trustworthy.
+- **A throw inside `merge` becomes a `Defect`**, like every other callback in the
+  library.
+- **`merge` must be synchronous.** An `async` one is a compile error — its
+  `Promise` would land unqualified in `E`.
+
+The record form names each failure, and the entries are **correlated per key**,
+so a `switch` on the key narrows the error:
+
+```ts
+import { validateAllFromDict } from "unthrown";
+
+validateAllFromDict(
+  {
+    vatRate: checkRate(inv),
+    currency: checkCurrency(inv),
+    dueDate: checkDueDate(inv),
+  },
+  (entries) => new InvoiceRejected({ fields: entries.map(([field]) => field) }),
+);
+```
+
+That correlation is what keeps two checks that share an error type distinguishable — with a flat list of `RuleViolated`s you could not tell which field produced which.
+
+`validateAllAsync` and `validateAllFromDictAsync` are the concurrent
+counterparts. Note that the accumulating and fail-fast forms do the **same work**: every input has already run by the time the aggregate sees it, so the choice is purely about which errors get reported.
+
+::: tip Schema-shaped input?
+If you're validating a request body or a form, reach for [`fromSchema`](./validate-with-standard-schema) instead — a validator already hands you every issue as the modeled error. `validateAll` is for independent checks you wrote yourself.
+:::
 
 ## Where to go next
 

--- a/docs/how-to/combine-parallel-results.md
+++ b/docs/how-to/combine-parallel-results.md
@@ -29,7 +29,8 @@ import { allFromDict, Ok } from "unthrown";
 allFromDict({ id: Ok(1), name: Ok("ada") }).get(); // => { id: 1, name: "ada" }
 ```
 
-Both report the **first** `Err` and stop looking. To report every one instead, see [Accumulate every error](#accumulate-every-error-with-validateall) below.
+Both report the **first** `Err`, unless a later input carries a `Defect` — the walk
+keeps looking so a `Defect` still takes precedence. To report every error instead, see [Accumulate every error](#accumulate-every-error-with-validateall) below.
 
 ## Combine async results concurrently
 

--- a/docs/how-to/migrate-from-neverthrow.md
+++ b/docs/how-to/migrate-from-neverthrow.md
@@ -20,7 +20,7 @@
 | `ResultAsync.fromPromise(p, mapErr)` | `fromPromise(p, qualify)`                         | `qualify` must return `E` **or** `defect(cause)` — triage is forced                    |
 | `ResultAsync.fromSafePromise(p)`     | `fromSafePromise(p)`                              | a rejection becomes a `Defect`, not an `Err`                                           |
 | `Result.combine([...])`              | `all([...])`                                      | any `Defect` dominates                                                                 |
-| `Result.combineWithAllErrors`        | —                                                 | error accumulation is deliberately excluded                                            |
+| `Result.combineWithAllErrors`        | `validateAll([...], merge)`                       | `merge` is mandatory: the errors fold into a named `E2`, never an `E[]`                |
 | `safeTry(function* …)`               | `Do().bind(…).let(…)`                             | see [do-notation](./sequence-dependent-steps)                                          |
 | `fromThrowable(fn, mapErr)`          | `fromThrowable(fn, qualify)`                      | same idea, plus the defect arm                                                         |
 

--- a/docs/reference/combinators.md
+++ b/docs/reference/combinators.md
@@ -23,27 +23,29 @@ moves the channels: `flatMap` widens `E` to `E | E2`, `recoverErrCases` empties 
 [exhaustive matcher](#the-error-channel) rather than a single callback;
 the signatures below abbreviate its callback as `(matcher) => …`.
 
-| I want to…                                     | use               | signature                                                    | channel      |
-| ---------------------------------------------- | ----------------- | ------------------------------------------------------------ | ------------ |
-| transform the success value                    | `map`             | `(v: T) => U` → `Result<U, E>`                               | Ok           |
-| chain a `Result`-returning step                | `flatMap`         | `(v: T) => Result<U, E2>` → `Result<U, E \| E2>`             | Ok           |
-| run a side effect, keep the value              | `tap`             | `(v: T) => void` → `Result<T, E>`                            | Ok           |
-| run a **failable** side effect, keep the value | `flatTap`         | `(v: T) => Result<unknown, E2>` → `Result<T, E \| E2>`       | Ok           |
-| validate a success / refine its type           | `ensure`          | `((v: T) => boolean, (v: T) => E2)` → `Result<T, E \| E2>`   | Ok           |
-| sequence steps into a named scope              | `Do`/`bind`/`let` | `bind(k, (scope) => Result<U, E2>)` → `Result<{…}, E \| E2>` | Ok           |
-| replace the value with a constant              | `as`              | `(value: U)` → `Result<U, E>`                                | Ok           |
-| drop the value (success type becomes `void`)   | `discard`         | `()` → `Result<void, E>`                                     | Ok           |
-| transform the error (matched)                  | `mapErrCases`     | `(matcher) => …` → `Result<T, E2>`                           | Err          |
-| try a fallback that returns a `Result`         | `flatMapErrCases` | `(matcher) => …` → `Result<T \| U, E2>`                      | Err          |
-| turn an error into a success value             | `recoverErrCases` | `(matcher) => …` → `Result<T \| U, never>`                   | Err          |
-| run a side effect on the error                 | `tapErrCases`     | `(matcher) => …` → `Result<T, E>`                            | Err          |
-| run a **failable** side effect on the error    | `flatTapErrCases` | `(matcher) => …` → `Result<T, E \| E2>`                      | Err          |
-| recover from a defect (rare)                   | `recoverDefect`   | `(cause) => Result<U, E2>` → `Result<T \| U, E \| E2>`       | Defect       |
-| observe a defect, e.g. log it                  | `tapDefect`       | `(cause) => void` → `Result<T, E>`                           | Defect       |
-| observe **any** failure (error _or_ defect)    | `tapFailure`      | `(f: FailureView<E>) => void` → `Result<T, E>`               | Err + Defect |
-| handle all three channels at the edge          | `match`           | `{ ok, errCases, defect }` → `R`                             | all          |
-| combine an array of `Result`s                  | `all`             | `Result<T, E>[]` → `Result<T[], E>`                          | —            |
-| combine a record of `Result`s                  | `allFromDict`     | `{ [k]: Result<T, E> }` → `Result<{ [k]: T }, E>`            | —            |
+| I want to…                                     | use                   | signature                                                    | channel      |
+| ---------------------------------------------- | --------------------- | ------------------------------------------------------------ | ------------ |
+| transform the success value                    | `map`                 | `(v: T) => U` → `Result<U, E>`                               | Ok           |
+| chain a `Result`-returning step                | `flatMap`             | `(v: T) => Result<U, E2>` → `Result<U, E \| E2>`             | Ok           |
+| run a side effect, keep the value              | `tap`                 | `(v: T) => void` → `Result<T, E>`                            | Ok           |
+| run a **failable** side effect, keep the value | `flatTap`             | `(v: T) => Result<unknown, E2>` → `Result<T, E \| E2>`       | Ok           |
+| validate a success / refine its type           | `ensure`              | `((v: T) => boolean, (v: T) => E2)` → `Result<T, E \| E2>`   | Ok           |
+| sequence steps into a named scope              | `Do`/`bind`/`let`     | `bind(k, (scope) => Result<U, E2>)` → `Result<{…}, E \| E2>` | Ok           |
+| replace the value with a constant              | `as`                  | `(value: U)` → `Result<U, E>`                                | Ok           |
+| drop the value (success type becomes `void`)   | `discard`             | `()` → `Result<void, E>`                                     | Ok           |
+| transform the error (matched)                  | `mapErrCases`         | `(matcher) => …` → `Result<T, E2>`                           | Err          |
+| try a fallback that returns a `Result`         | `flatMapErrCases`     | `(matcher) => …` → `Result<T \| U, E2>`                      | Err          |
+| turn an error into a success value             | `recoverErrCases`     | `(matcher) => …` → `Result<T \| U, never>`                   | Err          |
+| run a side effect on the error                 | `tapErrCases`         | `(matcher) => …` → `Result<T, E>`                            | Err          |
+| run a **failable** side effect on the error    | `flatTapErrCases`     | `(matcher) => …` → `Result<T, E \| E2>`                      | Err          |
+| recover from a defect (rare)                   | `recoverDefect`       | `(cause) => Result<U, E2>` → `Result<T \| U, E \| E2>`       | Defect       |
+| observe a defect, e.g. log it                  | `tapDefect`           | `(cause) => void` → `Result<T, E>`                           | Defect       |
+| observe **any** failure (error _or_ defect)    | `tapFailure`          | `(f: FailureView<E>) => void` → `Result<T, E>`               | Err + Defect |
+| handle all three channels at the edge          | `match`               | `{ ok, errCases, defect }` → `R`                             | all          |
+| combine an array of `Result`s                  | `all`                 | `Result<T, E>[]` → `Result<T[], E>`                          | —            |
+| combine a record of `Result`s                  | `allFromDict`         | `{ [k]: Result<T, E> }` → `Result<{ [k]: T }, E>`            | —            |
+| combine an array, **reporting every error**    | `validateAll`         | `+ (errors) => E2` → `Result<T[], E2>`                       | —            |
+| combine a record, **reporting every error**    | `validateAllFromDict` | `+ (entries) => E2` → `Result<{ [k]: T }, E2>`               | —            |
 
 ## Behavior at a glance
 
@@ -232,6 +234,7 @@ Use this table to move between the two:
 | add an **async** step mid-chain           | `.flatMap((v) => fromPromise(work(v), qualify))`      |
 | add a **sync** step to an async chain     | `.flatMap((v) => Ok(v + 1))` — a `Result` is accepted |
 | combine async results                     | `allAsync` / `allFromDictAsync`                       |
+| combine async, reporting every error      | `validateAllAsync` / `validateAllFromDictAsync`       |
 
 ```ts
 // A chain that crosses an async boundary stays an AsyncResult to the end.

--- a/docs/reference/combinators.md
+++ b/docs/reference/combinators.md
@@ -23,29 +23,29 @@ moves the channels: `flatMap` widens `E` to `E | E2`, `recoverErrCases` empties 
 [exhaustive matcher](#the-error-channel) rather than a single callback;
 the signatures below abbreviate its callback as `(matcher) => …`.
 
-| I want to…                                     | use                   | signature                                                    | channel      |
-| ---------------------------------------------- | --------------------- | ------------------------------------------------------------ | ------------ |
-| transform the success value                    | `map`                 | `(v: T) => U` → `Result<U, E>`                               | Ok           |
-| chain a `Result`-returning step                | `flatMap`             | `(v: T) => Result<U, E2>` → `Result<U, E \| E2>`             | Ok           |
-| run a side effect, keep the value              | `tap`                 | `(v: T) => void` → `Result<T, E>`                            | Ok           |
-| run a **failable** side effect, keep the value | `flatTap`             | `(v: T) => Result<unknown, E2>` → `Result<T, E \| E2>`       | Ok           |
-| validate a success / refine its type           | `ensure`              | `((v: T) => boolean, (v: T) => E2)` → `Result<T, E \| E2>`   | Ok           |
-| sequence steps into a named scope              | `Do`/`bind`/`let`     | `bind(k, (scope) => Result<U, E2>)` → `Result<{…}, E \| E2>` | Ok           |
-| replace the value with a constant              | `as`                  | `(value: U)` → `Result<U, E>`                                | Ok           |
-| drop the value (success type becomes `void`)   | `discard`             | `()` → `Result<void, E>`                                     | Ok           |
-| transform the error (matched)                  | `mapErrCases`         | `(matcher) => …` → `Result<T, E2>`                           | Err          |
-| try a fallback that returns a `Result`         | `flatMapErrCases`     | `(matcher) => …` → `Result<T \| U, E2>`                      | Err          |
-| turn an error into a success value             | `recoverErrCases`     | `(matcher) => …` → `Result<T \| U, never>`                   | Err          |
-| run a side effect on the error                 | `tapErrCases`         | `(matcher) => …` → `Result<T, E>`                            | Err          |
-| run a **failable** side effect on the error    | `flatTapErrCases`     | `(matcher) => …` → `Result<T, E \| E2>`                      | Err          |
-| recover from a defect (rare)                   | `recoverDefect`       | `(cause) => Result<U, E2>` → `Result<T \| U, E \| E2>`       | Defect       |
-| observe a defect, e.g. log it                  | `tapDefect`           | `(cause) => void` → `Result<T, E>`                           | Defect       |
-| observe **any** failure (error _or_ defect)    | `tapFailure`          | `(f: FailureView<E>) => void` → `Result<T, E>`               | Err + Defect |
-| handle all three channels at the edge          | `match`               | `{ ok, errCases, defect }` → `R`                             | all          |
-| combine an array of `Result`s                  | `all`                 | `Result<T, E>[]` → `Result<T[], E>`                          | —            |
-| combine a record of `Result`s                  | `allFromDict`         | `{ [k]: Result<T, E> }` → `Result<{ [k]: T }, E>`            | —            |
-| combine an array, **reporting every error**    | `validateAll`         | `+ (errors) => E2` → `Result<T[], E2>`                       | —            |
-| combine a record, **reporting every error**    | `validateAllFromDict` | `+ (entries) => E2` → `Result<{ [k]: T }, E2>`               | —            |
+| I want to…                                     | use                   | signature                                                             | channel      |
+| ---------------------------------------------- | --------------------- | --------------------------------------------------------------------- | ------------ |
+| transform the success value                    | `map`                 | `(v: T) => U` → `Result<U, E>`                                        | Ok           |
+| chain a `Result`-returning step                | `flatMap`             | `(v: T) => Result<U, E2>` → `Result<U, E \| E2>`                      | Ok           |
+| run a side effect, keep the value              | `tap`                 | `(v: T) => void` → `Result<T, E>`                                     | Ok           |
+| run a **failable** side effect, keep the value | `flatTap`             | `(v: T) => Result<unknown, E2>` → `Result<T, E \| E2>`                | Ok           |
+| validate a success / refine its type           | `ensure`              | `((v: T) => boolean, (v: T) => E2)` → `Result<T, E \| E2>`            | Ok           |
+| sequence steps into a named scope              | `Do`/`bind`/`let`     | `bind(k, (scope) => Result<U, E2>)` → `Result<{…}, E \| E2>`          | Ok           |
+| replace the value with a constant              | `as`                  | `(value: U)` → `Result<U, E>`                                         | Ok           |
+| drop the value (success type becomes `void`)   | `discard`             | `()` → `Result<void, E>`                                              | Ok           |
+| transform the error (matched)                  | `mapErrCases`         | `(matcher) => …` → `Result<T, E2>`                                    | Err          |
+| try a fallback that returns a `Result`         | `flatMapErrCases`     | `(matcher) => …` → `Result<T \| U, E2>`                               | Err          |
+| turn an error into a success value             | `recoverErrCases`     | `(matcher) => …` → `Result<T \| U, never>`                            | Err          |
+| run a side effect on the error                 | `tapErrCases`         | `(matcher) => …` → `Result<T, E>`                                     | Err          |
+| run a **failable** side effect on the error    | `flatTapErrCases`     | `(matcher) => …` → `Result<T, E \| E2>`                               | Err          |
+| recover from a defect (rare)                   | `recoverDefect`       | `(cause) => Result<U, E2>` → `Result<T \| U, E \| E2>`                | Defect       |
+| observe a defect, e.g. log it                  | `tapDefect`           | `(cause) => void` → `Result<T, E>`                                    | Defect       |
+| observe **any** failure (error _or_ defect)    | `tapFailure`          | `(f: FailureView<E>) => void` → `Result<T, E>`                        | Err + Defect |
+| handle all three channels at the edge          | `match`               | `{ ok, errCases, defect }` → `R`                                      | all          |
+| combine an array of `Result`s                  | `all`                 | `Result<T, E>[]` → `Result<T[], E>`                                   | —            |
+| combine a record of `Result`s                  | `allFromDict`         | `{ [k]: Result<T, E> }` → `Result<{ [k]: T }, E>`                     | —            |
+| combine an array, **reporting every error**    | `validateAll`         | `(Result<T, E>[], (errors) => E2)` → `Result<T[], E2>`                | —            |
+| combine a record, **reporting every error**    | `validateAllFromDict` | `({ [k]: Result<T, E> }, (entries) => E2)` → `Result<{ [k]: T }, E2>` | —            |
 
 ## Behavior at a glance
 

--- a/docs/reference/result-surface.md
+++ b/docs/reference/result-surface.md
@@ -136,9 +136,10 @@ functions carry (`AsyncResult.all` **is** `allAsync`; `AsyncResult.Ok` **is**
 ## Aggregating: `all` / `allFromDict`
 
 `all` collects a **tuple/array** of `Result`s into a `Result` of all their
-values; `allFromDict` takes a **record** for named results. Both short-circuit on
-the first `Err`, and any `Defect` dominates (even over an earlier `Err`). Neither
-is error accumulation.
+values; `allFromDict` takes a **record** for named results. Both report the
+**first** `Err`, and any `Defect` dominates (even over an earlier `Err`). To
+report every error instead, see
+[`validateAll`](#accumulating-validateall-validateallfromdict) below.
 
 ```ts
 import { all, allFromDict, Ok, type Result } from "unthrown";
@@ -159,6 +160,38 @@ const [a, b] = (
   await allAsync([fromSafePromise(loadA()), fromSafePromise(loadB())])
 ).get();
 ```
+
+## Accumulating: `validateAll` / `validateAllFromDict`
+
+The accumulating counterparts. Same success channel as `all` (positional tuples,
+collapsing arrays); the difference is the error channel — every `Err` is collected
+and folded by a mandatory `merge` into one named domain error, rather than the
+first one winning.
+
+```ts
+import { validateAll, validateAllFromDict, Ok, Err } from "unthrown";
+
+validateAll([Ok(1), Err("stock"), Err("credit")], (errors) =>
+  errors.join(" and "),
+);
+// => Err("stock and credit")
+
+validateAllFromDict(
+  { vatRate: Err("range"), currency: Ok("EUR"), dueDate: Err("past") },
+  (entries) => entries.map(([key]) => key),
+);
+// => Err(["vatRate", "dueDate"])
+```
+
+| Rule                 | Behaviour                                                                  |
+| -------------------- | -------------------------------------------------------------------------- |
+| `merge` totality     | receives a **non-empty** list; never called on an all-`Ok` input           |
+| `Defect`             | still **dominates** — accumulated errors are discarded, `merge` not called |
+| throw inside `merge` | becomes a `Defect`                                                         |
+| `async merge`        | a compile error (`NotThenable`) — a `Promise` in `E` is unqualified        |
+| record entries       | `[key, error]`, **correlated per key**, in `Object.keys` order             |
+
+`validateAllAsync` / `validateAllFromDictAsync` are the concurrent counterparts. Both forms do the same work as `all` — every input has already run by the time the aggregate sees it — so the choice is purely which errors get reported. See [Combine parallel results](../how-to/combine-parallel-results#accumulate-every-error-with-validateall).
 
 ## Interop constructors
 

--- a/docs/reference/result-surface.md
+++ b/docs/reference/result-surface.md
@@ -169,7 +169,19 @@ and folded by a mandatory `merge` into one named domain error, rather than the
 first one winning.
 
 ```ts
-import { validateAll, validateAllFromDict, Ok, Err } from "unthrown";
+import {
+  validateAll,
+  validateAllFromDict,
+  Ok,
+  Err,
+  TaggedError,
+} from "unthrown";
+
+class InvalidInvoice extends TaggedError("InvalidInvoice")<{
+  fields: readonly string[];
+}> {
+  override message = `invalid: ${this.fields.join(", ")}`;
+}
 
 validateAll([Ok(1), Err("stock"), Err("credit")], (errors) =>
   errors.join(" and "),
@@ -178,9 +190,11 @@ validateAll([Ok(1), Err("stock"), Err("credit")], (errors) =>
 
 validateAllFromDict(
   { vatRate: Err("range"), currency: Ok("EUR"), dueDate: Err("past") },
-  (entries) => entries.map(([key]) => key),
+  (entries) => new InvalidInvoice({ fields: entries.map(([key]) => key) }),
 );
-// => Err(["vatRate", "dueDate"])
+// => Err(InvalidInvoice) — `merge` names the failure; returning the raw
+//    `entries` array would put a *shape* in `E`, which is what `merge` exists
+//    to prevent
 ```
 
 | Rule                 | Behaviour                                                                  |

--- a/docs/typedoc.core.json
+++ b/docs/typedoc.core.json
@@ -32,6 +32,9 @@
     "Unset",
     "BranchReturn",
     "PinnedOut",
-    "PinTooLate"
+    "PinTooLate",
+    "DictErrEntry",
+    "AsyncDictErrEntry",
+    "NonEmpty"
   ]
 }

--- a/examples/checkout-domain/src/errors.ts
+++ b/examples/checkout-domain/src/errors.ts
@@ -37,4 +37,43 @@ export class PaymentDeclined extends TaggedError("PaymentDeclined")<{
   override message = `payment declined (${this.code})`;
 }
 
+/**
+ * A policy check that is not about stock: the order is too small to be worth
+ * shipping. Distinct payload, distinct type — which is what lets the merged
+ * report say something specific about it.
+ */
+export class BelowMinimum extends TaggedError("BelowMinimum")<{
+  total: number;
+  minimum: number;
+}> {
+  override message = `order total ${this.total} is below the ${this.minimum} minimum`;
+}
+
+/** Another policy check, again with its own payload. */
+export class UnservedRegion extends TaggedError("UnservedRegion")<{ region: string }> {
+  override message = `we do not ship to ${this.region}`;
+}
+
+/**
+ * The merged error the accumulating aggregates fold into.
+ *
+ * This is the shape `validateAll` forces you to name. neverthrow's
+ * `combineWithAllErrors` would hand the caller an `OutOfStock[]`; an array is a
+ * *shape*, not a domain failure, so every consuming site would have to decide
+ * what it means. Naming it once, here, is the whole point — and the payload
+ * stays structured (Thesis #4), so the edge can render it however it likes.
+ */
+export class CartRejected extends TaggedError("CartRejected")<{
+  violations: readonly OutOfStock[];
+}> {
+  override message = `${this.violations.length} line(s) cannot be fulfilled`;
+}
+
+/** The merged error for the *named* policy checks. */
+export class CheckoutBlocked extends TaggedError("CheckoutBlocked")<{
+  reasons: readonly string[];
+}> {
+  override message = this.reasons.join("; ");
+}
+
 export type CheckoutError = CartNotFound | CartEmpty | OutOfStock | PaymentDeclined;

--- a/examples/checkout-domain/src/index.spec.ts
+++ b/examples/checkout-domain/src/index.spec.ts
@@ -1,13 +1,18 @@
-import { Err, Ok, P, OkAsync, ErrAsync } from "unthrown";
+import { Err, Ok, P, fromSafeThrowable, OkAsync, ErrAsync } from "unthrown";
 import { expect, test } from "vitest";
 import "@unthrown/vitest";
 
 import {
+  BelowMinimum,
   CartNotFound,
+  checkPolicies,
   OutOfStock,
   PaymentDeclined,
+  reviewCart,
+  UnservedRegion,
   type Cart,
   type CheckoutDeps,
+  type PolicyDeps,
   placeOrder,
 } from "./index.js";
 
@@ -113,4 +118,90 @@ test("a payment-provider outage becomes a Defect, not an Err", async () => {
   // combinator, so it mints a Defect carrying the thrown value as-is. (The
   // AggregateError wrapping is reserved for the failure *observers*.)
   await expect(result).toBeDefectWith(boom);
+});
+
+// --- reviewing a whole cart: every violation, not just the first -------------
+
+const OUT_OF_STOCK = (sku: string) => new OutOfStock({ sku, requested: 2, available: 0 });
+
+test("reviewCart reports EVERY unfulfillable line, not just the first", () => {
+  const cart: Cart = {
+    id: "cart_1",
+    lines: [
+      { sku: "COFFEE-1KG", quantity: 2, unitPrice: 12_00 },
+      { sku: "TEA-500G", quantity: 2, unitPrice: 8_00 },
+      { sku: "MUG", quantity: 1, unitPrice: 5_00 },
+    ],
+  };
+  const result = reviewCart(
+    deps({ reserve: (line) => (line.sku === "MUG" ? Ok() : Err(OUT_OF_STOCK(line.sku))) }),
+    cart,
+  );
+  // `getErr()` does not compile on a still-fallible Result — fold the channel
+  // exhaustively instead, which is the same thing the API edge would do.
+  const skus = result.match({
+    ok: () => [],
+    errCases: (m) => m.with(P.tag("CartRejected"), (e) => e.violations.map((v) => v.sku)),
+    defect: () => [],
+  });
+  // `placeOrder`'s lazy fold would have stopped at COFFEE-1KG.
+  expect(skus).toEqual(["COFFEE-1KG", "TEA-500G"]);
+});
+
+test("reviewCart never calls merge when every line reserves", () => {
+  const cart: Cart = { id: "cart_1", lines: [LINE] };
+  const result = reviewCart(deps(), cart);
+  expect(result.getOrNull()).toEqual([LINE]);
+});
+
+test("a Defect in one line dominates the accumulated violations", () => {
+  const cart: Cart = {
+    id: "cart_1",
+    lines: [LINE, { sku: "TEA-500G", quantity: 1, unitPrice: 8_00 }],
+  };
+  // Note where the defect comes from: `reserve` is called while the array is
+  // being built, BEFORE `validateAll` sees anything, so a raw `throw` here would
+  // escape the aggregate entirely. A defect reaches an aggregate the way defects
+  // always arise — through a boundary. `fromSafeThrowable` is that boundary.
+  const explode = fromSafeThrowable((): void => {
+    throw new Error("stock service exploded");
+  });
+  const result = reviewCart(
+    deps({
+      reserve: (line) => (line.sku === "COFFEE-1KG" ? Err(OUT_OF_STOCK(line.sku)) : explode()),
+    }),
+    cart,
+  );
+  // The violation it beat was computed alongside broken code, so it is dropped.
+  expect(result.isDefect()).toBe(true);
+});
+
+// --- named policy checks: the entries stay correlated with their key ---------
+
+const policies = (over: Partial<PolicyDeps> = {}): PolicyDeps => ({
+  checkMinimum: () => Ok(),
+  checkRegion: () => Ok(),
+  ...over,
+});
+
+test("checkPolicies merges each failure using the error type its key produces", () => {
+  const cart: Cart = { id: "cart_1", lines: [LINE] };
+  const result = checkPolicies(
+    policies({
+      checkMinimum: () => Err(new BelowMinimum({ total: 500, minimum: 2_000 })),
+      checkRegion: () => Err(new UnservedRegion({ region: "Antarctica" })),
+    }),
+    cart,
+  );
+  const reasons = result.match({
+    ok: () => [],
+    errCases: (m) => m.with(P.tag("CheckoutBlocked"), (e) => e.reasons),
+    defect: () => [],
+  });
+  expect(reasons).toEqual(["total 500 < 2000", "no shipping to Antarctica"]);
+});
+
+test("checkPolicies passes when every rule holds", () => {
+  const result = checkPolicies(policies(), { id: "cart_1", lines: [LINE] });
+  expect(result.isOk()).toBe(true);
 });

--- a/examples/checkout-domain/src/index.ts
+++ b/examples/checkout-domain/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./checkout.js";
 export * from "./errors.js";
+export * from "./review.js";

--- a/examples/checkout-domain/src/review.ts
+++ b/examples/checkout-domain/src/review.ts
@@ -1,0 +1,64 @@
+import { type Result, validateAll, validateAllFromDict } from "unthrown";
+
+import type { Cart, CartLine, CheckoutDeps } from "./checkout.js";
+import { type BelowMinimum, CartRejected, CheckoutBlocked, type UnservedRegion } from "./errors.js";
+
+/**
+ * Review a whole cart: check **every** line and report all the ones that cannot
+ * be fulfilled.
+ *
+ * The deliberate contrast with `reserveAll` in `checkout.ts`. That one folds with
+ * `flatMap` so the walk stays lazy — placing an order, the first failure ends the
+ * transaction and there is no reason to keep going. Here the caller is rendering
+ * a cart-review screen: telling a shopper about one bad line, then a second one
+ * after they fix it, is a worse product. So every line is checked and every
+ * violation reported.
+ *
+ * `merge` is mandatory, and it is called only when at least one line failed — it
+ * receives a **non-empty** list, so there is no "shouldn't happen" branch here.
+ */
+export const reviewCart = (
+  deps: CheckoutDeps,
+  cart: Cart,
+): Result<readonly CartLine[], CartRejected> =>
+  validateAll(
+    cart.lines.map((line) => deps.reserve(line).map(() => line)),
+    (violations) => new CartRejected({ violations }),
+  );
+
+/**
+ * The named policy checks, each with its own error type.
+ *
+ * `validateAllFromDict` hands `merge` a list of `[key, error]` **entries**, and
+ * they are correlated per key — the union is
+ * `["minimum", BelowMinimum] | ["region", UnservedRegion]`, not the cross
+ * product. So the `switch` below narrows the error from the key with no casts
+ * and no re-checking, and `["region", BelowMinimum]` would not compile.
+ *
+ * That correlation is what keeps the record form worth having: it still names
+ * the failing check even when two of them share one error type, where a flat
+ * list of errors could not tell you which key produced which.
+ */
+export type PolicyDeps = {
+  checkMinimum: (cart: Cart) => Result<void, BelowMinimum>;
+  checkRegion: (cart: Cart) => Result<void, UnservedRegion>;
+};
+
+export const checkPolicies = (deps: PolicyDeps, cart: Cart): Result<void, CheckoutBlocked> =>
+  validateAllFromDict(
+    {
+      minimum: deps.checkMinimum(cart),
+      region: deps.checkRegion(cart),
+    },
+    (entries) =>
+      new CheckoutBlocked({
+        reasons: entries.map((entry) => {
+          switch (entry[0]) {
+            case "minimum":
+              return `total ${entry[1].total} < ${entry[1].minimum}`;
+            case "region":
+              return `no shipping to ${entry[1].region}`;
+          }
+        }),
+      }),
+  ).discard();

--- a/examples/checkout-domain/src/review.ts
+++ b/examples/checkout-domain/src/review.ts
@@ -33,7 +33,9 @@ export const reviewCart = (
  * they are correlated per key — the union is
  * `["minimum", BelowMinimum] | ["region", UnservedRegion]`, not the cross
  * product. So the `switch` below narrows the error from the key with no casts
- * and no re-checking, and `["region", BelowMinimum]` would not compile.
+ * and no re-checking, and `["region", BelowMinimum]` would not compile. The
+ * correlation survives destructuring the entry, so the branches read as
+ * `[check, violation]` rather than `entry[0]` / `entry[1]`.
  *
  * That correlation is what keeps the record form worth having: it still names
  * the failing check even when two of them share one error type, where a flat
@@ -52,12 +54,12 @@ export const checkPolicies = (deps: PolicyDeps, cart: Cart): Result<void, Checko
     },
     (entries) =>
       new CheckoutBlocked({
-        reasons: entries.map((entry) => {
-          switch (entry[0]) {
+        reasons: entries.map(([check, violation]) => {
+          switch (check) {
             case "minimum":
-              return `total ${entry[1].total} < ${entry[1].minimum}`;
+              return `total ${violation.total} < ${violation.minimum}`;
             case "region":
-              return `no shipping to ${entry[1].region}`;
+              return `no shipping to ${violation.region}`;
           }
         }),
       }),

--- a/packages/core/src/aggregate.spec.ts
+++ b/packages/core/src/aggregate.spec.ts
@@ -11,6 +11,10 @@ import {
   fromSafePromise,
   Ok,
   type Result,
+  validateAll,
+  validateAllAsync,
+  validateAllFromDict,
+  validateAllFromDictAsync,
 } from "./index.js";
 import { boom, defectOf, expectErr, expectOk } from "./test-helpers.js";
 
@@ -214,5 +218,148 @@ describe("allFromDictAsync", () => {
     };
     const r = await allFromDictAsync(bad);
     expect(r.isDefect()).toBe(true);
+  });
+});
+
+// The accumulating aggregates funnel into the same `foldArray`/`foldRecord` as
+// the fail-fast four, so the shared rules (Defect dominates, throw in `merge`
+// becomes a Defect, a non-Result element becomes a Defect) are asserted once on
+// `validateAll`; the other three cover only what is theirs — key correlation,
+// concurrent settling, prototype safety.
+const join = (errors: readonly string[]) => errors.join(",");
+const joinEntries = (entries: readonly (readonly [string, string])[]) =>
+  entries.map(([key, error]) => `${key}:${error}`).join(",");
+
+describe("validateAll", () => {
+  it("collects a tuple of Ok values, preserving positional types", () => {
+    const r = validateAll([Ok(1), Ok("two"), Ok(true)], join);
+    // merge never ran, so the error channel is only ever the merged type
+    expect(r.getOrNull()).toEqual([1, "two", true]);
+  });
+
+  it("accumulates EVERY Err, in input order, and merges them", () => {
+    const r = validateAll([Ok(1), Err("stock"), Ok(3), Err("credit")], join);
+    expectErr(r, "stock,credit");
+  });
+
+  it("calls merge with a non-empty list — never on an all-Ok input", () => {
+    let calls = 0;
+    const r = validateAll([Ok(1), Ok(2)], (errors) => {
+      calls += 1;
+      return join(errors);
+    });
+    expect(calls).toBe(0);
+    expect(r.getOrNull()).toEqual([1, 2]);
+  });
+
+  it("lets a Defect dominate, discarding the accumulated errors without calling merge", () => {
+    let calls = 0;
+    const r = validateAll([Err("a"), Err("b"), defectOf(boom)], (errors) => {
+      calls += 1;
+      return join(errors);
+    });
+    expect(calls).toBe(0);
+    expect(r.isDefect()).toBe(true);
+    expectOk(
+      r.recoverDefect((c) => Ok(c === boom)),
+      true,
+    );
+  });
+
+  it("turns a throw inside merge into a Defect — nothing escapes as a raw throw", () => {
+    const r = validateAll([Err("a")], () => {
+      throw boom;
+    });
+    expect(r.isDefect()).toBe(true);
+    expectOk(
+      r.recoverDefect((c) => Ok(c === boom)),
+      true,
+    );
+  });
+
+  it("returns Ok([]) for an empty tuple, typed as the empty tuple", () => {
+    const r = validateAll([], join);
+    const empty: Result<[], string> = r;
+    expect(empty.getOrNull()).toEqual([]);
+  });
+
+  it("surfaces an out-of-contract non-Result element as a Defect", () => {
+    const bad = [Ok(1), undefined, Ok(3)] as unknown as Result<number, never>[];
+    expect(validateAll(bad, join).isDefect()).toBe(true);
+  });
+});
+
+describe("validateAllFromDict", () => {
+  it("collects a record of Ok values into a record, keyed by name", () => {
+    const r = validateAllFromDict({ id: Ok(1), name: Ok("ada") }, joinEntries);
+    expect(r.getOrNull()).toEqual({ id: 1, name: "ada" });
+  });
+
+  it("accumulates every Err as a [key, error] entry, in Object.keys order", () => {
+    const r = validateAllFromDict(
+      { vatRate: Err("range"), currency: Ok("EUR"), dueDate: Err("past") },
+      joinEntries,
+    );
+    expectErr(r, "vatRate:range,dueDate:past");
+  });
+
+  it("does not let a `__proto__` key pollute the prototype", () => {
+    const r = validateAllFromDict(
+      { ["__proto__"]: Ok({ polluted: true }), safe: Ok(1) },
+      joinEntries,
+    );
+    expect(r.isOk()).toBe(true);
+    expect(({} as Record<string, unknown>)["polluted"]).toBeUndefined();
+  });
+});
+
+describe("validateAllAsync", () => {
+  it("resolves concurrently and accumulates every Err", async () => {
+    const r = await validateAllAsync(
+      [fromSafePromise(Promise.resolve(1)), Err("stock").toAsync(), Err("credit").toAsync()],
+      join,
+    );
+    expectErr(r, "stock,credit");
+  });
+
+  it("collects Ok values, preserving positional types", async () => {
+    const r = await validateAllAsync(
+      [fromSafePromise(Promise.resolve(1)), fromSafePromise(Promise.resolve("two"))],
+      join,
+    );
+    expect(r.getOrNull()).toEqual([1, "two"]);
+  });
+
+  it("adopts a raw rejecting thenable as a Defect, never rejecting the internal promise", async () => {
+    const rejecting = Promise.reject(boom) as unknown as AsyncResult<number, string>;
+    const r = await validateAllAsync([fromSafePromise(Promise.resolve(1)), rejecting], join);
+    expect(r.isDefect()).toBe(true);
+  });
+});
+
+describe("validateAllFromDictAsync", () => {
+  it("accumulates every Err as a [key, error] entry", async () => {
+    const r = await validateAllFromDictAsync(
+      { stock: Err("none").toAsync(), credit: Ok(500).toAsync(), zone: Err("unserved").toAsync() },
+      joinEntries,
+    );
+    expectErr(r, "stock:none,zone:unserved");
+  });
+
+  it("collects a record of Ok values, keyed by name", async () => {
+    const r = await validateAllFromDictAsync(
+      { a: fromSafePromise(Promise.resolve(1)), b: fromSafePromise(Promise.resolve("x")) },
+      joinEntries,
+    );
+    expect(r.getOrNull()).toEqual({ a: 1, b: "x" });
+  });
+
+  it("does not let a `__proto__` key pollute the prototype", async () => {
+    const r = await validateAllFromDictAsync(
+      { ["__proto__"]: Ok({ polluted: true }).toAsync(), safe: Ok(1).toAsync() },
+      joinEntries,
+    );
+    expect(r.isOk()).toBe(true);
+    expect(({} as Record<string, unknown>)["polluted"]).toBeUndefined();
   });
 });

--- a/packages/core/src/facade.spec.ts
+++ b/packages/core/src/facade.spec.ts
@@ -20,6 +20,10 @@ import {
   isResult,
   Ok,
   Result,
+  validateAll,
+  validateAllAsync,
+  validateAllFromDict,
+  validateAllFromDictAsync,
 } from "./index.js";
 import { boom } from "./test-helpers.js";
 
@@ -54,6 +58,8 @@ describe("Result facade mirrors the free functions", () => {
     expect(Result.Do).toBe(Do);
     expect(Result.all).toBe(all);
     expect(Result.allFromDict).toBe(allFromDict);
+    expect(Result.validateAll).toBe(validateAll);
+    expect(Result.validateAllFromDict).toBe(validateAllFromDict);
     expect(Result.fromNullable(null, () => "absent").getErr()).toBe("absent");
     expect(Result.all([Result.Ok(1), Result.Ok(2)]).get()).toEqual([1, 2]);
     expect(Result.allFromDict({ a: Result.Ok(1) }).get()).toEqual({ a: 1 });
@@ -64,6 +70,8 @@ describe("Result facade mirrors the free functions", () => {
     expect("fromSafePromise" in Result).toBe(false);
     expect("allAsync" in Result).toBe(false);
     expect("allFromDictAsync" in Result).toBe(false);
+    expect("validateAllAsync" in Result).toBe(false);
+    expect("validateAllFromDictAsync" in Result).toBe(false);
   });
 });
 
@@ -74,6 +82,8 @@ describe("AsyncResult facade groups the async-producing entry points", () => {
     expect(AsyncResult.Do).toBe(DoAsync);
     expect(AsyncResult.all).toBe(allAsync);
     expect(AsyncResult.allFromDict).toBe(allFromDictAsync);
+    expect(AsyncResult.validateAll).toBe(validateAllAsync);
+    expect(AsyncResult.validateAllFromDict).toBe(validateAllFromDictAsync);
   });
 
   it("AsyncResult.Do starts an async do-chain", async () => {

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -18,6 +18,10 @@ import {
   fromSafePromise,
   fromSafeThrowable,
   fromThrowable,
+  validateAll,
+  validateAllAsync,
+  validateAllFromDict,
+  validateAllFromDictAsync,
 } from "./interop.js";
 import type { AsyncResult as AsyncResultType, Result as ResultType } from "./types.js";
 
@@ -26,7 +30,8 @@ import type { AsyncResult as AsyncResultType, Result as ResultType } from "./typ
  * single, discoverable namespace: {@link Result.Ok}, {@link Result.Err},
  * {@link Result.Do}, {@link Result.fromNullable}, {@link Result.fromThrowable},
  * {@link Result.fromSafeThrowable}, {@link Result.all},
- * {@link Result.allFromDict}, {@link Result.isOk}, {@link Result.isErr},
+ * {@link Result.allFromDict}, {@link Result.validateAll},
+ * {@link Result.validateAllFromDict}, {@link Result.isOk}, {@link Result.isErr},
  * {@link Result.isDefect}, {@link Result.isResult}.
  *
  * @remarks
@@ -56,6 +61,8 @@ export const Result = {
   fromSafeThrowable,
   all,
   allFromDict,
+  validateAll,
+  validateAllFromDict,
   isOk,
   isErr,
   isDefect,
@@ -86,7 +93,8 @@ export type Result<T, E> = ResultType<T, E>;
  * the matching namespace: {@link AsyncResult.Ok}, {@link AsyncResult.Err},
  * {@link AsyncResult.Do}, {@link AsyncResult.fromExecutor},
  * {@link AsyncResult.fromPromise}, {@link AsyncResult.fromSafePromise},
- * {@link AsyncResult.all}, {@link AsyncResult.allFromDict}.
+ * {@link AsyncResult.all}, {@link AsyncResult.allFromDict},
+ * {@link AsyncResult.validateAll}, {@link AsyncResult.validateAllFromDict}.
  *
  * @remarks
  * The async sibling of {@link Result}. Statics are grouped by what they
@@ -97,7 +105,8 @@ export type Result<T, E> = ResultType<T, E>;
  * functions carry (`AsyncResult.Ok` is `OkAsync`; `AsyncResult.Err` is
  * `ErrAsync`; `AsyncResult.Do` is `DoAsync`; `AsyncResult.all` is `allAsync`;
  * `AsyncResult.allFromDict` is
- * `allFromDictAsync`). Like {@link Result}, the free functions remain the
+ * `allFromDictAsync`; `AsyncResult.validateAll` is `validateAllAsync`). Like
+ * {@link Result}, the free functions remain the
  * primary, tree-shakeable API; the value `AsyncResult` and the type
  * {@link AsyncResult} share one name.
  *
@@ -122,6 +131,8 @@ export const AsyncResult = {
   fromSafePromise,
   all: allAsync,
   allFromDict: allFromDictAsync,
+  validateAll: validateAllAsync,
+  validateAllFromDict: validateAllFromDictAsync,
 } as const;
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,10 @@ export {
   fromSafePromise,
   fromSafeThrowable,
   fromThrowable,
+  validateAll,
+  validateAllAsync,
+  validateAllFromDict,
+  validateAllFromDictAsync,
 } from "./interop.js";
 export { TaggedError } from "./tagged.js";
 

--- a/packages/core/src/interop.ts
+++ b/packages/core/src/interop.ts
@@ -464,6 +464,15 @@ type AllOk<
   Ts extends readonly unknown[],
 > = number extends Rs["length"] ? Ts[number][] : Ts;
 
+/** A `[key, error]` pair from a record aggregate, correlated per key. @internal */
+type DictErrEntry<R> = { [K in keyof R]: readonly [K, ErrOf<R[K]>] }[keyof R];
+
+/** The {@link AsyncResult} counterpart of {@link DictErrEntry}. @internal */
+type AsyncDictErrEntry<R> = { [K in keyof R]: readonly [K, AsyncErrOf<R[K]>] }[keyof R];
+
+/** A non-empty readonly list — `merge` runs only when an `Err` was collected. @internal */
+type NonEmpty<T> = readonly [T, ...T[]];
+
 /** A record of `Result`s — the input to {@link allFromDict}. */
 type ResultRecord = Record<string, Result<unknown, unknown>>;
 /** A record of `AsyncResult`s — the input to {@link allFromDictAsync}. */
@@ -480,11 +489,39 @@ function nonResultDefect(): Result<unknown, unknown> {
   return defectRes(new TypeError("unthrown: aggregate received a non-Result element"));
 }
 
-function foldArray(results: readonly Result<unknown, unknown>[]): Result<unknown, unknown> {
+/**
+ * Resolve every input concurrently (order preserved), adopting each one
+ * defensively: a cast/untyped rejecting thenable becomes a `Defect` rather than
+ * rejecting the internal promise, so the "an `AsyncResult`'s internal promise
+ * never rejects" invariant holds even for out-of-contract input.
+ *
+ * @internal
+ */
+function settleAll(
+  results: readonly AsyncResult<unknown, unknown>[],
+): Promise<readonly Result<unknown, unknown>[]> {
+  return Promise.all(
+    results.map((r) =>
+      Promise.resolve(r).then(
+        (x) => x,
+        (cause) => defectRes(cause),
+      ),
+    ),
+  ) as Promise<readonly Result<unknown, unknown>[]>;
+}
+
+/** An accumulated `[index, error]` pair. @internal */
+type IndexedErr = readonly [number, unknown];
+
+function foldArray(
+  results: readonly Result<unknown, unknown>[],
+  merge?: (errors: NonEmpty<IndexedErr>) => unknown,
+): Result<unknown, unknown> {
   let firstErr: Result<unknown, unknown> | undefined;
   let firstDefect: Result<unknown, unknown> | undefined;
   const values: unknown[] = [];
-  for (const r of results) {
+  const errors: IndexedErr[] = [];
+  for (const [i, r] of results.entries()) {
     if (!isResult(r)) {
       // Out-of-contract element (a hole/undefined/non-Result, reachable only via
       // untyped or cast input). Surface it as a Defect — an unexpected failure —
@@ -496,10 +533,27 @@ function foldArray(results: readonly Result<unknown, unknown>[]): Result<unknown
     if (r.tag === "Defect") {
       firstDefect ??= r;
       break; // any Defect dominates — nothing later can change the outcome
-    } else if (r.tag === "Err") firstErr ??= r;
-    else values.push(r.value);
+    } else if (r.tag === "Err") {
+      // Fail-fast keeps the first Err; the validating fold accumulates every
+      // one, paired with its index so the record fold can name it.
+      if (merge) errors.push([i, r.error]);
+      else firstErr ??= r;
+    } else values.push(r.value);
   }
-  return firstDefect ?? firstErr ?? Ok(values);
+  // A Defect dominates even the accumulated errors: something in this batch is
+  // broken in a way nobody modeled, so the modeled violations it beat were
+  // computed alongside broken code and `merge` is never called.
+  if (firstDefect) return firstDefect;
+  if (merge && errors.length > 0) {
+    // `merge` is user code, so the throw → defect rule applies: nothing escapes
+    // an aggregate as a raw throw.
+    try {
+      return Err(merge(errors as unknown as NonEmpty<IndexedErr>));
+    } catch (cause) {
+      return defectRes(cause);
+    }
+  }
+  return firstErr ?? Ok(values);
 }
 
 /**
@@ -518,11 +572,27 @@ function foldArray(results: readonly Result<unknown, unknown>[]): Result<unknown
  *
  * @internal
  */
-function foldRecord(results: ResultRecord): Result<unknown, unknown> {
+function foldRecord(
+  results: ResultRecord,
+  merge?: (entries: NonEmpty<readonly [string, unknown]>) => unknown,
+): Result<unknown, unknown> {
   const keys = Object.keys(results);
-  return foldArray(Object.values(results)).map((values) =>
-    Object.fromEntries(keys.map((key, i) => [key, (values as unknown[])[i]])),
-  );
+  return foldArray(
+    Object.values(results),
+    // The positional fold accumulates `[index, error]`; the record form names
+    // each one by pairing the index back onto its key before `merge` sees it.
+    merge && ((errors) => merge(nameErrors(errors, keys))),
+  ).map((values) => Object.fromEntries(keys.map((key, i) => [key, (values as unknown[])[i]])));
+}
+
+/** Drop the accumulated indices — the positional forms merge errors alone. @internal */
+function stripIndices<E>(errors: NonEmpty<IndexedErr>): NonEmpty<E> {
+  return errors.map(([, e]) => e) as unknown as NonEmpty<E>;
+}
+
+/** Pair each accumulated index back onto its key. @internal */
+function nameErrors<Entry>(errors: NonEmpty<IndexedErr>, keys: readonly string[]): NonEmpty<Entry> {
+  return errors.map(([i, e]) => [keys[i] as string, e]) as unknown as NonEmpty<Entry>;
 }
 
 /**
@@ -611,19 +681,9 @@ export function allFromDict<R extends ResultRecord>(
 export function allAsync<Rs extends readonly AsyncResult<unknown, unknown>[]>(
   results: readonly [...Rs],
 ): AsyncResult<AllOk<Rs, { [K in keyof Rs]: AsyncOkOf<Rs[K]> }>, AsyncErrOf<Rs[number]>> {
-  // Each library AsyncResult is a never-rejecting thenable, so Promise.all
-  // adopts them; `foldArray` then applies the all() rules. Adopt every input
-  // defensively — a cast/untyped rejecting thenable becomes a `Defect` rather
-  // than rejecting the internal promise (the "internal promise never rejects"
-  // invariant holds even for out-of-contract input).
-  const settled = Promise.all(
-    results.map((r) =>
-      Promise.resolve(r).then(
-        (x) => x,
-        (cause) => defectRes(cause),
-      ),
-    ),
-  ).then((resolved) => foldArray(resolved as readonly Result<unknown, unknown>[]));
+  // Each library AsyncResult is a never-rejecting thenable, so `settleAll`
+  // adopts them concurrently; `foldArray` then applies the all() rules.
+  const settled = settleAll(results).then((resolved) => foldArray(resolved));
   return new AsyncRes(settled) as unknown as AsyncResult<
     AllOk<Rs, { [K in keyof Rs]: AsyncOkOf<Rs[K]> }>,
     AsyncErrOf<Rs[number]>
@@ -655,25 +715,206 @@ export function allFromDictAsync<R extends AsyncResultRecord>(
   results: R,
 ): AsyncResult<{ [K in keyof R]: AsyncOkOf<R[K]> }, AsyncErrOf<R[keyof R]>> {
   const keys = Object.keys(results);
-  const settled = Promise.all(
-    // Adopt each input defensively (see `allAsync`): a rejecting thenable
-    // becomes a `Defect`, so the internal promise never rejects.
-    Object.values(results).map((ar) =>
-      Promise.resolve(ar).then(
-        (x) => x,
-        (cause) => defectRes(cause),
-      ),
-    ),
-  ).then((resolved) =>
-    // The positional fold applies the `all` rules; the keys are paired back on
-    // afterwards, with the same `Object.fromEntries` prototype guarantee
-    // `foldRecord` relies on.
-    foldArray(resolved as readonly Result<unknown, unknown>[]).map((values) =>
-      Object.fromEntries(keys.map((key, i) => [key, (values as unknown[])[i]])),
-    ),
+  // Re-pair the settled results with their keys and hand them to the sync record
+  // fold, so the `all` rules and the `Object.fromEntries` prototype guarantee
+  // come from one place.
+  const settled = settleAll(Object.values(results)).then((resolved) =>
+    foldRecord(Object.fromEntries(keys.map((key, i) => [key, resolved[i]])) as ResultRecord),
   );
   return new AsyncRes(settled) as unknown as AsyncResult<
     { [K in keyof R]: AsyncOkOf<R[K]> },
     AsyncErrOf<R[keyof R]>
   >;
+}
+
+/**
+ * Collect a tuple/array of {@link Result}s, **accumulating every** `Err` and
+ * merging them into a single modeled error — the accumulating counterpart of
+ * {@link all}.
+ *
+ * @remarks
+ * Same success channel as {@link all}: a **fixed tuple** keeps its positional
+ * types, a **dynamic array** collapses to `Result<T[], E2>`. The difference is
+ * the error channel — instead of the first `Err` winning, every `Err` is
+ * collected in input order and handed to `merge`, whose return becomes the
+ * modeled error.
+ *
+ * `merge` receives a **non-empty** list, so it is total: it is called only when
+ * at least one `Err` was collected. It is **not** called when every element is
+ * `Ok`, nor when a `Defect` is present.
+ *
+ * Any `Defect` still **dominates** — it wins over the accumulated errors, which
+ * are discarded and never reach `merge`. A defect means something in this batch
+ * failed in a way nobody modeled, so the violations computed alongside it are
+ * not trustworthy. An out-of-contract non-`Result` element becomes a
+ * `TypeError`-caused `Defect` the same way, and a throw inside `merge` becomes
+ * a `Defect` too.
+ *
+ * `merge` must be **synchronous** — an `async` one is a compile error
+ * ({@link NotThenable}), since a `Promise` in `E` is an unqualified rejection.
+ *
+ * For **schema-shaped** input (a request body, a form), reach for
+ * `@unthrown/standard-schema`'s `fromSchema` instead — a validator already
+ * hands you every issue as the modeled error. `validateAll` is for independent
+ * checks you wrote yourself. For a **record** keyed by name, use
+ * {@link validateAllFromDict}.
+ *
+ * @typeParam Rs - the tuple/array of input `Result` types.
+ * @typeParam E2 - the merged error type.
+ * @param results - the results to collect.
+ * @param merge - folds the collected errors into one modeled error.
+ *
+ * @category Aggregate
+ *
+ * @example
+ * ```ts
+ * import { validateAll, Ok, Err } from "unthrown";
+ *
+ * // every Err is collected, not just the first
+ * validateAll([Ok(1), Err("stock"), Err("credit")], (errors) => errors.join(" and "));
+ * // => Err("stock and credit")
+ *
+ * // all-Ok keeps the positional tuple; `merge` never runs
+ * validateAll([Ok(1), Ok("a")], (errors) => errors.join());
+ * // => Ok([1, "a"]) typed Result<[number, string], string>
+ * ```
+ */
+export function validateAll<Rs extends readonly Result<unknown, unknown>[], E2>(
+  results: readonly [...Rs],
+  merge: (errors: NonEmpty<ErrOf<Rs[number]>>) => E2 & NotThenable<E2>,
+): Result<AllOk<Rs, { [K in keyof Rs]: OkOf<Rs[K]> }>, E2> {
+  return foldArray(results, (errors) => merge(stripIndices(errors))) as unknown as Result<
+    AllOk<Rs, { [K in keyof Rs]: OkOf<Rs[K]> }>,
+    E2
+  >;
+}
+
+/**
+ * Collect a **record** of {@link Result}s, accumulating every `Err` — the
+ * accumulating counterpart of {@link allFromDict}, and the named counterpart of
+ * {@link validateAll}.
+ *
+ * @remarks
+ * `merge` receives a non-empty list of **`[key, error]` entries**, correlated
+ * per key: `{ a: Result<A, E1>; b: Result<B, E2> }` yields
+ * `["a", E1] | ["b", E2]`, so a `switch` on the key narrows the error and an
+ * impossible pairing does not typecheck. That is what keeps two checks sharing
+ * one error type distinguishable. Entries come in `Object.keys` order.
+ *
+ * Every other rule matches {@link validateAll}: any `Defect` dominates and
+ * discards the accumulated errors, a throw in `merge` becomes a `Defect`, and
+ * `merge` must be synchronous.
+ *
+ * @typeParam R - the record of input `Result` types.
+ * @typeParam E2 - the merged error type.
+ * @param results - the results to collect, keyed by name.
+ * @param merge - folds the collected `[key, error]` entries into one error.
+ *
+ * @category Aggregate
+ *
+ * @example
+ * ```ts
+ * import { validateAllFromDict, Ok, Err } from "unthrown";
+ *
+ * validateAllFromDict(
+ *   { vatRate: Err("out of range"), currency: Ok("EUR"), dueDate: Err("past") },
+ *   (entries) => entries.map(([key, error]) => `${key}: ${error}`).join("; "),
+ * );
+ * // => Err("vatRate: out of range; dueDate: past")
+ * ```
+ */
+export function validateAllFromDict<R extends ResultRecord, E2>(
+  results: R,
+  merge: (entries: NonEmpty<DictErrEntry<R>>) => E2 & NotThenable<E2>,
+): Result<{ [K in keyof R]: OkOf<R[K]> }, E2> {
+  return foldRecord(results, (entries) =>
+    merge(entries as NonEmpty<DictErrEntry<R>>),
+  ) as unknown as Result<{ [K in keyof R]: OkOf<R[K]> }, E2>;
+}
+
+/**
+ * The asynchronous counterpart of {@link validateAll}: collect a tuple/array of
+ * {@link AsyncResult}s, accumulating every `Err` into one merged error.
+ *
+ * @remarks
+ * Every {@link validateAll} rule holds, with the inputs resolved
+ * **concurrently** (order preserved) — as with {@link allAsync}, no work is
+ * short-circuited either way; the fail-fast/accumulating split is purely which
+ * errors get reported. The internal promise never rejects: an out-of-contract
+ * rejecting thenable becomes a dominating `Defect`. `merge` stays synchronous
+ * here too — this is exactly where its rejection would land unqualified in `E`.
+ * For a **record**, use {@link validateAllFromDictAsync}.
+ *
+ * @typeParam Rs - the tuple/array of input `AsyncResult` types.
+ * @typeParam E2 - the merged error type.
+ * @param results - the async results to collect.
+ * @param merge - folds the collected errors into one modeled error.
+ *
+ * @category Aggregate
+ *
+ * @example
+ * ```ts
+ * import { validateAllAsync, OkAsync, ErrAsync } from "unthrown";
+ *
+ * const checked = validateAllAsync(
+ *   [OkAsync(1), ErrAsync("stock"), ErrAsync("credit")],
+ *   (errors) => errors.join(" and "),
+ * );
+ * // (await checked) => Err("stock and credit")
+ * ```
+ */
+export function validateAllAsync<Rs extends readonly AsyncResult<unknown, unknown>[], E2>(
+  results: readonly [...Rs],
+  merge: (errors: NonEmpty<AsyncErrOf<Rs[number]>>) => E2 & NotThenable<E2>,
+): AsyncResult<AllOk<Rs, { [K in keyof Rs]: AsyncOkOf<Rs[K]> }>, E2> {
+  const settled = settleAll(results).then((resolved) =>
+    foldArray(resolved, (errors) => merge(stripIndices(errors))),
+  );
+  return new AsyncRes(settled) as unknown as AsyncResult<
+    AllOk<Rs, { [K in keyof Rs]: AsyncOkOf<Rs[K]> }>,
+    E2
+  >;
+}
+
+/**
+ * The asynchronous counterpart of {@link validateAllFromDict}: collect a record
+ * of {@link AsyncResult}s, accumulating every `Err` into one merged error.
+ *
+ * @remarks
+ * The {@link validateAllFromDict} rules, over inputs resolved concurrently as
+ * in {@link validateAllAsync}.
+ *
+ * @typeParam R - the record of input `AsyncResult` types.
+ * @typeParam E2 - the merged error type.
+ * @param results - the async results to collect, keyed by name.
+ * @param merge - folds the collected `[key, error]` entries into one error.
+ *
+ * @category Aggregate
+ *
+ * @example
+ * ```ts
+ * import { validateAllFromDictAsync, OkAsync, ErrAsync } from "unthrown";
+ *
+ * const checked = validateAllFromDictAsync(
+ *   { stock: ErrAsync("none left"), credit: OkAsync(500) },
+ *   (entries) => entries.map(([key, error]) => `${key}: ${error}`).join("; "),
+ * );
+ * // (await checked) => Err("stock: none left")
+ * ```
+ */
+export function validateAllFromDictAsync<R extends AsyncResultRecord, E2>(
+  results: R,
+  merge: (entries: NonEmpty<AsyncDictErrEntry<R>>) => E2 & NotThenable<E2>,
+): AsyncResult<{ [K in keyof R]: AsyncOkOf<R[K]> }, E2> {
+  const keys = Object.keys(results);
+  // Re-pair the settled results with their keys and hand them to the sync record
+  // fold — the key naming, the `Object.fromEntries` prototype guarantee and the
+  // throw → defect net all come from there rather than being restated.
+  const settled = settleAll(Object.values(results)).then((resolved) =>
+    foldRecord(
+      Object.fromEntries(keys.map((key, i) => [key, resolved[i]])) as ResultRecord,
+      (entries) => merge(entries as NonEmpty<AsyncDictErrEntry<R>>),
+    ),
+  );
+  return new AsyncRes(settled) as unknown as AsyncResult<{ [K in keyof R]: AsyncOkOf<R[K]> }, E2>;
 }

--- a/packages/core/src/interop.ts
+++ b/packages/core/src/interop.ts
@@ -114,7 +114,9 @@ export function fromThrowable<A extends unknown[], T, R>(
   return (...args: A): Result<T, E> => {
     try {
       const value = fn(...args);
-      return isThenable(value) ? thenableReturnDefect<T, E>(value) : (Ok(value) as Result<T, E>);
+      return isThenable(value)
+        ? thenableReturnDefect<T, E>(value, SYNC_FN_THENABLE)
+        : (Ok(value) as Result<T, E>);
     } catch (cause) {
       return qualifyToResult<T, E>(cause, triage);
     }
@@ -160,7 +162,9 @@ export function fromSafeThrowable<A extends unknown[], T>(
   return (...args: A): Result<T, never> => {
     try {
       const value = fn(...args);
-      return isThenable(value) ? thenableReturnDefect<T, never>(value) : Ok(value);
+      return isThenable(value)
+        ? thenableReturnDefect<T, never>(value, SYNC_FN_THENABLE)
+        : Ok(value);
     } catch (cause) {
       return defectRes<T, never>(cause);
     }
@@ -412,34 +416,50 @@ function qualifyToResult<T, E>(
 }
 
 /**
- * The Defect minted when a **synchronous** boundary's `fn` returns a thenable —
- * i.e. an `async` function was handed to {@link fromThrowable} /
- * {@link fromSafeThrowable}.
+ * The message for {@link thenableReturnDefect} at a **synchronous boundary** —
+ * an `async` function handed to {@link fromThrowable} / {@link fromSafeThrowable}.
+ *
+ * @internal
+ */
+const SYNC_FN_THENABLE =
+  "unthrown: fromThrowable/fromSafeThrowable wrap a SYNCHRONOUS function, but `fn` returned a thenable — its rejection would escape qualification. Use fromPromise/fromSafePromise instead.";
+
+/**
+ * The message for {@link thenableReturnDefect} in an **accumulating aggregate** —
+ * an `async` `merge` handed to {@link validateAll} and friends.
+ *
+ * @internal
+ */
+const MERGE_THENABLE =
+  "unthrown: an accumulating aggregate's `merge` must be SYNCHRONOUS, but it returned a thenable — its rejection would escape qualification.";
+
+/**
+ * The Defect minted where a callback that must be **synchronous** returned a
+ * thenable: a `fn` handed to {@link fromThrowable} / {@link fromSafeThrowable},
+ * or a `merge` handed to an accumulating aggregate.
  *
  * @remarks
  * This is the sibling of the thenable-`qualify` net in {@link qualifyToResult},
  * and it closes a strictly worse hole. A synchronous boundary only ever sees a
  * synchronous `throw`, so an async `fn`'s rejection never reaches `qualify` at
  * all: it would sit inside `Ok(<Promise>)`, un-triaged, and then float as an
- * unhandled rejection — which terminates the process on Node by default.
+ * unhandled rejection — which terminates the process on Node by default. An
+ * async `merge` is the same hole one channel over: `Err(<Promise>)`.
  *
- * Unlike the combinator callbacks, this cannot be banned at compile time
- * without collateral damage: `T & NotThenable<T>` on `fn`'s return makes a
- * **generic** function unassignable, so `fromSafeThrowable(structuredClone)`
- * stops compiling and `T` collapses to `unknown`. (The phantom rest-tuple guard
- * `fromPromise` uses fares worse.) So the ban is enforced here, at runtime,
- * where it costs nothing: a Defect, plus adopt-and-silence so the orphaned
- * rejection cannot float.
+ * The `fn` case cannot be banned at compile time without collateral damage:
+ * `T & NotThenable<T>` on `fn`'s return makes a **generic** function
+ * unassignable, so `fromSafeThrowable(structuredClone)` stops compiling and `T`
+ * collapses to `unknown`. (The phantom rest-tuple guard `fromPromise` uses fares
+ * worse.) `merge` *is* `NotThenable`-constrained, but a cast or an untyped
+ * caller still reaches here. Either way the runtime answer is the same, and it
+ * costs nothing: a Defect, plus adopt-and-silence so the orphaned rejection
+ * cannot float.
  *
  * @internal
  */
-function thenableReturnDefect<T, E>(value: unknown): Result<T, E> {
-  void Promise.resolve(value).then(undefined, () => undefined);
-  return defectRes<T, E>(
-    new TypeError(
-      "unthrown: fromThrowable/fromSafeThrowable wrap a SYNCHRONOUS function, but `fn` returned a thenable — its rejection would escape qualification. Use fromPromise/fromSafePromise instead.",
-    ),
-  );
+function thenableReturnDefect<T, E>(value: unknown, message: string): Result<T, E> {
+  silenceIfThenable(value);
+  return defectRes<T, E>(new TypeError(message));
 }
 
 /**
@@ -567,16 +587,9 @@ function foldArray(
       const merged = merge(errors as unknown as NonEmpty<IndexedErr>);
       // `merge` is `NotThenable`-constrained, but a cast/untyped caller can
       // still hand us an async one. `Err(<Promise>)` would put an unqualified
-      // thenable in `E` and float its rejection — a Defect instead, adopted and
-      // silenced (the sibling of `thenableReturnDefect`'s net).
-      if (isThenable(merged)) {
-        silenceIfThenable(merged);
-        return defectRes(
-          new TypeError(
-            "unthrown: an accumulating aggregate's `merge` must be SYNCHRONOUS, but it returned a thenable — its rejection would escape qualification.",
-          ),
-        );
-      }
+      // thenable in `E` and float its rejection — the same net the synchronous
+      // boundaries use, one channel over.
+      if (isThenable(merged)) return thenableReturnDefect(merged, MERGE_THENABLE);
       return Err(merged);
     } catch (cause) {
       return defectRes(cause);
@@ -634,7 +647,8 @@ function nameErrors<Entry>(errors: NonEmpty<IndexedErr>, keys: readonly string[]
  * `Err`. A **fixed tuple** keeps its positional types — `all([Ok(1), Ok("a")])`
  * is `Result<[number, string], …>` — while a **dynamic array** `Result<T, E>[]`
  * collapses to `Result<T[], E>` with no cast. For a **record** keyed by name,
- * use {@link allFromDict}.
+ * use {@link allFromDict}. To report **every** `Err` instead of only the first,
+ * use {@link validateAll}.
  *
  * @category Aggregate
  *
@@ -663,7 +677,9 @@ export function all<Rs extends readonly Result<unknown, unknown>[]>(
  *
  * @remarks
  * Same folding rules as {@link all}: first `Err` short-circuits, any `Defect`
- * dominates. This is **not** error accumulation.
+ * dominates. This is **not** error accumulation — for that, reach for
+ * {@link validateAllFromDict}, which accumulates every `Err` and folds them into
+ * one modeled error.
  *
  * @category Aggregate
  *
@@ -692,7 +708,8 @@ export function allFromDict<R extends ResultRecord>(
  * The inputs are resolved **concurrently** (order preserved); the resolved
  * `Result`s are then folded with the same rules as {@link all} — first `Err`
  * short-circuits, any `Defect` dominates. As ever, the returned `AsyncResult`'s
- * internal promise never rejects. For a **record**, use {@link allFromDictAsync}.
+ * internal promise never rejects. For a **record**, use {@link allFromDictAsync};
+ * to report **every** `Err`, use {@link validateAllAsync}.
  *
  * @category Aggregate
  *
@@ -725,7 +742,8 @@ export function allAsync<Rs extends readonly AsyncResult<unknown, unknown>[]>(
  *
  * @remarks
  * Resolved concurrently (order preserved), folded with the {@link all} rules,
- * and the internal promise never rejects.
+ * and the internal promise never rejects. To report **every** `Err`, use
+ * {@link validateAllFromDictAsync}.
  *
  * @category Aggregate
  *

--- a/packages/core/src/interop.ts
+++ b/packages/core/src/interop.ts
@@ -464,11 +464,27 @@ type AllOk<
   Ts extends readonly unknown[],
 > = number extends Rs["length"] ? Ts[number][] : Ts;
 
-/** A `[key, error]` pair from a record aggregate, correlated per key. @internal */
-type DictErrEntry<R> = { [K in keyof R]: readonly [K, ErrOf<R[K]>] }[keyof R];
+/**
+ * A `[key, error]` pair from a record aggregate, correlated per key.
+ *
+ * @remarks
+ * `-?` because the mapped type is homomorphic: an optional input key would
+ * otherwise carry its optionality through and put `undefined` in the entry
+ * union, breaking the documented `([key, error]) => …` destructure. An entry
+ * whose error channel is `never` (an infallible input — every `@unthrown/drizzle`
+ * read) is dropped rather than emitted as an uninhabited `[K, never]` arm, which
+ * a `switch` over the key would still have to write a dead case for.
+ *
+ * @internal
+ */
+type DictErrEntry<R> = {
+  [K in keyof R]-?: [ErrOf<R[K]>] extends [never] ? never : readonly [K, ErrOf<R[K]>];
+}[keyof R];
 
 /** The {@link AsyncResult} counterpart of {@link DictErrEntry}. @internal */
-type AsyncDictErrEntry<R> = { [K in keyof R]: readonly [K, AsyncErrOf<R[K]>] }[keyof R];
+type AsyncDictErrEntry<R> = {
+  [K in keyof R]-?: [AsyncErrOf<R[K]>] extends [never] ? never : readonly [K, AsyncErrOf<R[K]>];
+}[keyof R];
 
 /** A non-empty readonly list — `merge` runs only when an `Err` was collected. @internal */
 type NonEmpty<T> = readonly [T, ...T[]];
@@ -548,7 +564,20 @@ function foldArray(
     // `merge` is user code, so the throw → defect rule applies: nothing escapes
     // an aggregate as a raw throw.
     try {
-      return Err(merge(errors as unknown as NonEmpty<IndexedErr>));
+      const merged = merge(errors as unknown as NonEmpty<IndexedErr>);
+      // `merge` is `NotThenable`-constrained, but a cast/untyped caller can
+      // still hand us an async one. `Err(<Promise>)` would put an unqualified
+      // thenable in `E` and float its rejection — a Defect instead, adopted and
+      // silenced (the sibling of `thenableReturnDefect`'s net).
+      if (isThenable(merged)) {
+        silenceIfThenable(merged);
+        return defectRes(
+          new TypeError(
+            "unthrown: an accumulating aggregate's `merge` must be SYNCHRONOUS, but it returned a thenable — its rejection would escape qualification.",
+          ),
+        );
+      }
+      return Err(merged);
     } catch (cause) {
       return defectRes(cause);
     }

--- a/packages/core/src/invariants.spec.ts
+++ b/packages/core/src/invariants.spec.ts
@@ -1,11 +1,25 @@
 // Explicit guards for the load-bearing runtime invariants documented in
 // CLAUDE.md. Most get a dedicated `describe` here; a couple are guarded where
-// their feature lives instead — prototype-pollution safety and `all` / `allAsync`
-// Defect-dominance are covered in `aggregate.spec.ts`.
+// their feature lives instead — prototype-pollution safety and Defect-dominance
+// (for the fail-fast `all` family and the accumulating `validateAll` one alike)
+// are covered in `aggregate.spec.ts`.
 
 import { describe, expect, it, vi } from "vitest";
 
-import { Do, Err, fromExecutor, fromSafePromise, Ok, P, type Result, GetError } from "./index.js";
+import {
+  Do,
+  Err,
+  fromExecutor,
+  fromSafePromise,
+  Ok,
+  P,
+  type Result,
+  GetError,
+  validateAll,
+  validateAllAsync,
+  validateAllFromDict,
+  validateAllFromDictAsync,
+} from "./index.js";
 import { adoptionProbe, boom, defectOf, flushMicrotasks } from "./test-helpers.js";
 
 describe("Invariant 1: throw inside any combinator becomes a Defect", () => {
@@ -58,6 +72,19 @@ describe("Invariant 1: throw inside any combinator becomes a Defect", () => {
     expect(defectOf(boom).tapDefect(t).isDefect()).toBe(true);
     expect(Err("e").tapFailure(t).isDefect()).toBe(true);
     expect(defectOf(boom).tapFailure(t).isDefect()).toBe(true);
+  });
+
+  it("covers the aggregates' `merge` too — the one callback outside the method surface", async () => {
+    const t = () => {
+      throw boom;
+    };
+    // `merge` is user code inside a core function, so the same rule holds: an
+    // aggregate never lets a throw escape as a raw throw, which is what keeps
+    // the "one match at the edge, no try/catch" promise true for these too.
+    expect(validateAll([Err("e")], t).isDefect()).toBe(true);
+    expect(validateAllFromDict({ a: Err("e") }, t).isDefect()).toBe(true);
+    expect((await validateAllAsync([Err("e").toAsync()], t)).isDefect()).toBe(true);
+    expect((await validateAllFromDictAsync({ a: Err("e").toAsync() }, t)).isDefect()).toBe(true);
   });
 });
 

--- a/packages/core/src/invariants.spec.ts
+++ b/packages/core/src/invariants.spec.ts
@@ -356,6 +356,14 @@ describe("Invariant 6: a DISCARDED thenable is adopted, so its rejection never f
     ["flatMap", (t: PromiseLike<never>) => Ok(1).flatMap((() => t) as never)],
     ["flatTap", (t: PromiseLike<never>) => Ok(1).flatTap((() => t) as never)],
     ["bind", (t: PromiseLike<never>) => Do().bind("a", (() => t) as never)],
+    [
+      "validateAll merge",
+      (t: PromiseLike<never>) => validateAll([Err("e" as const)], (() => t) as never),
+    ],
+    [
+      "validateAllFromDict merge",
+      (t: PromiseLike<never>) => validateAllFromDict({ a: Err("e" as const) }, (() => t) as never),
+    ],
     ["fromExecutor", (t: PromiseLike<never>) => fromExecutor<number, never>(() => t)],
     [
       "fromExecutor settle",
@@ -382,6 +390,16 @@ describe("Invariant 6: a DISCARDED thenable is adopted, so its rejection never f
         .toAsync()
         .tapFailure((() => t) as never),
     );
+  });
+
+  it("an async `merge` yields a Defect, never `Err(<Promise>)`", () => {
+    // `merge` is `NotThenable`-constrained, so this needs a cast — but a
+    // thenable in `E` is un-triaged by definition, and its rejection would
+    // float. Both aggregate folds mint a Defect instead.
+    const { thenable } = adoptionProbe();
+    const async = (() => thenable) as never;
+    expect(validateAll([Err("e" as const)], async).isDefect()).toBe(true);
+    expect(validateAllFromDict({ a: Err("e" as const) }, async).isDefect()).toBe(true);
   });
 
   it("the observer still passes the original result through unchanged", () => {

--- a/packages/core/src/skill-surface.test-d.ts
+++ b/packages/core/src/skill-surface.test-d.ts
@@ -46,6 +46,10 @@ import {
   TaggedError,
   type TaggedErrorConstructor,
   type TaggedErrorInstance,
+  validateAll,
+  validateAllAsync,
+  validateAllFromDict,
+  validateAllFromDictAsync,
 } from "./index.js";
 
 type Equal<X, Y> =
@@ -188,6 +192,14 @@ const tuple = all([Ok(1), Ok("a")] as const);
 const dict = allFromDict({ a: Ok(1), b: Ok("x") });
 const tupleAsync = allAsync([OkAsync(1), OkAsync("a")] as const);
 const dictAsync = allFromDictAsync({ a: OkAsync(1), b: OkAsync("x") });
+const validatedTuple = validateAll([Ok(1), Ok("a")] as const, () => Err("failures" as const));
+const validatedDict = validateAllFromDict({ a: Ok(1), b: Ok("x") }, () => Err("failures" as const));
+const asyncValidatedTuple = validateAllAsync([OkAsync(1), OkAsync("a")] as const, () =>
+  Err("failures" as const),
+);
+const asyncValidatedDict = validateAllFromDictAsync({ a: OkAsync(1), b: OkAsync("x") }, () =>
+  Err("failures" as const),
+);
 
 declare const unknownValue: unknown;
 const guarded = isResult(unknownValue);
@@ -209,6 +221,8 @@ const viaFacade = [
   Result.fromSafeThrowable(() => 1),
   Result.all([Ok(1)] as const),
   Result.allFromDict({ a: Ok(1) }),
+  Result.validateAll([Ok(1), Ok("a")] as const, () => Err("failures" as const)),
+  Result.validateAllFromDict({ a: Ok(1), b: Ok("x") }, () => Err("failures" as const)),
 ] as const;
 const viaAsyncFacade = [
   AsyncResult.Ok(1),
@@ -218,6 +232,10 @@ const viaAsyncFacade = [
   AsyncResult.fromSafePromise(Promise.resolve(1)),
   AsyncResult.all([OkAsync(1)] as const),
   AsyncResult.allFromDict({ a: OkAsync(1) }),
+  AsyncResult.validateAll([OkAsync(1), OkAsync("a")] as const, () => Err("failures" as const)),
+  AsyncResult.validateAllFromDict({ a: OkAsync(1), b: OkAsync("x") }, () =>
+    Err("failures" as const),
+  ),
 ] as const;
 
 // --- references/api.md: the P namespace ---------------------------------------
@@ -272,6 +290,8 @@ export type _SkillSurface = [
   // (a readonly tuple in, a mutable positional tuple out — the `AllOk` mapping)
   Expect<Equal<OkOf<typeof tuple>, [number, string]>>,
   Expect<Equal<OkOf<typeof dict>, { a: number; b: string }>>,
+  Expect<Equal<OkOf<typeof validatedTuple>, [number, string]>>,
+  Expect<Equal<OkOf<typeof validatedDict>, { a: number; b: string }>>,
   // FailureView's second parameter defaults, so `FailureView<E>` is spellable
   Expect<Equal<typeof failureView, FailureView<AgeError, never>>>,
 ];
@@ -300,6 +320,8 @@ export const _skillSurfaceValues = [
   doAsyncChain,
   tupleAsync,
   dictAsync,
+  asyncValidatedTuple,
+  asyncValidatedDict,
   guarded,
   okGuard,
   errGuard,

--- a/packages/core/src/skill-surface.test-d.ts
+++ b/packages/core/src/skill-surface.test-d.ts
@@ -192,8 +192,8 @@ const tuple = all([Ok(1), Ok("a")] as const);
 const dict = allFromDict({ a: Ok(1), b: Ok("x") });
 const tupleAsync = allAsync([OkAsync(1), OkAsync("a")] as const);
 const dictAsync = allFromDictAsync({ a: OkAsync(1), b: OkAsync("x") });
-const validatedTuple = validateAll([Ok(1), Ok("a")] as const, () => Err("failures" as const));
-const validatedDict = validateAllFromDict({ a: Ok(1), b: Ok("x") }, () => Err("failures" as const));
+const validatedTuple = validateAll([Ok(1), Ok("a")] as const, () => "failures" as const);
+const validatedDict = validateAllFromDict({ a: Ok(1), b: Ok("x") }, () => "failures" as const);
 const asyncValidatedTuple = validateAllAsync([OkAsync(1), OkAsync("a")] as const, () =>
   Err("failures" as const),
 );

--- a/packages/core/src/skill-surface.test-d.ts
+++ b/packages/core/src/skill-surface.test-d.ts
@@ -194,11 +194,13 @@ const tupleAsync = allAsync([OkAsync(1), OkAsync("a")] as const);
 const dictAsync = allFromDictAsync({ a: OkAsync(1), b: OkAsync("x") });
 const validatedTuple = validateAll([Ok(1), Ok("a")] as const, () => "failures" as const);
 const validatedDict = validateAllFromDict({ a: Ok(1), b: Ok("x") }, () => "failures" as const);
-const asyncValidatedTuple = validateAllAsync([OkAsync(1), OkAsync("a")] as const, () =>
-  Err("failures" as const),
+const asyncValidatedTuple = validateAllAsync(
+  [OkAsync(1), OkAsync("a")] as const,
+  () => "failures" as const,
 );
-const asyncValidatedDict = validateAllFromDictAsync({ a: OkAsync(1), b: OkAsync("x") }, () =>
-  Err("failures" as const),
+const asyncValidatedDict = validateAllFromDictAsync(
+  { a: OkAsync(1), b: OkAsync("x") },
+  () => "failures" as const,
 );
 
 declare const unknownValue: unknown;
@@ -221,8 +223,8 @@ const viaFacade = [
   Result.fromSafeThrowable(() => 1),
   Result.all([Ok(1)] as const),
   Result.allFromDict({ a: Ok(1) }),
-  Result.validateAll([Ok(1), Ok("a")] as const, () => Err("failures" as const)),
-  Result.validateAllFromDict({ a: Ok(1), b: Ok("x") }, () => Err("failures" as const)),
+  Result.validateAll([Ok(1), Ok("a")] as const, () => "failures" as const),
+  Result.validateAllFromDict({ a: Ok(1), b: Ok("x") }, () => "failures" as const),
 ] as const;
 const viaAsyncFacade = [
   AsyncResult.Ok(1),
@@ -232,10 +234,8 @@ const viaAsyncFacade = [
   AsyncResult.fromSafePromise(Promise.resolve(1)),
   AsyncResult.all([OkAsync(1)] as const),
   AsyncResult.allFromDict({ a: OkAsync(1) }),
-  AsyncResult.validateAll([OkAsync(1), OkAsync("a")] as const, () => Err("failures" as const)),
-  AsyncResult.validateAllFromDict({ a: OkAsync(1), b: OkAsync("x") }, () =>
-    Err("failures" as const),
-  ),
+  AsyncResult.validateAll([OkAsync(1), OkAsync("a")] as const, () => "failures" as const),
+  AsyncResult.validateAllFromDict({ a: OkAsync(1), b: OkAsync("x") }, () => "failures" as const),
 ] as const;
 
 // --- references/api.md: the P namespace ---------------------------------------
@@ -292,6 +292,11 @@ export type _SkillSurface = [
   Expect<Equal<OkOf<typeof dict>, { a: number; b: string }>>,
   Expect<Equal<OkOf<typeof validatedTuple>, [number, string]>>,
   Expect<Equal<OkOf<typeof validatedDict>, { a: number; b: string }>>,
+  // `merge` returns the domain error itself, so `E2` is that value — not a Result
+  Expect<Equal<ErrOf<typeof validatedTuple>, "failures">>,
+  Expect<Equal<ErrOf<typeof validatedDict>, "failures">>,
+  Expect<Equal<AsyncErrOf<typeof asyncValidatedTuple>, "failures">>,
+  Expect<Equal<AsyncErrOf<typeof asyncValidatedDict>, "failures">>,
   // FailureView's second parameter defaults, so `FailureView<E>` is spellable
   Expect<Equal<typeof failureView, FailureView<AgeError, never>>>,
 ];

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -41,6 +41,10 @@ import {
   type Result,
   TaggedError,
   type TaggedErrorInstance,
+  validateAll,
+  validateAllAsync,
+  validateAllFromDict,
+  validateAllFromDictAsync,
 } from "./index.js";
 
 // --- assertion helpers -------------------------------------------------------
@@ -101,6 +105,98 @@ type _tupleAsync = Expect<Equal<typeof tupleAsync, AsyncResult<[number, string],
 
 const dictAsync = allFromDictAsync({ id: Ok(1).toAsync(), name: Ok("ada").toAsync() });
 type _dictAsync = Expect<Equal<typeof dictAsync, AsyncResult<{ id: number; name: string }, never>>>;
+
+// --- validateAll*: accumulate every Err, merged into one modeled error -------
+//
+// Same success channel as `all` (positional tuples, collapsing arrays, `[]` for
+// the empty tuple); the error channel is whatever `merge` returns. These pin the
+// inference the design hinged on — CLAUDE.md bans conditional types on
+// inference-bearing parameters, and `merge` carries one on BOTH sides
+// (`ErrOf<Rs[number]>` in, `NotThenable<E2>` out). If either deflects, the
+// parameter silently degrades to `unknown[]` with no compile error; these
+// assertions are what makes that loud.
+
+class MergedViolations {
+  readonly _tag = "MergedViolations" as const;
+}
+
+// the merged error type infers from `merge`'s return — no explicit type argument
+const validated = validateAll([r1, r2], (errors) => {
+  // `merge` sees the exact error union, as a NON-EMPTY list (it is called only
+  // when at least one Err was collected, so it is total)
+  type _errs = Expect<Equal<typeof errors, readonly ["e1" | "e2", ...("e1" | "e2")[]]>>;
+  return new MergedViolations();
+});
+type _validated = Expect<Equal<typeof validated, Result<[number, string], MergedViolations>>>;
+
+// a dynamic array still collapses to `T[]`
+const validatedArr = validateAll(arr, (errors) => {
+  type _errs = Expect<Equal<typeof errors, readonly ["e", ..."e"[]]>>;
+  return new MergedViolations();
+});
+type _validatedArr = Expect<Equal<typeof validatedArr, Result<number[], MergedViolations>>>;
+
+// the empty tuple stays `[]` here too
+const validatedEmpty = validateAll([], () => new MergedViolations());
+type _validatedEmpty = Expect<Equal<typeof validatedEmpty, Result<[], MergedViolations>>>;
+
+// an async `merge` does not compile — its Promise would land unqualified in E
+// @ts-expect-error merge is synchronous (NotThenable)
+validateAll([r1, r2], async () => new MergedViolations());
+
+// the record form's entries are CORRELATED per key: `["vatRate", DateOutOfRange]`
+// is not representable, and a switch on the key narrows the error. This is what
+// keeps two checks sharing one error type distinguishable.
+declare const rate: Result<number, "RuleViolated">;
+declare const ccy: Result<string, "RuleViolated">;
+declare const due: Result<Date, "DateOutOfRange">;
+
+type Entry =
+  | readonly ["vatRate", "RuleViolated"]
+  | readonly ["currency", "RuleViolated"]
+  | readonly ["dueDate", "DateOutOfRange"];
+
+const validatedDict = validateAllFromDict(
+  { vatRate: rate, currency: ccy, dueDate: due },
+  (entries) => {
+    type _entries = Expect<Equal<typeof entries, readonly [Entry, ...Entry[]]>>;
+    return new MergedViolations();
+  },
+);
+type _validatedDict = Expect<
+  Equal<
+    typeof validatedDict,
+    Result<{ vatRate: number; currency: string; dueDate: Date }, MergedViolations>
+  >
+>;
+
+// @ts-expect-error merge is synchronous (NotThenable), record form
+validateAllFromDict({ vatRate: rate }, async () => new MergedViolations());
+
+// async counterparts infer identically through the Awaitable then-channel
+const validatedAsync = validateAllAsync([r1.toAsync(), r2.toAsync()], (errors) => {
+  type _errs = Expect<Equal<typeof errors, readonly ["e1" | "e2", ...("e1" | "e2")[]]>>;
+  return new MergedViolations();
+});
+type _validatedAsync = Expect<
+  Equal<typeof validatedAsync, AsyncResult<[number, string], MergedViolations>>
+>;
+
+type AsyncEntry = readonly ["a", "e1"] | readonly ["b", "e2"];
+
+const validatedDictAsync = validateAllFromDictAsync(
+  { a: r1.toAsync(), b: r2.toAsync() },
+  (entries) => {
+    type _entries = Expect<Equal<typeof entries, readonly [AsyncEntry, ...AsyncEntry[]]>>;
+    return new MergedViolations();
+  },
+);
+type _validatedDictAsync = Expect<
+  Equal<typeof validatedDictAsync, AsyncResult<{ a: number; b: string }, MergedViolations>>
+>;
+
+// @ts-expect-error merge is synchronous (NotThenable), async form
+validateAllAsync([r1.toAsync()], async () => new MergedViolations());
 
 // --- boundaries: `Defect` is subtracted from the error channel ---------------
 

--- a/packages/core/src/types.test-d.ts
+++ b/packages/core/src/types.test-d.ts
@@ -156,6 +156,8 @@ type Entry =
   | readonly ["currency", "RuleViolated"]
   | readonly ["dueDate", "DateOutOfRange"];
 
+type Entry2 = readonly ["vatRate", "RuleViolated"];
+
 const validatedDict = validateAllFromDict(
   { vatRate: rate, currency: ccy, dueDate: due },
   (entries) => {
@@ -197,6 +199,27 @@ type _validatedDictAsync = Expect<
 
 // @ts-expect-error merge is synchronous (NotThenable), async form
 validateAllAsync([r1.toAsync()], async () => new MergedViolations());
+
+// @ts-expect-error merge is synchronous (NotThenable), async record form
+validateAllFromDictAsync({ a: r1.toAsync() }, async () => new MergedViolations());
+
+// An infallible input contributes NO entry — an uninhabited `["infallible", never]`
+// arm would still force a dead `case` on every `switch` over the key (and fail
+// `noImplicitReturns`). An optional key contributes its entry without `undefined`.
+declare const infallible: Result<boolean, never>;
+declare const optional: { vatRate?: Result<number, "RuleViolated"> };
+
+validateAllFromDict({ vatRate: rate, infallible }, (entries) => {
+  type _entries = Expect<Equal<typeof entries, readonly [Entry2, ...Entry2[]]>>;
+  return new MergedViolations();
+});
+
+validateAllFromDict(optional, (entries) => {
+  const [key, error] = entries[0];
+  type _entry = Expect<Equal<typeof key, "vatRate">>;
+  type _err = Expect<Equal<typeof error, "RuleViolated">>;
+  return new MergedViolations();
+});
 
 // --- boundaries: `Defect` is subtracted from the error channel ---------------
 

--- a/packages/oxlint/src/rules/no-async-result-race.test.ts
+++ b/packages/oxlint/src/rules/no-async-result-race.test.ts
@@ -76,6 +76,16 @@ ruleTester.run("no-async-result-race", noAsyncResultRace, {
       code: `import { OkAsync, ErrAsync } from "unthrown";\nconst a = OkAsync(1).map((n) => n + 1);\nconst b = ErrAsync("e").tapFailure(() => {});\nconst r = a.flatMap(() => b);`,
       errors: [{ messageId: "noAsyncResultRace" }],
     },
+    // The accumulating aggregates construct too — the race this rule exists for
+    // is just as invisible on `validateAllAsync` as on `allAsync`.
+    {
+      code: `import { validateAllAsync, OkAsync } from "unthrown";\nconst a = validateAllAsync([OkAsync(1)], merge);\nconst b = OkAsync(2);\nconst r = a.flatMap(() => b);`,
+      errors: [{ messageId: "noAsyncResultRace" }],
+    },
+    {
+      code: `import { AsyncResult } from "unthrown";\nconst a = AsyncResult.validateAllFromDict({ a: 1 }, merge);\nconst b = AsyncResult.Ok(2);\nconst r = a.flatMap(() => b);`,
+      errors: [{ messageId: "noAsyncResultRace" }],
+    },
     // The facade companion constructs too.
     {
       code: `import { AsyncResult } from "unthrown";\nconst a = AsyncResult.Ok(1);\nconst b = AsyncResult.fromPromise(Promise.resolve(2), (e) => e);\nconst r = a.flatMap(() => b);`,

--- a/packages/oxlint/src/rules/no-async-result-race.ts
+++ b/packages/oxlint/src/rules/no-async-result-race.ts
@@ -19,6 +19,8 @@ const ASYNC_FREE_PRODUCERS: ReadonlySet<string> = new Set([
   "fromExecutor",
   "allAsync",
   "allFromDictAsync",
+  "validateAllAsync",
+  "validateAllFromDictAsync",
 ]);
 
 // The producing members of the `AsyncResult` facade companion.
@@ -31,6 +33,8 @@ const COMPANION_PRODUCERS: ReadonlySet<string> = new Set([
   "fromSafePromise",
   "all",
   "allFromDict",
+  "validateAll",
+  "validateAllFromDict",
 ]);
 
 /**

--- a/packages/oxlint/src/rules/no-unhandled-result.test.ts
+++ b/packages/oxlint/src/rules/no-unhandled-result.test.ts
@@ -20,6 +20,10 @@ const FREE_PRODUCERS = [
   "allAsync",
   "allFromDict",
   "allFromDictAsync",
+  "validateAll",
+  "validateAllAsync",
+  "validateAllFromDict",
+  "validateAllFromDictAsync",
 ] as const;
 
 ruleTester.run("no-unhandled-result", noUnhandledResult, {
@@ -73,6 +77,14 @@ ruleTester.run("no-unhandled-result", noUnhandledResult, {
     },
     {
       code: `import { AsyncResult } from "unthrown";\nAsyncResult.fromPromise(p, q);`,
+      errors: [{ messageId: "noUnhandledResult" }],
+    },
+    {
+      code: `import { Result } from "unthrown";\nResult.validateAll([Ok(1)], merge);`,
+      errors: [{ messageId: "noUnhandledResult" }],
+    },
+    {
+      code: `import { AsyncResult } from "unthrown";\nAsyncResult.validateAllFromDict({ a }, merge);`,
       errors: [{ messageId: "noUnhandledResult" }],
     },
     {

--- a/packages/oxlint/src/rules/no-unhandled-result.ts
+++ b/packages/oxlint/src/rules/no-unhandled-result.ts
@@ -26,6 +26,10 @@ const FREE_PRODUCERS: ReadonlySet<string> = new Set([
   "allAsync",
   "allFromDict",
   "allFromDictAsync",
+  "validateAll",
+  "validateAllAsync",
+  "validateAllFromDict",
+  "validateAllFromDictAsync",
 ]);
 
 // The producing members of the facade companions (`Result.Ok(...)`,
@@ -41,6 +45,8 @@ const COMPANION_PRODUCERS: Readonly<Record<string, ReadonlySet<string>>> = {
     "fromSafeThrowable",
     "all",
     "allFromDict",
+    "validateAll",
+    "validateAllFromDict",
   ]),
   AsyncResult: new Set([
     "Ok",
@@ -51,6 +57,8 @@ const COMPANION_PRODUCERS: Readonly<Record<string, ReadonlySet<string>>> = {
     "fromSafePromise",
     "all",
     "allFromDict",
+    "validateAll",
+    "validateAllFromDict",
   ]),
 };
 

--- a/skills/migrating-to-unthrown/SKILL.md
+++ b/skills/migrating-to-unthrown/SKILL.md
@@ -84,7 +84,7 @@ after every file:
 
 - **[references/from-neverthrow.md](references/from-neverthrow.md)** — the
   neverthrow→unthrown mapping table, the `mapErr`/`orElse`/`safeTry`/`match`
-  rewrites, the `combineWithAllErrors` gap, and a worked seam.
+  rewrites, `combineWithAllErrors` → `validateAll`, and a worked seam.
 - **[references/from-boxed.md](references/from-boxed.md)** — the Boxed→unthrown
   mapping table (Result, Future, statics), the `Option` decision tree, and the
   `AsyncData`/`retry`/`concurrent` gaps.

--- a/skills/migrating-to-unthrown/references/from-neverthrow.md
+++ b/skills/migrating-to-unthrown/references/from-neverthrow.md
@@ -4,27 +4,27 @@ Apply mechanically; the judgment calls live in SKILL.md's decide-once list.
 
 ## Mapping table
 
-| neverthrow                                | unthrown                                          | Notes                                                                           |
-| ----------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------- |
-| `ok(v)` / `err(e)`                        | `Ok(v)` / `Err(e)`                                | capitalized free functions                                                      |
-| `okAsync(v)` / `errAsync(e)`              | `OkAsync(v)` / `ErrAsync(e)`                      | pre-lifted async constructors                                                   |
-| `result.map(f)`                           | same                                              | callback must be synchronous                                                    |
-| `result.andThen(f)`                       | `result.flatMap(f)`                               | one name per concept                                                            |
-| `result.andTee(f)` / `andThrough(f)`      | `tap(f)` / `flatTap(f)`                           |                                                                                 |
-| `result.mapErr(f)`                        | `mapErrCases((matcher) => …)`                     | exhaustive: one `.with(…)` arm per case in `E` — see rewrite below              |
-| `result.orElse(f)`                        | `flatMapErrCases(…)` or `recoverErrCases(…)`      | fallback `Result` vs plain recovery value — see rewrite below                   |
-| `result.match(okFn, errFn)`               | `match({ ok, errCases: (matcher) => …, defect })` | object handlers; the `defect` arm is new and mandatory                          |
-| `result.unwrapOr(v)`                      | `getOr(v)`                                        | all `unwrap*` names are removed; still panics on a Defect                       |
-| `result.isOk()` / `isErr()`               | same                                              | plus `isDefect()`                                                               |
-| `result.value` / `result.error`           | same, after narrowing                             |                                                                                 |
-| `ResultAsync`                             | `AsyncResult`                                     | `await` collapses it to a `Result`; it never rejects                            |
-| `ResultAsync.fromPromise(p, mapErr)`      | `fromPromise(p, qualify)`                         | `qualify(cause, defect)` must triage — the mapper was total, this is a decision |
-| `ResultAsync.fromSafePromise(p)`          | `fromSafePromise(p)`                              | a rejection becomes a `Defect`, not an `Err`                                    |
-| `Result.fromThrowable(fn, mapErr)`        | `fromThrowable(fn, qualify)`                      | wraps the function; same triage                                                 |
-| `Result.combine([...])`                   | `all([...])` / `allAsync([...])`                  | record variant: `allFromDict` / `allFromDictAsync`                              |
+| neverthrow                                | unthrown                                                       | Notes                                                                                                 |
+| ----------------------------------------- | -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `ok(v)` / `err(e)`                        | `Ok(v)` / `Err(e)`                                             | capitalized free functions                                                                            |
+| `okAsync(v)` / `errAsync(e)`              | `OkAsync(v)` / `ErrAsync(e)`                                   | pre-lifted async constructors                                                                         |
+| `result.map(f)`                           | same                                                           | callback must be synchronous                                                                          |
+| `result.andThen(f)`                       | `result.flatMap(f)`                                            | one name per concept                                                                                  |
+| `result.andTee(f)` / `andThrough(f)`      | `tap(f)` / `flatTap(f)`                                        |                                                                                                       |
+| `result.mapErr(f)`                        | `mapErrCases((matcher) => …)`                                  | exhaustive: one `.with(…)` arm per case in `E` — see rewrite below                                    |
+| `result.orElse(f)`                        | `flatMapErrCases(…)` or `recoverErrCases(…)`                   | fallback `Result` vs plain recovery value — see rewrite below                                         |
+| `result.match(okFn, errFn)`               | `match({ ok, errCases: (matcher) => …, defect })`              | object handlers; the `defect` arm is new and mandatory                                                |
+| `result.unwrapOr(v)`                      | `getOr(v)`                                                     | all `unwrap*` names are removed; still panics on a Defect                                             |
+| `result.isOk()` / `isErr()`               | same                                                           | plus `isDefect()`                                                                                     |
+| `result.value` / `result.error`           | same, after narrowing                                          |                                                                                                       |
+| `ResultAsync`                             | `AsyncResult`                                                  | `await` collapses it to a `Result`; it never rejects                                                  |
+| `ResultAsync.fromPromise(p, mapErr)`      | `fromPromise(p, qualify)`                                      | `qualify(cause, defect)` must triage — the mapper was total, this is a decision                       |
+| `ResultAsync.fromSafePromise(p)`          | `fromSafePromise(p)`                                           | a rejection becomes a `Defect`, not an `Err`                                                          |
+| `Result.fromThrowable(fn, mapErr)`        | `fromThrowable(fn, qualify)`                                   | wraps the function; same triage                                                                       |
+| `Result.combine([...])`                   | `all([...])` / `allAsync([...])`                               | record variant: `allFromDict` / `allFromDictAsync`                                                    |
 | `Result.combineWithAllErrors([...])`      | `validateAll([...], merge)` / `validateAllAsync([...], merge)` | `merge` is mandatory — see below; record variants: `validateAllFromDict` / `validateAllFromDictAsync` |
-| `safeTry(function* () { yield* … })`      | `Do()` / `DoAsync()` + `.bind(name, f)` + `.let`  | see rewrite below                                                               |
-| `fromPromise` re-thrown / `_unsafeUnwrap` | `get()` (needs `E = never`) / `getOrThrow()`      | type-gated extraction; no `_unsafe*` family                                     |
+| `safeTry(function* () { yield* … })`      | `Do()` / `DoAsync()` + `.bind(name, f)` + `.let`               | see rewrite below                                                                                     |
+| `fromPromise` re-thrown / `_unsafeUnwrap` | `get()` (needs `E = never`) / `getOrThrow()`                   | type-gated extraction; no `_unsafe*` family                                                           |
 
 ## The three non-mechanical rewrites
 

--- a/skills/migrating-to-unthrown/references/from-neverthrow.md
+++ b/skills/migrating-to-unthrown/references/from-neverthrow.md
@@ -22,7 +22,7 @@ Apply mechanically; the judgment calls live in SKILL.md's decide-once list.
 | `ResultAsync.fromSafePromise(p)`          | `fromSafePromise(p)`                              | a rejection becomes a `Defect`, not an `Err`                                    |
 | `Result.fromThrowable(fn, mapErr)`        | `fromThrowable(fn, qualify)`                      | wraps the function; same triage                                                 |
 | `Result.combine([...])`                   | `all([...])` / `allAsync([...])`                  | record variant: `allFromDict` / `allFromDictAsync`                              |
-| `Result.combineWithAllErrors([...])`      | `validateAll([...], merge)`                       | `merge` is mandatory — see below; record variant: `validateAllFromDict`         |
+| `Result.combineWithAllErrors([...])`      | `validateAll([...], merge)` / `validateAllAsync([...], merge)` | `merge` is mandatory — see below; record variants: `validateAllFromDict` / `validateAllFromDictAsync` |
 | `safeTry(function* () { yield* … })`      | `Do()` / `DoAsync()` + `.bind(name, f)` + `.let`  | see rewrite below                                                               |
 | `fromPromise` re-thrown / `_unsafeUnwrap` | `get()` (needs `E = never`) / `getOrThrow()`      | type-gated extraction; no `_unsafe*` family                                     |
 

--- a/skills/migrating-to-unthrown/references/from-neverthrow.md
+++ b/skills/migrating-to-unthrown/references/from-neverthrow.md
@@ -22,7 +22,7 @@ Apply mechanically; the judgment calls live in SKILL.md's decide-once list.
 | `ResultAsync.fromSafePromise(p)`          | `fromSafePromise(p)`                              | a rejection becomes a `Defect`, not an `Err`                                    |
 | `Result.fromThrowable(fn, mapErr)`        | `fromThrowable(fn, qualify)`                      | wraps the function; same triage                                                 |
 | `Result.combine([...])`                   | `all([...])` / `allAsync([...])`                  | record variant: `allFromDict` / `allFromDictAsync`                              |
-| `Result.combineWithAllErrors([...])`      | —                                                 | accumulation is deliberately excluded — see gap below                           |
+| `Result.combineWithAllErrors([...])`      | `validateAll([...], merge)`                       | `merge` is mandatory — see below; record variant: `validateAllFromDict`         |
 | `safeTry(function* () { yield* … })`      | `Do()` / `DoAsync()` + `.bind(name, f)` + `.let`  | see rewrite below                                                               |
 | `fromPromise` re-thrown / `_unsafeUnwrap` | `get()` (needs `E = never`) / `getOrThrow()`      | type-gated extraction; no `_unsafe*` family                                     |
 
@@ -61,13 +61,30 @@ DoAsync()
   .map(({ user, prefs }) => ({ user, prefs }));
 ```
 
-## Gap: `combineWithAllErrors`
+## `combineWithAllErrors` → `validateAll`
 
-unthrown has no error accumulation, deliberately. Options, in order: validate
-with `@unthrown/standard-schema` (a validator's issue list is one modeled
-error carrying all issues); or model the aggregate as one error case whose
-payload holds the collected failures, built by folding the results yourself at
-that one site. Do not fake a `Validation` type.
+`validateAll` / `validateAllFromDict` (and the async pair `validateAllAsync` /
+`validateAllFromDictAsync`) accumulate every `Err` in input order — but they do
+**not** hand you the `Result<T[], E[]>` neverthrow returns. A mandatory
+`merge: (errors) => E2` folds the collected failures into one named domain
+error, because an `E[]` is a _shape_, not an anticipated failure, and it pushes
+"what does it mean that several rules failed?" to every consuming site forever.
+
+```ts
+validateAll(
+  [checkStock(o), checkCredit(c)],
+  (violations) => new OrderRejected({ violations }),
+);
+```
+
+`merge` receives a **non-empty** list, so there is no "shouldn't happen" branch;
+the record form gets `[key, error]` entries correlated per key. A `Defect` still
+dominates and discards the accumulated errors.
+
+For schema-shaped input (a request body, a form) reach for
+`@unthrown/standard-schema`'s `fromSchema` instead — a validator already hands
+you every issue as one modeled error. There is still no `Validation` applicative;
+do not fake one.
 
 ## The seam (untouched neverthrow callers)
 

--- a/skills/unthrown/SKILL.md
+++ b/skills/unthrown/SKILL.md
@@ -261,7 +261,8 @@ what `no-ambiguous-error-type` flags.
 
 - **[references/api.md](references/api.md)** — the full combinator table
   (by-intent + per-channel behavior), matcher patterns (`P.*`), do-notation
-  (`Do`/`bind`/`let`), aggregates (`all`/`allFromDict` + async), guards,
+  (`Do`/`bind`/`let`), aggregates (`all`/`allFromDict` + the accumulating
+  `validateAll`/`validateAllFromDict`, and their async twins), guards,
   facade namespaces (`Result.*`/`AsyncResult.*`), and utility types. Read when
   choosing a combinator or writing anything beyond the basics above.
 - **[references/ecosystem.md](references/ecosystem.md)** — the `@unthrown/*`

--- a/skills/unthrown/references/api.md
+++ b/skills/unthrown/references/api.md
@@ -179,8 +179,9 @@ triggered it, after the remaining undos run.
 
 ## Aggregates
 
-All four short-circuit on the first `Err`, any `Defect` dominates, and none
-accumulate errors (deliberately excluded).
+Eight functions in two families. Any `Defect` **dominates** in all of them; the families differ only in which `Err`s get reported. Neither short-circuits any _work_ — every input has already run by the time the aggregate sees it.
+
+**Fail-fast — the first `Err` wins:**
 
 - `all([r1, r2])` — tuple in, positional tuple out
   (`Result<[A, B], E1 | E2>`); a dynamic `Result<T, E>[]` collapses to
@@ -189,6 +190,16 @@ accumulate errors (deliberately excluded).
   parallel work without tupling.
 - `allAsync` / `allFromDictAsync` — the `AsyncResult` twins; resolve
   concurrently, never reject. Facade: `AsyncResult.all` / `AsyncResult.allFromDict`.
+
+**Accumulating — every `Err`, merged into one domain error:**
+
+- `validateAll([r1, r2], merge)` → `Result<[A, B], E2>`. Same success channel as `all`; `merge: (errors) => E2` is **mandatory** — the errors fold into a named domain error, never an `E[]`.
+- `validateAllFromDict({ a: ra, b: rb }, merge)` → `Result<{ a: A; b: B }, E2>`. `merge` receives `[key, error]` **entries**, correlated per key (`["a", E1] | ["b", E2]`), in `Object.keys` order — so a `switch` on the key narrows the error.
+- `validateAllAsync` / `validateAllFromDictAsync` — the `AsyncResult` twins. Facade: `AsyncResult.validateAll` / `AsyncResult.validateAllFromDict`.
+
+Rules for `merge`: it receives a **non-empty** list (so it is total, and is never called on an all-`Ok` input); a `Defect` dominates it, discarding the accumulated errors without calling it; a throw inside it becomes a `Defect`; and it must be **synchronous** — an `async` merge is a compile error.
+
+For **schema-shaped** input (a request body, a form), use `@unthrown/standard-schema`'s `fromSchema` instead — a validator already hands you every issue as the modeled error. `validateAll` is for independent checks you wrote yourself.
 
 ## Guards
 
@@ -205,11 +216,12 @@ The free functions are primary (tree-shakeable). Two opt-in companion objects
 group them **by what they return**:
 
 - `Result.*`: `Ok`, `Err`, `Do`, `fromNullable`, `fromThrowable`,
-  `fromSafeThrowable`, `all`, `allFromDict`, `isOk`/`isErr`/`isDefect`/`isResult`.
+  `fromSafeThrowable`, `all`, `allFromDict`, `validateAll`,
+  `validateAllFromDict`, `isOk`/`isErr`/`isDefect`/`isResult`.
 - `AsyncResult.*`: `Ok` (= `OkAsync`), `Err` (= `ErrAsync`), `Do`
-  (= `DoAsync`), `fromExecutor`, `fromPromise`,
-  `fromSafePromise`, `all` (= `allAsync`), `allFromDict`
-  (= `allFromDictAsync`).
+  (= `DoAsync`), `fromExecutor`, `fromPromise`, `fromSafePromise`, `all`
+  (= `allAsync`), `allFromDict` (= `allFromDictAsync`), `validateAll`
+  (= `validateAllAsync`), `validateAllFromDict` (= `validateAllFromDictAsync`).
 
 Both are value + type companions — `Result<T, E>` / `AsyncResult<T, E>` are the
 same names as types.


### PR DESCRIPTION
<!--
Thanks for contributing! Keep PRs focused on one concern.
See CONTRIBUTING.md for the full workflow.
-->

## What & why

Four new core exports `validateAll`, `validateAllFromDict`, `validateAllAsync`, `validateAllFromDictAsync`.  the accumulating siblings of all / allFromDict, which report only the first Err.

```
validateAllFromDict(
  { minimum: checkMinimum(cart), region: checkRegion(cart) },
  (entries) => new CheckoutBlocked({ reasons: entries.map(describe) }),
);
// both checks failed → Err(CheckoutBlocked) naming both, not just the first
```

- Same success channel as all, unchanged: fixed tuple keeps positional types, dynamic array collapses to `T[]`, record answers a record. Only the error channel differs.
- merge is mandatory. Every `Err` is collected in input order and folded into one modeled error.
- The record form hands it `[key, error]` entries correlated per key `({ a: Result<A, E1>; b: Result<B, E2> } → ["a", E1] | ["b", E2])`, so a switch on the key narrows the error and `["b", E1]` does not compile.
- Every existing aggregate rule holds: a `Defect` dominates and discards the accumulated errors (merge not called), a non-Result element is a TypeError-caused Defect, a throw in merge becomes a Defect, merge must be synchronous (NotThenable), the async pair resolves concurrently and its internal promise never rejects.
- Both facades gained the entry points; `validateAllAsync` → `AsyncResult.validateAll`, per the existing suffix-dropping rule.


<!-- What does this change and why? Link any related issue (Closes #123). -->

## Checklist

- [X] The full gate passes locally: `pnpm format --check && pnpm lint && pnpm typecheck && pnpm knip && pnpm test && pnpm build`
- [X] Added/updated tests (and invariant guards / type-level tests if behaviour changed)
- [x] Added a changeset (`pnpm changeset`) for any user-facing change
- [X] Updated TSDoc and `CLAUDE.md` if the public surface or a design rule changed
- [X] Commits follow Conventional Commits


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `validateAll` APIs for accumulating errors across arrays, tuples, and records.
  - Added concurrent asynchronous variants and access through `Result` and `AsyncResult`.
  - Added synchronous error merging while preserving successful value shapes and correlated record entries.
  - Defects and merge failures take precedence over accumulated validation errors.

- **Documentation**
  - Added API guidance, migration notes, and checkout-domain examples.

- **Bug Fixes**
  - Updated lint rules to detect unhandled and potentially racing validation aggregates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->